### PR TITLE
use snippets to implement language-specific title quoting

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -254,3 +254,9 @@ suggested-citation:
 journal-title:
   en: The Programming Historian
   es: The Programming Historian en español
+title-open-quote:
+  en: '"'
+  es: '"'
+title-close-quote:
+  en: ',"'
+  es: '",'

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -181,7 +181,7 @@ layout: base
 
         <h5 class="suggested-citation-header">{{ site.data.snippets.suggested-citation[page.lang] }}</h5>
         <div class="suggested-citation-text">
-        <p class="suggested-citation-text">{% include author.html %}, "{{ page.title | strip }},"{% if page.translator %} {{ site.data.snippets.translator[page.lang] }} {{ page.translator | array_to_sentence_string: site.data.snippets.and[page.lang] }},{% endif %} <em>{{ site.data.snippets.journal-title[page.lang] }}</em> {{ vol_no }} ({{ page_year }}), {{ site.url }}{{ page.url }}.</p>
+        <p class="suggested-citation-text">{% include author.html %}, {{ site.data.snippets.title-open-quote[page.lang] }}{{ page.title | strip }}{{ site.data.snippets.title-close-quote[page.lang] }}{% if page.translator %} {{ site.data.snippets.translator[page.lang] }} {{ page.translator | array_to_sentence_string: site.data.snippets.and[page.lang] }},{% endif %} <em>{{ site.data.snippets.journal-title[page.lang] }}</em> {{ vol_no }} ({{ page_year }}), {{ site.url }}{{ page.url }}.</p>
         </div>
       </div>
   </div>


### PR DESCRIPTION
re: #771

I broke this out into snippets because if we implement yet more languages, we'll need to deal with the possibility of using e.g. `«»`