### PR TITLE
Adds asset file; link from lesson. Closes #758.

### DIFF
--- a/lessons/transforming-xml-with-xsl.md
+++ b/lessons/transforming-xml-with-xsl.md
@@ -119,6 +119,8 @@ To begin work with the Scissors and Paste Database, visit its [Github repository
 
 {% include figure.html filename="transforming-xml-with-xsl-1.png" caption="Figure 1: Downloading Your Data" %}
 
+Alternatively, you can also download the scissors and paste file [here](../assets/scissorsandpaste-master.zip).
+
 Open the ZIP file and you will find a folder entitled **scissorsandpaste-master**.  Extract this folder by either using the extract button of your unzipping programme or by dragging and dropping the folder onto your desktop.
 
 This data package has three main components


### PR DESCRIPTION
This would resolve #758. It does the following:
* Adds the zip file of the assets directly;
* Adds a link in the lesson. I think the idea of leaving the original instructions makes sense and respects the authors' intentions (plus it's good for people to see that they can download entire GitHub repositories as a ZIP).