### PR TITLE
Fix es language tag for Siddiqui bio

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -772,7 +772,7 @@
   bio:
     en: |
         Nabeel Siddiqui is a doctoral candidate in American Studies at the College of William and Mary, where he is also an inaugural fellow of the Digital Equality Lab. His research focuses broadly on the relationship between the humanities and computation, with a particular expertise on the cultural history of media, new media studies, digital humanities, information studies, and the history of science and technology. Currently, he is completing his dissertation entitled "Byting Out the Public," which looks at the historical relationship between the personal computer and the private sphere.
-    en: |
+    es: |
         Nabeel Siddiqui es doctoranda en Estudios Americanos en College of William and Mary, donde también es becaria del Digital Equality Lab. Su investigación se centra en las relaciones entre las Humanidades y la Informática, en particular en la historia cultural de los medios, Comunicación y Humanidades Digitales, Ciencias de la Información, Historia de la Ciencia y Tecnología. Actualmente, está realizando su tesis doctoral titulada "Byting Out the Public", que pretende estudiar la relación entre el ordenador personal y la privacidad.
 
 - name: Anandi Silva Knuppel


### PR DESCRIPTION
Closes #737 Someone put in `en` twice!

