### PR TITLE
Update miditime import

### DIFF
--- a/lessons/sonification.md
+++ b/lessons/sonification.md
@@ -200,6 +200,8 @@ Let us look at the sample script provided. Open your text editor, and copy and p
 #!/usr/bin/python
 
 from miditime.miditime import MIDITime
+# NOTE: this import works at least as of v1.1.3; for older versions or forks of miditime, you may need to use
+# from miditime.MIDITime import MIDITime
 
 # Instantiate the class with a tempo (120bpm is the default) and an output file destination.
 mymidi = MIDITime(120, 'myfile.mid')

--- a/lessons/sonification.md
+++ b/lessons/sonification.md
@@ -199,7 +199,7 @@ Let us look at the sample script provided. Open your text editor, and copy and p
 ```python
 #!/usr/bin/python
 
-from miditime.MIDITime import MIDITime
+from miditime.miditime import MIDITime
 
 # Instantiate the class with a tempo (120bpm is the default) and an output file destination.
 mymidi = MIDITime(120, 'myfile.mid')


### PR DESCRIPTION
The miditime import in the example didn't work for me, I had to switch it to this version.  I used `pip install` and got `miditime==1.1.3`.    (The project documentation shows the old import, but that doesn't work.)

I thought it might be worth updating, because if people aren't familiar with Python they may not be able to figure it out.   You might want to add something about the version of miditime or document the older syntax also, but I don't know where that should go.

NOTICE: Are you attempting to submit a lesson to the Programming Historian? We no longer accept lesson submissions by pull request to this repository. Please consult our [guidelines for submitting a lesson](http://programminghistorian.org/new-lesson-workflow) for further instructions.

If your pull request instead concerns some issue with the formatting or functioning of our site, or some error in an existing lesson, please see our technical contribution guidelines: https://github.com/programminghistorian/jekyll/wiki/Making-technical-contributions
