### PR TITLE
remove roles from Visconti to reflect new position

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -589,9 +589,7 @@
     es: |
         Amanda trabaja en las mejoras técnicas de la web de The Programming Historian.
   team_roles:
-   - technical
    - ombuds
-   - board
 
 - name: Megan R. Brett
   twitter: magpie


### PR DESCRIPTION
I've removed the 'technical' and 'board' roles from @amandavisconti to reflect her new role as ombudsperson only.