### PR TITLE
Fixing a bug with the month of last modification

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -169,7 +169,7 @@ layout: base
   })
     .done(function( data ) {
       var date = new Date(data[0].commit.author.date);
-      var formatted_date = date.getFullYear()+'-'+("0"+date.getMonth()).slice(-2)+'-'+("0"+date.getDate()).slice(-2);
+      var formatted_date = date.getFullYear() + '-'+("0"+(date.getMonth() + 1)).slice(-2)+'-'+("0"+date.getDate()).slice(-2);
       $("#modified-date").text(formatted_date);
     });
 })();


### PR DESCRIPTION
date.getMonth() returns a result [ranging from 0 to 11](https://www.w3schools.com/jsref/jsref_getmonth.asp), we need to add 1 to it, otherwise the display is wrong. For January update : 00 instead of 01.

See an example of the bug on [Sentiment Analysis for Exploratory Data Analysis ](https://programminghistorian.org/lessons/sentiment-analysis) lesson that currently display "modified 2018-00-25". This patch fixes the issue and does not seem to break anything.