### PR TITLE
Make Feedback options more visible

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
 <p class="github">
         <a href="https://github.com/programminghistorian/jekyll">Hosted on GitHub <img src="{{site.url}}/images/GitHub-Mark-32px.png" title="GitHub logo"></a> 
 		<a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">Previous Versions</a>&nbsp;&#183;&nbsp;
-		<a href="../report-issue">Report an Issue</a>
+		<a href="../feedback">Give Feedback</a>
 </p>
 
 </footer>

--- a/contribute.md
+++ b/contribute.md
@@ -5,50 +5,48 @@ layout: blank
 
 # Contribute to the Programming Historian
 
-The _Programming Historian_ runs on the energy of volunteers, and we welcome contributions from the community. Most people become involved in one of the following activities:
+The _Programming Historian_ runs on the energy of volunteers, and we welcome contributions from the community. Please consider the following ways to get involved, or let us know about other ideas you have for broadening participation.
 
-- <a href="#readers">Readers: Report a problem with a lesson</a>
-- <a href="#reviewers">Reviewers: Join our team of reviewers</a>
-- <a href="#authors">Authors: Write a lesson</a>
+## Provide feedback and report problems
 
------
-
-
-## <a name="readers"></a>Readers: Report a problem with a lesson
 <figure>
 	<img src="../images/reader-sm.png" width="180px" style="float: left; margin-right: 15px; margin-bottom: 15px;" />
 </figure>
-We would much rather hear about a problem with a lesson than for you to leave frustrated if something doesn't work. As URLs change and as new versions of software and platforms are released, lessons develop glitches over time. Please help us keep the _Programming Historian_ up to date by letting us know about these when you come across them in the course of your reading. 
 
-If you notice a problem with a lesson, please report it following our instructions on [how to create an issue in our GitHub repository](report-issue). Reporting only takes a moment and helps us provide the best learning resources possible.
+We welcome [feedback](../feedback.html) on any aspect of the Programming Historian. Let us know what we can do to make the project better!
 
+We are especially grateful for tips about lessons that seem to be broken. As URLs change and as new versions of software and platforms are released, lessons develop glitches over time. Please help us keep the _Programming Historian_ up to date by letting us know about these when you come across them in the course of your reading. 
 
-## <a name="reviewers"></a>Reviewers: Join our team of reviewers
-<figure>
-	<img src="../images/reviewer-sm.png" width="180px" style="float: left; margin-right: 15px; margin-bottom: 15px;" />
-</figure>
-Academic peer review is essential for producing trusted high-quality resources. The _Programming Historian_, holds peer review in the highest regard, and we take an open and collaborative approach in which reviewers get full and public credit for their work. For more on our review philosophy and procedures, please see the [Guidelines for Reviewers][reviewers].
+## Write a new lesson
 
-We hope you'll consider joining our team of reviewers. The time commitment is flexible, and you'll be contributing to helping us maintain high academic standards for this community resource. Please email <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a> to introduce yourself and let us know about the specific skills, tools, topics, and technologies that you'd like to be involved with so that we can send you the most appropriate lessons to review. 
-
-<div style="clear:both;"></div>
-
-## <a name="authors"></a>Authors: Write a lesson
 <figure>
 	<img src="../images/author-sm.png" width="180px" style="float: left; margin-right: 15px; margin-bottom: 15px;" />
 </figure>
-From our own experience, we know that the difficult job of writing technically challenging but accessible tutorials is one of the best ways to teach yourself particular skills and actively engage in the digital humanities community.
+
+We welcome submissions of [new lessons][submissions] from authors!
+
+Writing a tutorial is one of the best ways to teach yourself particular skills and actively engage in the digital humanities community.
 
 We don't simply accept or reject articles like traditional journals. Our editors collaborate with you to help craft and hone your topic and approach, as well as to make your tutorial as clear and as useful as possible. Our peer review process helps improve your lessons even further, as well as improve your technical writing skills. Please read more about our [submission proceess][submissions].
 
 If you'd like to propose a lesson (for you or for someone else to write), email <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a>. 
 
+## Join our team of reviewers
+
+<figure>
+	<img src="../images/reviewer-sm.png" width="180px" style="float: left; margin-right: 15px; margin-bottom: 15px;" />
+</figure>
+
+Academic peer review is essential for producing trusted high-quality resources. The _Programming Historian_, holds peer review in the highest regard, and we take an open and collaborative approach in which reviewers get full and public credit for their work. For more on our review philosophy and procedures, please see the [Guidelines for Reviewers][reviewers].
+
+We hope you'll consider joining our team of reviewers. The time commitment is flexible, and you'll be contributing to helping us maintain high academic standards for this community resource. Please email <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a> to introduce yourself and let us know about the specific skills, tools, topics, and technologies that you'd like to be involved with so that we can send you the most appropriate lessons to review. 
+
 ---
 
 No matter how you'd like to be involved, you can always email <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a> with any comments, questions, complaints, or suggestions.  We endeavor to respond to all emails promptly.
 
-
-Thanks for making _Programming Historian_ such a great resource!
+Thanks for your help in improving _The Programming Historian_!
  
  [submissions]: new-lesson-workflow
  [reviewers]: http://programminghistorian.org/reviewer-guidelines
+

--- a/feedback.md
+++ b/feedback.md
@@ -1,5 +1,5 @@
 ---
-title: Report an Issue
+title: Give Feedback
 date: 07-11-2015
 layout: directory
 redirect_from: /report-issue.html
@@ -8,13 +8,20 @@ redirect_from: /report-issue.html
 <figure>
 	<img src="../images/reader-sm.png" width="180px" style="float: left; margin-right: 15px; margin-bottom: 15px;" />
 </figure>
-See a problem with a lesson on the Programming Historian? Code that doesn't work or needs a clearer explanation? Typos? Syntax that doesn't look quite right? Thank you for taking the time to report a problem. Your assistance is crucial for helping us maintain the highest standards for our lessons.
 
-There are three easy ways that you can provide your feedback:
+See a problem with a lesson on the Programming Historian? Code that doesn't work or needs a clearer explanation? Typos? Syntax that doesn't look quite right? Thank you for taking the time to report a problem or suggest a change. Your assistance is crucial for helping us maintain the highest standards for our lessons.
+
+There are several easy ways that you can provide your feedback:
 
 <br/>
 
-## Option 1: Open an Issue on GitHub
+## Option 1: Email or Tweet
+
+Contact <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a> at the University of New Mexico or one of the other members of our [Project Team](./project-team.html). 
+
+You can also find us on Twitter at [@ProgHist](https://twitter.com/proghist).
+
+## Option 2: Open an Issue on GitHub
 
 First, [sign up for a free, personal GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account) if you don't already have one. Log in if you already have an account.
 
@@ -28,7 +35,7 @@ If your issue has not been reported, create a new issue with a descriptive title
 
 For more information about issues, read the GitHub Guide on [Mastering Issues](https://guides.github.com/features/issues/).
 
-## Option 2: Suggest a Particular Change
+## Option 3: Suggest a Particular Change
 
 To suggest or make minor changes to a lesson, first navigate to the  [lessons directory](https://github.com/programminghistorian/jekyll/tree/gh-pages/lessons) and click on the relevant lesson. 
 
@@ -47,15 +54,11 @@ Next, to comment on a line, hover over a line number, and a blue plus-sign will 
 Editors will be notified of these comments and can then incorporate your suggestions into the lesson. As much as we strive for openness, only _Programming Historian_ editors can make changes directly to the lessons at this time.
 
 
-## Option 3: Make a Pull Request
+## Option 4: Make a Pull Request
 
 If you believe you know how to fix the problem in the lesson, you may wish to consider forking our repository and making a pull request.
 
 For more information on pull requests, see the GitHub Guide on [Forking Projects](https://guides.github.com/activities/forking/) or Rich Jones's tutorial on [How to GitHub](https://gun.io/blog/how-to-github-fork-branch-and-pull-request/).
-
-## If all else fails (or is too confusing): Send Us an Email
-
-If you are unable to create an issue or make a pull request, you can also contact <a href="mailto:fwgibbs@gmail.com">Fred Gibbs</a> at the University of New Mexico.
 
 ## Further Resources on Git and GitHub
 

--- a/feedback.md
+++ b/feedback.md
@@ -2,6 +2,7 @@
 title: Report an Issue
 date: 07-11-2015
 layout: directory
+redirect_from: /report-issue.html
 ---
 
 <figure>


### PR DESCRIPTION
Following up on #152 discussion, I thought it would be good to make clearer that people can offer feedback without having to create a GitHub account. 

This pull request does two main things:
- Renames "Report an Issue" page to "Feedback" page
- Makes emailing or tweeting us the first option for feedback, with GitHub options lower on the page

I also wanted to demonstrate how an internal pull request can be made by someone on the Project Team, so that if someone submits a lesson by email, we can see how discussion could still happen on a pull request if desired.

@acrymble @miriamposner @ahegel @fredgibbs @ianmilligan1 What do you think about these changes?
