### PR TITLE
Issue 820 - update editor guidelines review-ticket

### DIFF
--- a/editor-guidelines.md
+++ b/editor-guidelines.md
@@ -237,9 +237,9 @@ To help readers evaluate which lessons best fit their goals and skill level, we 
 difficulty: 1
 ```
 
-### 6) Add the review ticket number to the YAML file
+### 6) Add the review ticket URL to the YAML file
 
-In order to promote transparency around the review process, create a `review-ticket` key in the YAML file and provide the ticket number for the corresponding review ticket in the ph-submissions repository. This information will be used to provide a link back to the review ticket for the lesson.
+In order to promote transparency around the review process, create a `review-ticket` key in the YAML file and provide the URL to the peer review in the ph-submissions repository. This information will be used to provide a link back to the review ticket for the lesson.
 
 ### 7) Update the date field in the YAML file
 
@@ -275,7 +275,7 @@ Check out the example below to see what finished front matter should look like:
     - Adam Crymble
     editors:
     - Adam Crymble
-    review-ticket: 14
+    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/164
     difficulty: 2
     activity: analyzing
     topics: [distant-reading]

--- a/editor-guidelines.md
+++ b/editor-guidelines.md
@@ -275,7 +275,7 @@ Check out the example below to see what finished front matter should look like:
     - Adam Crymble
     editors:
     - Adam Crymble
-    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/164
+    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/14
     difficulty: 2
     activity: analyzing
     topics: [distant-reading]

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -255,9 +255,9 @@ Con el objetivo de ayudar a los lectores a evaluar si una lección se ajusta a s
 difficulty: 1
 ```
 
-### 6) Añade un ticket de revisión al archivo YAML
+### 6) Añade la URL del tícket de revisión al archivo YAML
 
-Crea un ticket de revisión en el archivo YAML y proporciona el número del ticket correspondiente al envío del archivo en el repositorio `borradores`. Este procedimiento se realiza para incrementar la transparencia del proceso de revisión. La información, además, se utilizará para proporcionar un enlace al ticket de revisión.
+Crea un metadato `review-ticket` en el encabezado YAML y proporciona la URL del tícket correspondiente al envío del archivo en el repositorio `ph-submissions`. Este procedimiento se realiza para incrementar la transparencia del proceso de revisión. La información, además, se utilizará para proporcionar un enlace al ticket de revisión.
 
 ### 7) Actualiza la fecha en el archivo YAML
 
@@ -277,7 +277,7 @@ Teniendo como referencia el ejemplo de abajo, asegúrate que toda la parte preli
 3. Edita el archivo /js/lessonfilter.js para que funcione adecuadamente el botón que filtra la página de la lección con ese tópico. Busca en el archivo el fragmento de diez líneas de código que empieza con "$('#filter-api')", copia y pega ese fragmento de código y reemplaza las dos veces que aparece "api" con tu nuevo tópico.
 - **abstract** es una descripción de una a tres frases sobre lo que se aprende en esa lección. Trata de evitar, en lo posible, un vocabulario técnico, para que estos resúmenes ayuden a los académicos sin un conocimiento técnico a probar nuevas cosas.
 
-Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML de la lección completo:
+Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML de la lección por completo (para tutoriales originales):
 
     ---
     title: "Getting Started with Topic Modeling and MALLET"

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -295,7 +295,7 @@ Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML d
     - Adam Crymble
     editors:
     - Adam Crymble
-    review-ticket: 14
+    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/14
     difficulty: 2
     activity: analyzing
     topics: [distant-reading]


### PR DESCRIPTION
As per issue #820, this updates the editorial guidelines to tell editors to add the URL to the review ticket, not the ticket number.

This needs translation into Spanish before merging.