### PR TITLE
Issue 812 - review tickets to YAML

### DIFF
--- a/lessons/applied-archival-downloading-with-wget.md
+++ b/lessons/applied-archival-downloading-with-wget.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Ian Milligan
 difficulty: 2
+review-ticket: NULL
 activity: acquiring
 topics: [web-scraping]
 abstract: "Now that you have learned how Wget can be used to mirror or download specific files from websites via the command line, it's time to expand your web-scraping skills through a few more lessons that focus on other uses for Wget's recursive retrieval function."

--- a/lessons/automated-downloading-with-wget.md
+++ b/lessons/automated-downloading-with-wget.md
@@ -9,6 +9,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: acquiring
 topics: [web-scraping]
 abstract: "Wget is a useful program, run through your computer's command line, for

--- a/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 1
+review-ticket: 3
 activity: presenting
 topics: [website, data-management]
 abstract: "This lesson will help you create entirely free, easy-to-maintain, preservation-friendly, secure website over which you have full control, such as a scholarly blog, project website, or online portfolio."

--- a/lessons/cleaning-data-with-openrefine.md
+++ b/lessons/cleaning-data-with-openrefine.md
@@ -12,6 +12,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "This tutorial focuses on how scholars can diagnose and act upon the

--- a/lessons/cleaning-ocrd-text-with-regular-expressions.md
+++ b/lessons/cleaning-ocrd-text-with-regular-expressions.md
@@ -7,6 +7,7 @@ authors:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "Optical Character Recognition (OCR)—the conversion of scanned images to

--- a/lessons/code-reuse-and-modularity.md
+++ b/lessons/code-reuse-and-modularity.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "Computer programs can become long, unwieldy and confusing without

--- a/lessons/corpus-analysis-with-antconc.md
+++ b/lessons/corpus-analysis-with-antconc.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 1
+review-ticket: NULL
 activity: analyzing
 topics: [distant-reading]
 abstract: "Corpus analysis is a form of text analysis which allows you to make comparisons between textual objects at a large scale (so-called 'distant reading')."

--- a/lessons/correspondence-analysis-in-R.md
+++ b/lessons/correspondence-analysis-in-R.md
@@ -11,6 +11,7 @@ editors:
   - Matthew Lincoln
 layout: lesson
 difficulty: 3
+review-ticket: 78
 activity: analyzing
 topics: [data-manipulation, network-analysis]
 abstract: |

--- a/lessons/counting-frequencies.md
+++ b/lessons/counting-frequencies.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: analyzing
 topics: [python]
 abstract: "Counting the frequency of specific words in a list can provide illustrative data. This lesson will teach you Python's easy way to count such frequencies."

--- a/lessons/creating-an-omeka-exhibit.md
+++ b/lessons/creating-an-omeka-exhibit.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: presenting
 topics: [website]
 abstract: "Now that you've added items to your Omeka site and grouped them into collections, you're ready for the next step: taking your users on a guided tour through the items you've collected."

--- a/lessons/creating-and-viewing-html-files-with-python.md
+++ b/lessons/creating-and-viewing-html-files-with-python.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: presenting
 topics: [python, website]
 abstract: "Here you will learn how to create HTML files with Python scripts, and

--- a/lessons/creating-network-diagrams-from-historical-sources.md
+++ b/lessons/creating-network-diagrams-from-historical-sources.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [network-analysis]
 abstract: "Network visualizations can help humanities scholars reveal hidden and complex patterns and structures in textual sources. This tutorial explains how to extract network data (people, institutions, places, etc) from historical sources through the use of non-technical methods developed in Qualitative Data Analysis (QDA) and Social Network Analysis (SNA), and how to visualize this data with the platform-independent and particularly easy-to-use Palladio."

--- a/lessons/data-mining-the-internet-archive.md
+++ b/lessons/data-mining-the-internet-archive.md
@@ -10,6 +10,7 @@ editors:
 - William J. Turkel
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: acquiring
 topics: [web-scraping]
 abstract: "The collections of the Internet Archive include many digitized historical sources. Many contain rich bibliographic data in a format called MARC. In this lesson, you'll learn how to use Python to automate the downloading of large numbers of MARC files from the Internet Archive and the parsing of MARC records for specific information such as authors, places of publication, and dates. The lesson can be applied more generally to other Internet Archive files and to MARC records found elsewhere."

--- a/lessons/downloading-multiple-records-using-query-strings.md
+++ b/lessons/downloading-multiple-records-using-query-strings.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: acquiring
 topics: [web-scraping]
 abstract: "Downloading a single record from a website is easy, but downloading many records at a time – an increasingly frequent need for a historian – is much more efficient using a programming language such as Python. In this lesson, we will write a program that will download a series of records from the Old Bailey Online using custom search criteria, and save them to a directory on our computer."

--- a/lessons/extracting-keywords.md
+++ b/lessons/extracting-keywords.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: acquiring
 topics: [data-manipulation]
 abstract: "This lesson will teach you how to use Python to extract a set of keywords very quickly and systematically from a set of texts."

--- a/lessons/from-html-to-list-of-words-1.md
+++ b/lessons/from-html-to-list-of-words-1.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "In this two-part lesson, we will build on what you’ve learned about Downloading Web Pages with Python, learning how to remove the HTML markup from the webpage of Benjamin Bowsey’s 1780 criminal trial transcript. We will achieve this by using a variety of string operators, string methods, and close reading skills. We introduce looping and branching so that programs can repeat tasks and test for certain conditions, making it possible to separate the content from the HTML tags. Finally, we convert content from a long string to a list of words that can later be sorted,

--- a/lessons/from-html-to-list-of-words-2.md
+++ b/lessons/from-html-to-list-of-words-2.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "In this lesson, you will learn the Python commands needed to implement the second part of the algorithm begun in the lesson 'From HTML to a List of Words (part 1)'."

--- a/lessons/generating-an-ordered-data-set-from-an-OCR-text-file.md
+++ b/lessons/generating-an-ordered-data-set-from-an-OCR-text-file.md
@@ -9,6 +9,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 3
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "This tutorial illustrates strategies for taking raw OCR output from a scanned text, parsing it to isolate and correct essential elements of metadata, and generating an ordered data set (a python dictionary) from it."

--- a/lessons/getting-started-with-github-desktop.md
+++ b/lessons/getting-started-with-github-desktop.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Caleb McDaniel
 difficulty: 1
+review-ticket: 14
 activity: sustaining
 topics: [data-management]
 abstract: "In this lesson you will be introduced to the basics of version control, understand why it is useful and implement basic version control for a plain text document using git and GitHub."

--- a/lessons/getting-started-with-markdown.md
+++ b/lessons/getting-started-with-markdown.md
@@ -8,6 +8,7 @@ reviewers:
 - John Fink
 - Nancy Lemay
 difficulty: 1
+review-ticket: 165
 editors:
 - Ian Milligan
 activity: presenting

--- a/lessons/getting-started-with-markdown.md
+++ b/lessons/getting-started-with-markdown.md
@@ -8,7 +8,7 @@ reviewers:
 - John Fink
 - Nancy Lemay
 difficulty: 1
-review-ticket: 165
+review-ticket: https://github.com/programminghistorian/jekyll/pull/61
 editors:
 - Ian Milligan
 activity: presenting

--- a/lessons/googlemaps-googleearth.md
+++ b/lessons/googlemaps-googleearth.md
@@ -12,6 +12,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: presenting
 topics: [mapping]
 abstract: "Google My Maps and Google Earth provide an easy way to start creating

--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -11,7 +11,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
-review-ticket: 166
+review-ticket: https://github.com/programminghistorian/jekyll/pull/131
 activity: acquiring
 topics: [lod]
 abstract: "This lesson explains why many cultural institutions are adopting graph databases, and how researchers can access these data though the query language called SPARQL."

--- a/lessons/graph-databases-and-SPARQL.md
+++ b/lessons/graph-databases-and-SPARQL.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: 166
 activity: acquiring
 topics: [lod]
 abstract: "This lesson explains why many cultural institutions are adopting graph databases, and how researchers can access these data though the query language called SPARQL."

--- a/lessons/installing-omeka.md
+++ b/lessons/installing-omeka.md
@@ -9,6 +9,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: 6
 activity: presenting
 topics: [website]
 abstract: "This lesson will teach you how to install your own copy of Omeka."

--- a/lessons/installing-python-modules-pip.md
+++ b/lessons/installing-python-modules-pip.md
@@ -8,6 +8,7 @@ reviewers:
 - Ben Hurwitz
 - Amanda Morton
 difficulty: 1
+review-ticket: NULL
 activity: acquiring
 topics: [get-ready, python]
 abstract: "There are many ways to install external python libraries; this tutorial explains one of the most common methods using pip."

--- a/lessons/intro-to-augmented-reality-with-unity.md
+++ b/lessons/intro-to-augmented-reality-with-unity.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: 17
 activity: presenting
 topics: [website,mapping]
 abstract: "This lesson serves as an introduction to creating mobile augmented reality applications. Augmented reality (AR) can be defined as the overlaying of digital content (images, video, text, sound, etc.) onto physical objects or locations, and it is typically experienced by looking through the camera lens of an electronic device such as a smartphone, tablet, or optical head-mounted display."

--- a/lessons/intro-to-bash.md
+++ b/lessons/intro-to-bash.md
@@ -12,6 +12,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation, get-ready]
 abstract: "This lesson will teach you how to enter commands using a command-line interface, rather than through a graphical interface. Command-line interfaces have advantages for computer users who need more precision in their work, such as digital historians. They allow for more detail when running some programs, as you can add modifiers to specify exactly how you want your program to run. Furthermore, they can be easily automated through scripts, which are essentially recipes of text-based commands."

--- a/lessons/intro-to-beautiful-soup.md
+++ b/lessons/intro-to-beautiful-soup.md
@@ -7,6 +7,7 @@ authors:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [web-scraping]
 abstract: "Beautiful Soup is a Python library for getting data out of HTML, XML,

--- a/lessons/introduction-and-installation.md
+++ b/lessons/introduction-and-installation.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 1
+review-ticket: NULL
 activity: transforming
 topics: [python, get-ready]
 abstract: "This first lesson in our section on dealing with Online Sources is

--- a/lessons/json-and-jq.md
+++ b/lessons/json-and-jq.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Ian Milligan
 difficulty: 2
+review-ticket: 23
 activity: transforming
 topics: [data-manipulation]
 abstract: "Working with data from an art museum API and from the Twitter API, this lesson teaches how to use the command-line utility [jq] to filter and parse complex JSON files into flat CSV files."

--- a/lessons/keywords-in-context-using-n-grams.md
+++ b/lessons/keywords-in-context-using-n-grams.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: presenting
 topics: [python]
 abstract: |

--- a/lessons/linux-installation.md
+++ b/lessons/linux-installation.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 1
+review-ticket: NULL
 activity: transforming
 topics: [get-ready, python]
 abstract: "This lesson will help you set up an integrated development environment for Python on a computer running the Linux operating system."

--- a/lessons/mac-installation.md
+++ b/lessons/mac-installation.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 1
+review-ticket: NULL
 activity: transforming
 topics: [get-ready, python]
 abstract: "This lesson will help you set up an integrated development environment for Python on a computer running an Apple operating system."

--- a/lessons/manipulating-strings-in-python.md
+++ b/lessons/manipulating-strings-in-python.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "This lesson is a brief introduction to string manipulation techniques in Python."

--- a/lessons/naive-bayesian.md
+++ b/lessons/naive-bayesian.md
@@ -9,6 +9,7 @@ reviewers:
 editors:
 - William J. Turkel
 difficulty: 3
+review-ticket: NULL
 activity: analyzing
 topics: [distant-reading]
 abstract: "This lesson shows how to use machine learning to extract interesting documents out of a digital archive."

--- a/lessons/normalizing-data.md
+++ b/lessons/normalizing-data.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "In this lesson, we will make the list we created in the 'From HTML to a List of Words' lesson easier to analyze by normalizing this data."

--- a/lessons/output-data-as-html-file.md
+++ b/lessons/output-data-as-html-file.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python, website]
 abstract: "This lesson takes the frequency pairs created in the 'Counting

--- a/lessons/output-keywords-in-context-in-html-file.md
+++ b/lessons/output-keywords-in-context-in-html-file.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: presenting
 topics: [python]
 abstract: "This lesson builds on 'Keywords in Context (Using N-grams)', where n-grams were extracted from a text. Here, you will learn how to output all of the n-grams of a given keyword in a document downloaded from the Internet, and display them clearly in your browser window."

--- a/lessons/preserving-your-research-data.md
+++ b/lessons/preserving-your-research-data.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: sustaining
 topics: [data-management]
 abstract: "This lesson will suggest ways in which historians can document and structure their research data so as to ensure it remains useful in the future."

--- a/lessons/qgis-layers.md
+++ b/lessons/qgis-layers.md
@@ -12,6 +12,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: NULL
 activity: presenting
 topics: [mapping]
 abstract: "In this lesson you will install QGIS software, download geospatial files

--- a/lessons/r-basics-with-tabular-data.md
+++ b/lessons/r-basics-with-tabular-data.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: 19
 activity: transforming
 topics: [data-manipulation]
 abstract: "This lesson teaches a way to quickly analyze large volumes of tabular data, making research faster and more effective."

--- a/lessons/research-data-with-unix.md
+++ b/lessons/research-data-with-unix.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "This lesson will look at how research data, when organised in a clear and predictable manner, can be counted and mined using the Unix shell."

--- a/lessons/sonification.md
+++ b/lessons/sonification.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Ian Milligan
 difficulty: 2
+review-ticket: 4
 activity: transforming
 topics: [distant-reading]
 abstract: "There are any number of guides that will help you visualize the past, but this lesson will help you hear the past."

--- a/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -8,6 +8,7 @@ authors:
 editors:
 - Fred Gibbs
 difficulty: 2
+review-ticket: NULL
 activity: sustaining
 topics: [website, data-management]
 abstract: "In this tutorial, you will first learn the basics of Markdown—an easy to read and write markup syntax for plain text—as well as Pandoc, a command line tool that converts plain text into a number of beautifully formatted file types: PDF, .docx, HTML, LaTeX, slide decks, and more."

--- a/lessons/text-mining-with-extracted-features.md
+++ b/lessons/text-mining-with-extracted-features.md
@@ -13,6 +13,7 @@ layout: lesson
 activity: analyzing
 topics: [distant-reading]
 difficulty: 3
+review-ticket: 29
 abstract: |
   Explains how to use Python to summarize and visualize data on millions of texts from the HathiTrust Research Center's Extracted Features dataset.
 ---

--- a/lessons/topic-modeling-and-mallet.md
+++ b/lessons/topic-modeling-and-mallet.md
@@ -12,6 +12,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: analyzing
 topics: [distant-reading]
 abstract: "In this lesson you will first learn what topic modeling is and why you might want to employ it in your research. You will then learn how to install and work with the MALLET natural language processing toolkit to do so."

--- a/lessons/transforming-xml-with-xsl.md
+++ b/lessons/transforming-xml-with-xsl.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 1
+review-ticket: 11
 activity: transforming
 topics: [data-manipulation]
 abstract: "This tutorial will provide you with the ability to convert or transform historical data from an XML database (whether a single file or several linked documents) into a variety of different presentations—condensed tables, exhaustive lists or paragraphed narratives—and file formats."

--- a/lessons/transliterating.md
+++ b/lessons/transliterating.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "This lesson shows how to use Python to transliterate automatically a

--- a/lessons/understanding-regular-expressions.md
+++ b/lessons/understanding-regular-expressions.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [data-manipulation]
 abstract: "In this lesson, we will use advanced find-and-replace capabilities in a

--- a/lessons/up-and-running-with-omeka.md
+++ b/lessons/up-and-running-with-omeka.md
@@ -9,6 +9,7 @@ editors:
 exclude_from_check:
   - reviewers
 difficulty: 1
+review-ticket: NULL
 activity: presenting
 topics: [website]
 abstract: "Omeka.net makes it easy to create websites that show off collections of items."

--- a/lessons/vector-layers-qgis.md
+++ b/lessons/vector-layers-qgis.md
@@ -13,6 +13,7 @@ reviewers:
 editors:
 - Adam Crymble
 difficulty: 2
+review-ticket: NULL
 activity: presenting
 topics: [mapping]
 abstract: "In this lesson you will learn how to create vector layers based on

--- a/lessons/viewing-html-files.md
+++ b/lessons/viewing-html-files.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: presenting
 topics: [python]
 abstract: "This lesson introduces you to HTML and the web pages it structures."

--- a/lessons/windows-installation.md
+++ b/lessons/windows-installation.md
@@ -11,6 +11,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 1
+review-ticket: NULL
 activity: transforming
 topics: [get-ready, python]
 abstract: "This lesson will help you set up an integrated development environment for Python on a computer running the Windows operating system."

--- a/lessons/working-with-text-files.md
+++ b/lessons/working-with-text-files.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: transforming
 topics: [python]
 abstract: "In this lesson you will learn how to manipulate text files using Python."

--- a/lessons/working-with-web-pages.md
+++ b/lessons/working-with-web-pages.md
@@ -10,6 +10,7 @@ reviewers:
 editors:
 - Miriam Posner
 difficulty: 2
+review-ticket: NULL
 activity: acquiring
 topics: [python]
 abstract: "This lesson introduces Uniform Resource Locators (URLs) and explains how to use Python to download and save the contents of a web page to your local hard drive."


### PR DESCRIPTION
As per issue #812, this adds missing 'review-ticket' metadata to 10 English tutorials (not Spanish) for which the data was missing. This should be all English-language cases for which a /submissions page ticket exists.