### PR TITLE
use page.path liquid variable to link to github source

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
 
 <p class="github">
         <a href="https://github.com/programminghistorian/jekyll">Hosted on GitHub <img src="{{site.url}}/images/GitHub-Mark-32px.png" title="GitHub logo"></a> 
-		<a href="https://github.com/programminghistorian/jekyll/commits/gh-pages{{ page.url | replace: '.html','.md' }}">Track Changes</a>&nbsp;&#183;&nbsp;
+		<a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">Track Changes</a>&nbsp;&#183;&nbsp;
 		<a href="https://github.com/programminghistorian/jekyll/wiki/Reporting-Issues">Report an Issue</a>
 </p>
 


### PR DESCRIPTION
This should fix https://github.com/programminghistorian/jekyll/issues/56
