### PR TITLE
Sparql link 404

### DIFF
--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -462,7 +462,7 @@ ORDER BY DESC(?n)
 
 ## Linking multiple SPARQL endpoints
 
-**2016-09-12: Unfortunately, Europeana has suspended their SPARQL endpoint until further notice, so the links in the following section are no longer operative.**
+**2016-09-12: Unfortunately, Europeana has suspended their SPARQL endpoint until further notice, so the links in the following section are no longer operative. The text below will be retained as-is for reference purposes, and will be updated if and when Europeana renews their endpoint.**
 
 Up until now, we have constructed queries that look for patterns in one dataset
 alone. In the ideal world envisioned by Linked Open Data advocates, multiple

--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -601,8 +601,8 @@ searching, or doing other mathematical operations more complex than counting.
 For a more complete rundown of the commands available in SPARQL, see these
 links:
 
-- [How to SPARQL](http://rdf.myexperiment.org/howtosparql?)
 - [Wikibooks SPARQL tutorial](http://en.wikibooks.org/wiki/XQuery/SPARQL_Tutorial)
+- [Full W3C Overview of SPARQL](https://www.w3.org/TR/sparql11-overview/)
 
 Both the Europeana and Getty Vocabularies LOD sites also offer extensive, and
 quite complex example queries which can be good sources for understanding how to

--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -462,6 +462,8 @@ ORDER BY DESC(?n)
 
 ## Linking multiple SPARQL endpoints
 
+**2016-09-12: Unfortunately, Europeana has suspended their SPARQL endpoint until further notice, so the links in the following section are no longer operative.**
+
 Up until now, we have constructed queries that look for patterns in one dataset
 alone. In the ideal world envisioned by Linked Open Data advocates, multiple
 databases can be interlinked to allow very complex queries dependent on


### PR DESCRIPTION
Addresses #289 
1. Replaces a broken link to a SPARQL tutorial in the "Further Reading" section with a link to the W3C overview of SPARQL (which is actually a better place for more in-depth study, anyway!)
2. Adds a note to the "Linking multiple SPARQL endpoints" section explaining that the Europeana endpoint is down as of 2016-09-12 until further notice (pending new info from the folks at Europeana Labs)

@wcaleb I bolded the advisory note, but if there's some other class baked into the PH CSS that would be better to use for this deprecation note, please let me know / edit the PR
