### PR TITLE
Add guidelines on editorial board diversity

### DIFF
--- a/about.md
+++ b/about.md
@@ -23,6 +23,9 @@ We do not charge Article Processing Charges (APCs), nor do we charge library sub
 
 The _Programming Historian_ (ISSN 2397-2068) is indexed by the [Directory of Open Access Journals](https://doaj.org/toc/2397-2068).
 
+## Diversity Policy
+
+The Programming Historian is committed to diversity, and we insist on a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion, or technical experience. Our commitment to diversity extends to our Editorial Board, which has adopted a diversity policy to ensure that members from any one gender or any one nationality do not comprise more than 50% + 1 of the members on the board. This is to ensure that the project continues to benefit from diverse viewpoints. This policy is under perpetual review and we welcome suggestions on it from the community.
 
 ## Funding & Ownership
 The _Programming Historian_ is a volunteer-driven project. It is not a legal entity, and does not currently receive direct funding from any source.

--- a/es/acerca-de.md
+++ b/es/acerca-de.md
@@ -21,6 +21,9 @@ No aplicamos cargos por procesamiento de artículos (APCs), o suscripción bibli
 
 _The Programming Historian en español_ está indexado en el Directorio de Revistas de Acceso Abierto [DOAJ](https://doaj.org/toc/2397-2068).
 
+## Política de diversidad
+
+En The Programming Historian estamos comprometidos con la diversidad y defendemos la necesidad de mantener un espacio de trabajo sin ningún tipo de acoso u hostigamiento basado en el género, identidad, orientación sexual, capacidades, físico, peso, etnia, edad, religión o nivel de conocimiento técnico de los participantes y colaboradores. Asimismo, nuestro compromiso con la diversidad se extiende a la composición del Consejo Editorial garantizando que los miembros de un mismo género o nacionalidad no alcanzan una ratio superior al 50% +1 del total. Con esto pretendemos que el proyecto se siga beneficiando de puntos de vista distintos. La medida está sujeta a revisiones futuras, por lo que aceptamos el envío de sugerencias de los miembros de la comunidad.
 
 ## Financiamiento y propiedad
 _The Programming Historian_ es una iniciativa dirigida por voluntarios, controlada en su totalidad por el Consejo Editorial de *The Programming Historian* con la ayuda de contribuyentes de la comunidad. No es una persona jurídica y, actualmente, no recibe financiación directa de ninguna organizacin o entidad.


### PR DESCRIPTION
To close issue #619 - Editorial Board Diversity suggestion.

I have changed the two 'about' pages with the agreed text. @arojascastro has asked for a review from another member of the Spanish team, since this was a difficult translation.
