### PR TITLE
Add networkx lesson reviewers

### DIFF
--- a/_data/reviewers.yml
+++ b/_data/reviewers.yml
@@ -92,3 +92,6 @@
 - Lee Skallerup Bessette
 - Sandra van Ginhoven
 - Taylor Arnold
+- Elisa Beshero-Bondar
+- Anne Chao
+- Qiwei Li


### PR DESCRIPTION
Per Adam's email, adding reviewers from the networkx lesson I edited. Should be able to get merged in without translation.