### PR TITLE
Updating contact information on research page, closes #637

### DIFF
--- a/research.md
+++ b/research.md
@@ -4,7 +4,7 @@ layout: blank
 ---
 
 # Project Scholarship
-The project team and members of the wider community are involved in a number of scholarly initiatives related to our work here at The _Programming Historian_. These include events, journal articles, reviews (of us by the community), and posters. If you are conducting academic research using this project please [contact our managing editor](mailto:jparr1129@gmail.com).
+The project team and members of the wider community are involved in a number of scholarly initiatives related to our work here at The _Programming Historian_. These include events, journal articles, reviews (of us by the community), and posters. If you are conducting academic research using this project please [contact Jessica Parr, our managing editor](mailto:jparr1129@gmail.com).
 
 ## Original Programming Historian
 * William J. Turkel and Alan MacEachern, [_The Programming Historian_](http://niche-canada.org/wp-content/uploads/2013/09/programming-historian-1.pdf) 1st edition (Network in Canadian History &amp; Environment: 2007-2008).

--- a/research.md
+++ b/research.md
@@ -4,7 +4,7 @@ layout: blank
 ---
 
 # Project Scholarship
-The project team and members of the wider community are involved in a number of scholarly initiatives related to our work here at The _Programming Historian_. These include events, journal articles, reviews (of us by the community), and posters. If you are conducting academic research using this project please let us know.
+The project team and members of the wider community are involved in a number of scholarly initiatives related to our work here at The _Programming Historian_. These include events, journal articles, reviews (of us by the community), and posters. If you are conducting academic research using this project please [contact our managing editor](mailto:jparr1129@gmail.com).
 
 ## Original Programming Historian
 * William J. Turkel and Alan MacEachern, [_The Programming Historian_](http://niche-canada.org/wp-content/uploads/2013/09/programming-historian-1.pdf) 1st edition (Network in Canadian History &amp; Environment: 2007-2008).


### PR DESCRIPTION
On the research page, there was no link to contact us – it just told readers to do so. This change adds in the e-mail address for our managing editor to streamline the process.

_This is part of a test process to document branches and pull requests._