### PR TITLE
update Crymble & Gayol entries

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -35,7 +35,7 @@
         Universidad de Hertfordshire, Reino Unido.
   bio:
     en: |
-        Adam Crymble is a lecturer of digital history at the University of
+        Adam Crymble is a senior lecturer of digital history at the University of
         Hertfordshire.
     es: |
         Adam Crymble es profesor de historia digital en la Universidad de Hertfordshire.
@@ -160,7 +160,6 @@
         Víctor Gayol es profesor investigador en el Centro de Estudios Históricos de El Colegio de Michoacán, A.C. (CPI-CONACYT), México.
   team_roles:
    - spanish
-   - managing-es
    - board
 
 - name: Antonio Rojas Castro


### PR DESCRIPTION
I've done a minor update to the ph_authors.yml file.

Crymble bio changed to 'senior' lecturer.
Gayol removed as managing editor while he is on sabbatical (to prevent queries heading his way).