### PR TITLE
Fixed GitHub Icon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
 
 <div class="row">
   <div class="col-sm-3">
-    <i class="fa fa-github" aria-hidden="true"></i>
+    <i class="fab fa-github" aria-hidden="true"></i>
     <a href="https://github.com/programminghistorian/jekyll">{{ site.data.snippets.footer.gh-hosted[page.lang] }}</a>
   </div>
 


### PR DESCRIPTION
GitHub icon was rendering as a block because the naming in Font Awesome 5 was slightly different. https://fontawesome.com/icons/github?style=brands

There is not an icon associated with `fa fa-github` in Font Awesome 5 but there is an icon associated with`fab fa-github`. It appears the former was supported in Font Awesome 4 but Programming Historian is now running on Font Awesome 5.

