### PR TITLE
Remove markdown that was not formatting in KWIC lesson abstract

### DIFF
--- a/lessons/keywords-in-context-using-n-grams.md
+++ b/lessons/keywords-in-context-using-n-grams.md
@@ -12,7 +12,8 @@ editors:
 difficulty: 2
 activity: presenting
 topics: [python]
-abstract: "This lesson takes the frequency pairs collected in [Counting Frequencies][] and outputs them in HTML."
+abstract: |
+  This lesson takes the frequency pairs collected in "Counting Frequencies" and outputs them in HTML.
 next: output-keywords-in-context-in-html-file
 previous: output-data-as-html-file
 python_warning: true


### PR DESCRIPTION
Fixes this problem:

![screen shot 2017-11-28 at 2 45 18 pm](https://user-images.githubusercontent.com/4392604/33348305-c78476b2-d44a-11e7-9630-06597a354819.png)
