### PR TITLE
Changed my name in the editor field for the open refine lesson

### DIFF
--- a/lessons/fetch-and-parse-data-with-openrefine.md
+++ b/lessons/fetch-and-parse-data-with-openrefine.md
@@ -10,7 +10,7 @@ reviewers:
 - Peggy Griesinger
 - Lisa Lowry
 editors:
-- Jeri E. Wieringa
+- Jeri Wieringa
 difficulty: 2
 review-ticket: 69
 activity: acquiring


### PR DESCRIPTION
I had included my middle initial where the name in the author file does not.

This is the first of two ideas I had this morning on why the site might not be compiling.