### PR TITLE
Issue 809 - YAML examples updated

### DIFF
--- a/editor-guidelines.md
+++ b/editor-guidelines.md
@@ -208,6 +208,7 @@ If the lesson has been written by a new author, editors should add information a
 
 ```yaml
 - name: Jim Clifford
+  team: false
   bio:
       en: |
           Jim Clifford is an assistant professor in the Department of History
@@ -272,6 +273,9 @@ Check out the example below to see what finished front matter should look like:
     - John Fink
     - Alan MacEachern
     - Adam Crymble
+    editors:
+    - Adam Crymble
+    review-ticket: 14
     difficulty: 2
     activity: analyzing
     topics: [distant-reading]

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -225,6 +225,7 @@ En el caso de las lecciones nuevas, si el tutorial ha sido escrito por un autor 
 
 ```yaml
 - name: Jim Clifford
+  team: false
   bio: 
    es: |
        Jim Clifford es profesor ayudante en el Departamento de Historia de la Universidad de Saskatchewan.
@@ -292,6 +293,9 @@ Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML d
     - John Fink
     - Alan MacEachern
     - Adam Crymble
+    editors:
+    - Adam Crymble
+    review-ticket: 14
     difficulty: 2
     activity: analyzing
     topics: [distant-reading]


### PR DESCRIPTION
This pull request Closes Issue #809 

It adds the newer YAML fields to the YAML examples in the editor guidelines. I've updated both the English and Spanish pages.

This should now reflect the actual YAML headers editors need to create.

