### PR TITLE
Spanish lesson date sort using translation_date

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -116,7 +116,7 @@ sort-by-date:
   en:
     sort by publication date
   es:
-    ordenar por fecha de publicación
+    ordenar por fecha de traducción
 sort-by-difficulty:
   en:
     sort by difficulty

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -29,11 +29,11 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   <p class="abstract">{{ lesson.abstract }}</p>
 
   {% comment %}
- Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work
+ Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is publication date for english lesson, and translation date for spanish lessons.
 {% endcomment %}
   <span class="activity">{{ lesson.activity }}</span>
   <span class="topics">{{ lesson.topics | join: ' '}}</span>
-  <span class="date">{{ lesson.date }}</span>
+  <span class="date">{% if lesson.lang == "es" %}{{ lesson.translation_date }}{% else %}{{ lesson.date }}{% endif %}</span>
   <span class="difficulty">{{ lesson.difficulty }}</span>
 
 </div>


### PR DESCRIPTION
To complete this fix, the snippet for the date sort display label needs to be changed from "ordenar por fecha de publicación" to instead describe the translation date. The line is located here, in the `translation-date-sort` branch: https://github.com/programminghistorian/jekyll/blob/translation-date-sort/_data/snippets.yml#L119

Closes #548 

