### PR TITLE
Fix for api filtering

### DIFF
--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -32,7 +32,7 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
  Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work
 {% endcomment %}
   <span class="activity">{{ lesson.activity }}</span>
-  <span class="topics">{{ lesson.topics }}</span>
+  <span class="topics">{{ lesson.topics | join: ' '}}</span>
   <span class="date">{{ lesson.date }}</span>
   <span class="difficulty">{{ lesson.difficulty }}</span>
 

--- a/js/lessonfilter.js
+++ b/js/lessonfilter.js
@@ -66,7 +66,6 @@ function wireButtons() {
   };
 
   var featureList = new List('lesson-list', options);
-
   // We need a stateObj for adjusting the URIs on button clicks, but the value is moot for now; could be useful for future functionality.
   var stateObj = { foo: "bar" };
 
@@ -176,7 +175,8 @@ function wireButtons() {
     var type = $(this).attr("id").substr(7);
 
     featureList.filter(function(item) {
-      if (item.values().topics.includes(type)) {
+      var topicsArray = item.values().topics.split(/\s/);
+      if (topicsArray.includes(type)) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
@mdlincoln can you glance over the search filtering here to just make sure I haven't gummed up the works? Should fix #574. Looked like it was loading topic categories all as one big string - so "webscrapingapiwebsite" for example. Then when filtering it was just just looking for a substring to match. Because "webscraping" has the letters "api" in it the filtering was getting confused. Switched it to add spaces between the topic categories. Then, when looking against those topic categories, it now splits them apart into an array on spaces and searches for a matching item in the array.