### PR TITLE
XML for Directory of Open Access Journals

### DIFF
--- a/doaj_xml/doaj.xml
+++ b/doaj_xml/doaj.xml
@@ -1,12 +1,11 @@
 ---
 ---
+<?xml version="1.0"?>
 {% comment %}
 Generates an XML file with metadata for all lessons for the Directory of Open Access Journals. For formatting information, see https://doaj.org/publishers#upload
 {% endcomment %}
 
 {% assign all_lessons = site.pages | where: "lesson" , "true" %}
-
-<?xml version="1.0"?>
 <records>
   {% for lesson in all_lessons %}
   {% assign lesson_two_lang = lesson.lang %}

--- a/doaj_xml/doaj.xml
+++ b/doaj_xml/doaj.xml
@@ -1,0 +1,43 @@
+---
+---
+{% comment %}
+Generates an XML file with metadata for all lessons for the Directory of Open Access Journals. For formatting information, see https://doaj.org/publishers#upload
+{% endcomment %}
+
+{% assign all_lessons = site.pages | where: "lesson" , "true" %}
+
+<?xml version="1.0"?>
+<records>
+  {% for lesson in all_lessons %}
+  {% assign lesson_two_lang = lesson.lang %}
+  {% if lesson_two_lang == "en" %}
+    {% assign lesson_lang = "eng" %}
+  {% elsif lesson_two_lang == "es" %}
+    {% assign lesson_lang = "spa" %}
+  {% endif %}
+  <record>
+    <journalTitle>The Programming Historian</journalTitle>
+    <eissn>23972068</eissn>
+    <publicationDate>{{ lesson.date }}</publicationDate>
+    <title language="{{ lesson_lang }}">{{ lesson.title }}</title>
+    <authors>
+      {% for author in lesson.authors %}
+      {% assign author_data = site.data.ph_authors | where: "name", author %}
+      <author>
+        <name>{{ author }}</name>
+        {% if author_data.email %}<email>{{ author_data.email }}</email>{% endif %}
+        {% if author_data.institution %}<affiliationId>{{ author_data.institution }}</affiliationId>{% endif %}
+      </author>
+      {% endfor %}
+    </authors>
+    <abstract language="{{ lesson_lang }}">{{ lesson.abstract }}</abstract>
+    <fullTextUrl format="html">https://programminghistorian.org{{ lesson.url }}</fullTextUrl>
+    <keywords language="eng">
+      {% for keyword in lesson.topics %}
+      {% assign eng_keyword = site.data.topics | where: "type", keyword | first %}
+      <keyword>{{ eng_keyword.displayname.en }}</keyword>
+      {% endfor %}
+    </keywords>
+  </record>
+{% endfor %}
+</records>

--- a/doaj_xml/doaj.xml
+++ b/doaj_xml/doaj.xml
@@ -25,7 +25,6 @@ Generates an XML file with metadata for all lessons for the Directory of Open Ac
       <author>
         <name>{{ author }}</name>
         {% if author_data.email %}<email>{{ author_data.email }}</email>{% endif %}
-        {% if author_data.institution %}<affiliationId>{{ author_data.institution }}</affiliationId>{% endif %}
       </author>
       {% endfor %}
     </authors>

--- a/doaj_xml/doaj.xml
+++ b/doaj_xml/doaj.xml
@@ -21,7 +21,7 @@ Generates an XML file with metadata for all lessons for the Directory of Open Ac
     <title language="{{ lesson_lang }}">{{ lesson.title }}</title>
     <authors>
       {% for author in lesson.authors %}
-      {% assign author_data = site.data.ph_authors | where: "name", author %}
+      {% assign author_data = site.data.ph_authors | where: "name", author | first %}
       <author>
         <name>{{ author }}</name>
         {% if author_data.email %}<email>{{ author_data.email }}</email>{% endif %}


### PR DESCRIPTION
This XML template builds a valid XML file with our lesson metadata for DOAJ

closes #698 
