### PR TITLE
split author bios into individual paragraphs

### DIFF
--- a/_includes/author-info.html
+++ b/_includes/author-info.html
@@ -12,13 +12,12 @@
       <p class="author-name">Acerca {% if authorCount == 1 %}del autor{% else %}de los autores{% endif %}</p>
   {% endif %}
 </div>
-<div class="author-description"><p>
+<div class="author-description">
   {% for author in page.authors %}
      {% for member in site.data.ph_authors %}
      {% if author == member.name %}
-         {{ member.bio[page.lang] }}&nbsp;
+         <p>{{ member.bio[page.lang] }}<p>
      {% endif %}
      {% endfor %}
-{% endfor %}</p>
-
+{% endfor %}
 </div>


### PR DESCRIPTION
I'd noticed that the current layout of author bios looks a bit weird when a lesson has more than one author, with awkward spacing between each sentence:

![screen shot 2018-03-20 at 8 52 18 am](https://user-images.githubusercontent.com/4392604/37666341-94d0c82c-2c1c-11e8-8068-4e89ca6499b3.png)

This PR instead splits multiple bios into their own paragraphs like so:

![screen shot 2018-03-20 at 8 54 41 am](https://user-images.githubusercontent.com/4392604/37666378-a71ae706-2c1c-11e8-9a6b-6c69b1859942.png)

Thoughts/reactions?