### PR TITLE
changes to the figure and figcaption styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -627,17 +627,17 @@ Figures
 ========================================================================== */
 
   figure {
-    margin: 0 auto;
+    margin: 0 auto .5rem;
     text-align: center;
     display:table;
   }
 
   figcaption {
-    margin-top:.2rem;
+    margin-top:.5rem;
     font-family:'Open Sans';
     font-size:0.8em;
     color: #666;
-    display:table-caption;
+    display:block;
     caption-side: bottom;
     text-align: justify;
   }


### PR DESCRIPTION
For cases when the figcaption does not contain a `<p>` tag.

I checked locally in Chrome and Safari, and from what I could see, the changes only add a slight bit of additional padding to  the bottom of the `<figure>` elements. 

Places to check include blog posts, such as https://programminghistorian.org/posts/roundup2017a and https://programminghistorian.org/posts/new-lessons-page; and lessons such as https://programminghistorian.org/lessons/correspondence-analysis-in-R 