### PR TITLE
Revisions to technical contributions text

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,2 +1,23 @@
+This document describes how to make _technical_ contributions to _The Programming Historian_ that modify the code that generates the site itself.
+
+If you are interested in making a _content_ contribution like a new lesson, please see our [pages on contributing as an author or an editor](http://programminghistorian.org/contribute).
+
+## Anti-harassment Policy
+
 The *Programming Historian* is dedicated to providing an open scholarly environment that offers community participants the freedom to thoroughly scrutinize ideas, to ask questions, make suggestions, or to requests for clarification, but also provides a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion, or technical experience. We do not tolerate harassment or ad hominem attacks of community participants in any form. Participants violating these rules may be expelled from the community at the discretion of the editorial board. If anyone witnesses or feels they have been the victim of the above described activity, please contact our ombudspeople (Ian Milligan and Amanda Visconti - <http://programminghistorian.org/project-team>). Thank you for helping us to create a safe space.
 
+## Setting up a GitHub pages development environment
+
+This site is built via Jekyll, using GitHub Pages as a hosting service. This means that all code in this GitHub repo is processed by GitHub servers to produce the HTML pages that readers see. If you want to preview what this generated site looks like on your own computer, you need to make sure you are using the same versions of Jekyll and its dependencies that GitHub does.
+
+Note: these instructions assume that you hare familiar with using the command line and git.
+
+1. [Set up Jekyll dependencies.](http://programminghistorian.org/lessons/building-static-sites-with-jekyll-github-pages#section2)
+2. Clone the programming historian repository
+3. Ensure you have the [bundler gem]() installed:
+```
+gem install bundler
+```
+4. `cd` into your clone of the PH repository, and install all the necessary dependencies with the command `bundle install`
+
+## 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,23 +1,7 @@
-This document describes how to make _technical_ contributions to _The Programming Historian_ that modify the code that generates the site itself.
+Our [technical contributions wiki](https://github.com/programminghistorian/jekyll/wiki/Making-technical-contributions) describes best practices for modifying the code that generates _The Programming Historian_ itself.
 
 If you are interested in making a _content_ contribution like a new lesson, please see our [pages on contributing as an author or an editor](http://programminghistorian.org/contribute).
 
 ## Anti-harassment Policy
 
 The *Programming Historian* is dedicated to providing an open scholarly environment that offers community participants the freedom to thoroughly scrutinize ideas, to ask questions, make suggestions, or to requests for clarification, but also provides a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion, or technical experience. We do not tolerate harassment or ad hominem attacks of community participants in any form. Participants violating these rules may be expelled from the community at the discretion of the editorial board. If anyone witnesses or feels they have been the victim of the above described activity, please contact our ombudspeople (Ian Milligan and Amanda Visconti - <http://programminghistorian.org/project-team>). Thank you for helping us to create a safe space.
-
-## Setting up a GitHub pages development environment
-
-This site is built via Jekyll, using GitHub Pages as a hosting service. This means that all code in this GitHub repo is processed by GitHub servers to produce the HTML pages that readers see. If you want to preview what this generated site looks like on your own computer, you need to make sure you are using the same versions of Jekyll and its dependencies that GitHub does.
-
-Note: these instructions assume that you hare familiar with using the command line and git.
-
-1. [Set up Jekyll dependencies.](http://programminghistorian.org/lessons/building-static-sites-with-jekyll-github-pages#section2)
-2. Clone the programming historian repository
-3. Ensure you have the [bundler gem]() installed:
-```
-gem install bundler
-```
-4. `cd` into your clone of the PH repository, and install all the necessary dependencies with the command `bundle install`
-
-## 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
 NOTICE: Are you attempting to submit a lesson to the Programming Historian? We no longer accept lesson submissions by pull request to this repository. Please consult our [guidelines for submitting a lesson](http://programminghistorian.org/new-lesson-workflow) for further instructions.
 
-If your pull request instead concerns some issue with the formatting or functioning of our site, or some error in an existing lesson, feel free to proceed with your PR and delete this template text!
-
+If your pull request instead concerns some issue with the formatting or functioning of our site, or some error in an existing lesson, please see our technical contribution guidelines: https://github.com/programminghistorian/jekyll/wiki/Making-technical-contributions


### PR DESCRIPTION
This PR adds several pointers to the new ["Making Technical Contributions"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions) page on the wiki. I would love to get feedback on the text here, as well as the wiki text.

Re: #387 