### PR TITLE
Update links to Europeana SPARQL

### DIFF
--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -462,8 +462,6 @@ ORDER BY DESC(?n)
 
 ## Linking multiple SPARQL endpoints
 
-**2016-09-12: Unfortunately, Europeana has suspended their SPARQL endpoint until further notice, so the links in the following section are no longer operative. The text below will be retained as-is for reference purposes, and will be updated if and when Europeana renews their endpoint.**
-
 Up until now, we have constructed queries that look for patterns in one dataset
 alone. In the ideal world envisioned by Linked Open Data advocates, multiple
 databases can be interlinked to allow very complex queries dependent on
@@ -480,10 +478,12 @@ Architecture thesaurus. SPARQL allows you to insert `SERVICE` statements that
 instruct the database to "phone a friend" and run a portion of the query on
 an outside dataset, using the results to complete the query on the local
 dataset. While this lesson will go into the data models in Europeana and DBpedia in depth, the following query illustrates how a `SELECT` statement works. You may run it yourself by copying and pasting the query text into the [Europeana endpoint][eursparql].
+(On the Europeana endpoint, you must set the "Sponging" menu to "Retrieve remote RDF data for all missing source graphs" in order for this query to work.)
 
-[eursparql]: http://europeana.ontotext.com/sparql
+[eursparql]: http://sparql.europeana.eu/
 
 ```
+PREFIX ore:    <http://www.openarchives.org/ore/terms/>
 PREFIX edm:    <http://www.europeana.eu/schemas/edm/>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX dbo:    <http://dbpedia.org/ontology/>


### PR DESCRIPTION
* Removes the deprecation message
* Updates link to point to sparql.europeana.eu
* Adds explicit declaration for the ore: prefix
* Notes that users must explicitly allow the Europeana endpoint to query outside servers if they want to... query outside servers.

This closes #289 