### PR TITLE
Add new team members to Membership History

### DIFF
--- a/es/equipo-de-proyecto.md
+++ b/es/equipo-de-proyecto.md
@@ -39,7 +39,8 @@ All editorial board information should be edited in data/ph_authors.yml. Authors
 * Brandon Walsh, University of Virginia (2017-Present)
 * Anandi Silva Knuppel, Emory University (2017-Present)
 * James Baker, University of Sussex (2017-Present)
-
+* Jos&eacute; Antonio Motilla, Universidad Aut&oacute;noma de San Luis Potosi (2018-Present)
+* Jennifer Isasi, Universidad de Nebraska (2018-Present)
 
 ## Participantes de la comunidad
 

--- a/project-team.md
+++ b/project-team.md
@@ -42,7 +42,8 @@ All editorial board information should be edited in data/ph_authors.yml. Authors
 * Brandon Walsh, University of Virginia (2017-Present)
 * Anandi Silva Knuppel, Emory University (2017-Present)
 * James Baker, University of Sussex (2017-Present)
-
+* Jos&eacute; Antonio Motilla, Universidad Aut&oacute;noma de San Luis Potosi (2018-Present)
+* Jennifer Isasi, University of Nebraska (2018-Present)
 
 ## Community Participants
 


### PR DESCRIPTION
I've added Jose and Jennifer to the "Project Team Membership History" lists on both the Spanish and English pages.