### PR TITLE
Update editorial guidelines refs #571

### DIFF
--- a/editor-guidelines.md
+++ b/editor-guidelines.md
@@ -182,9 +182,11 @@ If the lesson has been written by a new author, editors should add information a
 
 ```yaml
 - name: Jim Clifford
-  bio: |
-       Jim Clifford is an assistant professor in the Department of History
-       at the University of Saskatchewan.
+  team: false
+  bio:
+      en: |
+          Jim Clifford is an assistant professor in the Department of History
+          at the University of Saskatchewan.
 ```
 
 **Whitespace is important**, so be sure that the indentation matches the other examples.

--- a/editor-guidelines.md
+++ b/editor-guidelines.md
@@ -182,7 +182,6 @@ If the lesson has been written by a new author, editors should add information a
 
 ```yaml
 - name: Jim Clifford
-  team: false
   bio:
       en: |
           Jim Clifford is an assistant professor in the Department of History


### PR DESCRIPTION
Update the editorial guidelines for adding authors to the ph-authors.yml file a la #571. Syntax seemed out of date given the examples that are currently in there - I think it was referencing older syntax from before the website redesign and Spanish translations. Flagging @arojascastro to update the Spanish guidelines accordingly and @mdlincoln just to make sure I'm on track here.