### PR TITLE
Add Caleb McDaniel talk to /research

### DIFF
--- a/es/investigacion.md
+++ b/es/investigacion.md
@@ -35,17 +35,18 @@ El equipo del proyecto y los miembros de la comunidad en general están involucr
 
 ### Carteles, conferencias y presentaciones
 
-* James Baker, '[The Programming Historian: Open Access, Open Source, Open Project](https://www.slideshare.net/drjwbaker/the-programming-historian-open-access-open-source-open-project)', Research Hive Seminar on 'Open publication: exploring alternative models and practices', University of Sussex (22 March 2018).
-* Adam Crymble, 'White, Male, and North American: Challenges of Diversifying the Programming Historian', Universit&eacute; de Lausanne, Switzerland (23-24 March 2017).
+* Caleb McDaniel, 'Open Access, Transparent Peer Review', Annual Meeting of the Organizations of American Historians, Sacremento, California, (14 abril 2018).
+* James Baker, '[The Programming Historian: Open Access, Open Source, Open Project](https://www.slideshare.net/drjwbaker/the-programming-historian-open-access-open-source-open-project)', Research Hive Seminar on 'Open publication: exploring alternative models and practices', University of Sussex (22 marzo 2018).
+* Adam Crymble, 'White, Male, and North American: Challenges of Diversifying the Programming Historian', Universit&eacute; de Lausanne, Switzerland (23-24 marzo 2017).
 * Victor Gayol, 'La investigación del pasado y la historia digital: análisis de datos y cómo aprender (The Programming Historian en español)', _Humanidades Digitales_, IV Feria Internacional de Ciencias Sociales y Humanidades, Centro Universitario de Los Lagos - Universidad de Guadalajara, Lagos de Moreno, Jalisco (9 de marzo, 2017).
 * Victor Gayol, 'The Programming Historian: 'un modelo colaborativo para la investigaci&oacute;n y la ense&ntilde;anza en ciencias sociales y humanidades digitales', _Mesa de Trabajo sobre Ciencias Sociales y Humanidades Digitales_, El Colegio De Michoac&aacute;n, México (21 de febrero, 2017).
-* Adam Crymble, 'Bringing Digital Humanities into the University for Free', University of Cape Town, South Africa (27-28 June 2016).
-* Fred Gibbs, ‘The Programming Historian’ (Cartel), *American Historical Association*, New York (January 2015).
-* Adam Crymble, ‘The Programming Historian 2’, *Digital History Seminar*, Institute of Historical Research, London (13 October 2013).
-* Adam Crymble, ‘The Programming Historian 2’, *Digital Humanities 2012*, Hamburg (July 2012).
-* Anaclet Pons, “The Programming Historian en español”, Clionauta: Blog de historia, June 14, 2017, http://clionauta.hypotheses.org/16979
-* Seth Denbo, “Historian, Program! Self-Help for Digital Neophytes,” Perspectives on History: The Newsmagazine of the American Historical Association, May 2017, https://www.historians.org/publications-and-directories/perspectives-on-history/may-2017/historian-program-self-help-digital-neophytes.
-* Víctor Gayol, ‘The Programming Historian en español’, Blog de Humanidades Digitales, March 17, 2017, http://humanidadesdigitales.net/blog/2017/03/17/the-programming-historian-en-espanol/.
+* Adam Crymble, 'Bringing Digital Humanities into the University for Free', University of Cape Town, South Africa (27-28 junio 2016).
+* Fred Gibbs, ‘The Programming Historian’ (Cartel), *American Historical Association*, New York (enero 2015).
+* Adam Crymble, ‘The Programming Historian 2’, *Digital History Seminar*, Institute of Historical Research, London (13 octubre 2013).
+* Adam Crymble, ‘The Programming Historian 2’, *Digital Humanities 2012*, Hamburg (julio 2012).
+* Anaclet Pons, “The Programming Historian en español”, Clionauta: Blog de historia, junio 14, 2017, http://clionauta.hypotheses.org/16979
+* Seth Denbo, “Historian, Program! Self-Help for Digital Neophytes,” Perspectives on History: The Newsmagazine of the American Historical Association, mayo 2017, https://www.historians.org/publications-and-directories/perspectives-on-history/may-2017/historian-program-self-help-digital-neophytes.
+* Víctor Gayol, ‘The Programming Historian en español’, Blog de Humanidades Digitales, marzo 17, 2017, http://humanidadesdigitales.net/blog/2017/03/17/the-programming-historian-en-espanol/.
 
 ### Editoriales
 

--- a/research.md
+++ b/research.md
@@ -31,6 +31,7 @@ The project team and members of the wider community are involved in a number of 
 * Adam Crymble, 'Python Programming for Humanists', _Day of Digital Ideas_, University of Edinburgh (26 May 2015).
 
 ## Posters, Conference Papers, & Invited Talks
+* Caleb McDaniel, 'Open Access, Transparent Peer Review', Annual Meeting of the Organizations of American Historians, Sacremento, California, (14 April 2018).
 * James Baker, '[The Programming Historian: Open Access, Open Source, Open Project](https://www.slideshare.net/drjwbaker/the-programming-historian-open-access-open-source-open-project)', Research Hive Seminar on 'Open publication: exploring alternative models and practices', University of Sussex (22 March 2018).
 * Adam Crymble, 'White, Male, and North American: Challenges of Diversifying the Programming Historian', Universit&eacute; de Lausanne, Switzerland (23-24 March 2017).
 * Victor Gayol, 'La investigación del pasado y la historia digital: análisis de datos y cómo aprender (The Programming Historian en español)', _Humanidades Digitales_, IV Feria Internacional de Ciencias Sociales y Humanidades, Centro Universitario de Los Lagos - Universidad de Guadalajara, Lagos de Moreno, Jalisco (9 March, 2017).


### PR DESCRIPTION
Caleb McDaniel delivered a talk that covered our open access policies. I've added this to /research and /es/investigacion. I've also converted the months of various talks on that page from English into Spanish.