### PR TITLE
Issue 794 - xml to xsl lesson fixes

### DIFF
--- a/lessons/transforming-xml-with-xsl.md
+++ b/lessons/transforming-xml-with-xsl.md
@@ -225,15 +225,15 @@ After you save your file, open your preferred web browser (IE or Firefox) and us
 
 You should now see the text from your data file with line breaks but *without* its structuring elements, as pictured below.
 
-{% include figure.html filename="transforming-xml-with-xsl-4.png" caption="Figure 5: Initial Text Output" %}
+{% include figure.html filename="transforming-xml-with-xsl-4.png" caption="Figure 4: Initial Text Output" %}
 
 If you see the XML data without any formatting, or an error message, go back and double-check your stylesheet reference within you XML file as well as your XSL stylesheet. Even a small typographical error will prevent the transformer from rendering the output.
 
-{% include figure.html filename="transforming-xml-with-xsl-5.png" caption="Figure 6: Unstructured 'Error' Output" %}
+{% include figure.html filename="transforming-xml-with-xsl-5.png" caption="Figure 5: Unstructured 'Error' Output" %}
 
 Once you have successfully rendered the data as a plain-text output, organise your desktop so that you can move quickly between your text editor and your browser.  I suggest docking (snapping) your browser window to one side of the screen and your editor to the other.
 
-{% include figure.html filename="transforming-xml-with-xsl-6.png" caption="Figure 7: Organising Your Workspace" %}
+{% include figure.html filename="transforming-xml-with-xsl-6.png" caption="Figure 6: Organising Your Workspace" %}
 
 ## Populating Your Outputs
 

--- a/lessons/transforming-xml-with-xsl.md
+++ b/lessons/transforming-xml-with-xsl.md
@@ -300,7 +300,7 @@ Save and refresh your browser to see your changes.  Using this information, you 
 
 #### Exercise A:
 
-Note: Possible solutions for the following exercies are located at the end of the tutorial.
+Note: Possible solutions for the following exercises are located at the end of the tutorial.
 
 Print an inventory of the records in database, displaying the *id*, *title* and *date* of each record. A solution to this and the following exercises is available at the end of the tutorial.
 


### PR DESCRIPTION
As per #794, this pull request renumbers figures 5-7 to 4-6. This only affected caption labels.

It also fixes a typo on line 303.

It does not close the issue because I'm awaiting word from the author about a 3rd point.