### PR TITLE
Delete extra space in lesson sequence snippet

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -176,7 +176,7 @@ layout: base
 
      {% if page.next %}
       <div class="series-warning alert alert-info">
-        {{ site.data.snippets.series-next-note[page.lang] }} <a href="{{page.next}}">{{ site.data.snippets.next-lesson[page.lang] }} </a>.
+        {{ site.data.snippets.series-next-note[page.lang] }} <a href="{{page.next}}">{{ site.data.snippets.next-lesson[page.lang] }}</a>.
       </div>
      {% endif %}
 


### PR DESCRIPTION
When looking at some of the old lessons in the original Python sequence, I noticed that there is an extra space in the snippet that we use to point people to the next lesson:

https://programminghistorian.org/lessons/viewing-html-files#suggested-readings-for-learning-html

This PR changes the snippet from the original "move on to the next lesson ." to "move on to the next lesson." by getting rid of the extra space in the link before the period when we call the snippet. The snippet should be updated for Spanish as well now.
