### PR TITLE
Fixes "next lesson" on series of lessons

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -154,7 +154,7 @@ layout: base
 
      {% if page.next %}
       <div class="series-warning alert alert-info">
-        {{ site.data.snippets.series-next-note[page.lang] }} <a href="{{page.previous}}">{{ site.data.snippets.next-lesson[page.lang] }} </a>.
+        {{ site.data.snippets.series-next-note[page.lang] }} <a href="{{page.next}}">{{ site.data.snippets.next-lesson[page.lang] }} </a>.
       </div>
      {% endif %}
 

--- a/es/lecciones/introduccion-a-bash.md
+++ b/es/lecciones/introduccion-a-bash.md
@@ -25,7 +25,6 @@ difficulty: 1
 activity: transforming
 topics: [data-manipulation, get-ready]
 abstract: "Con esta lección aprenderás introducir órdenes a través de una Interfaz de Línea de comandos, en lugar de hacerlo en una Interfaz Gráfica de Usuario. La Interfaz de Línea de comandos es útil cuando el usuario necesita un mayor grado de precisión para llevar a cabo su investigación. Por ejemplo, permite añadir modificadores de tal modo que se puede ejecutar un programa de una manera determinada. Asimismo, te será útil para automatizar programas mediante scripts, es decir, recetas o paquetes que contienen una serie de instrucciones."
-next: datos-de-investigacion-con-unix
 ---
 
 {% include toc.html %}


### PR DESCRIPTION
The "next lesson" instructions in the lesson template was erroneously linking to the previous lesson in the series, not the next one. Tested locally and it now works properly.

This will resolve #671 when merged.