### PR TITLE
Fixing link syntax for pip lesson (Issue #676)

### DIFF
--- a/lessons/installing-python-modules-pip.md
+++ b/lessons/installing-python-modules-pip.md
@@ -149,7 +149,7 @@ python -m pip install XXX
 
 Happy installing!
 
-  [pip]:
-  [curl command]: http://www.thegeekstuff.com/2012/04/curl-examples/
+  [pip]: https://pip.pypa.io/en/stable/
+  [curl command]: http://www.thegeekstuff.com/2012/04/curl-examples/ 
   [here]: https://bootstrap.pypa.io/get-pip.py
   [StackOverflow page]: http://stackoverflow.com/questions/4750806/how-to-install-pip-on-windows


### PR DESCRIPTION
This fixes the broken links in the pip lesson. The Spanish lesson currently is working, so no translation needed. Built and tested locally.