### PR TITLE
CC license translations

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -94,6 +94,9 @@ footer:
   license:
     en: license
     es: licencia
+  cc-link:
+    en: https://creativecommons.org/licenses/by/4.0/deed.en
+    es: https://creativecommons.org/licenses/by/4.0/deed.es
   gh-hosted:
     en: Hosted on GitHub
     es: Alojado en GitHub

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="col-sm-12 footer-head">
-    {{ site.data.snippets.footer.ph-released[page.lang] }} <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">CC-BY</a> {{ site.data.snippets.footer.license[page.lang] }}.</p>
+    {{ site.data.snippets.footer.ph-released[page.lang] }} <a href="{{ site.data.snippets.footer.cc-link[page.lang] }}" rel="license">CC-BY</a> {{ site.data.snippets.footer.license[page.lang] }}.</p>
   </div>
 </div>
 

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,3 +1,7 @@
+{% comment %}
+Adds a table of contents to any page.
+{% endcomment %}
+
 ## {{ site.data.snippets.contents[page.lang] }}
 {:.no_toc}
 


### PR DESCRIPTION
This modification would point to the EN version of the CC-BY license from EN pages, and the ES translation of the CC-BY license from ES pages. Does this sound acceptable?

More on the translations for CC licenses: https://creativecommons.org/faq/#what-are-the-official-translations-of-the-cc-licenses-and-cc0