### PR TITLE
Baseurl to URL and add HTTPs to Config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 name: Programming Historian
 description: Introductory and intermediate programming lessons for humanists
-url: http://programminghistorian.org
+url: https://programminghistorian.org
 baseurl: ""
 permalink: :categories/:title
 exclude:

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -28,7 +28,7 @@ layout: base
 
       <div class="col-md-8">
         <div class="header-title">
-          <h1><a href="{{ site.baseurl }}/{{ page.url }}">{{ page.title }}</a></h1>
+          <h1><a href="{{ site.url }}{{ page.url }}">{{ page.title }}</a></h1>
         </div>
 
         <div class="header-author">

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -28,7 +28,7 @@ layout: base
 
       <div class="col-md-8">
         <div class="header-title">
-          <h1><a href="{{ site.url }}{{ page.url }}">{{ page.title }}</a></h1>
+          <h1><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></h1>
         </div>
 
         <div class="header-author">


### PR DESCRIPTION
Two changes -

Layout for lessons was pulling in baseurl, which is an empty string at the moment. Using the url variable instead. Also noticed that the url in the config file was still http and not https, so I updated that to use https as well. Should resolve #582