### PR TITLE
Set titles of es about & index pages to Spanish

### DIFF
--- a/es/acerca-de.md
+++ b/es/acerca-de.md
@@ -1,6 +1,7 @@
 ---
 layout: blank
-title: About the Programming Historian
+title: |
+  Acerca de The Programming Historian en español
 ---
 
 # Acerca de _The Programming Historian en español_

--- a/es/index.md
+++ b/es/index.md
@@ -1,6 +1,7 @@
 ---
 layout: base
-title: The Programming Historian
+title: |
+  The Programming Historian en español
 ---
 <div class="container" style="text-align:center">
 	<img class="home-image" src="{{ site.baseurl }}/images/about.png" />


### PR DESCRIPTION
While working a bit on #785 I discovered that the "title" attributes for the Spanish versions of the home page and about pages were still in English.
