### PR TITLE
Changing memory on OS X

### DIFF
--- a/lessons/topic-modeling-and-mallet.md
+++ b/lessons/topic-modeling-and-mallet.md
@@ -380,7 +380,8 @@ allocated to your *Java virtual machine*. To do so, you need to edit the
 code in the `mallet` file found in the `bin` subdirectory of your
 MALLET folder. Using Komodo Edit, (See [Mac][],
 [Windows,][Mac][Linux][Mac] for installation instructions), open the
-`Mallet.bat` file (`C:\Mallet\bin\mallet.bat`).
+`Mallet.bat` file (`C:\Mallet\bin\mallet.bat`) if you are using Windows,
+or the `mallet` file (`~/Mallet/bin/mallet`) if you are using Linux or OS X.
 
 Find the following line:
 


### PR DESCRIPTION
I believe these are correct instructions for increasing memory allocation: linux and mac users shouldn't be editing mallet.bat, right? I've had this problem myself, and saw someone getting confused over it on the Mallet listserv this morning. This needs review, though: I don't completely understand the architecture: `mallet.bat` doesn't do anything on Ubuntu or OS X, does it?
