### PR TITLE
Replace Wiki "Impact" page with blog post

### DIFF
--- a/_posts/2018-05-22-Uses-Of-The-Programming-Historian.md
+++ b/_posts/2018-05-22-Uses-Of-The-Programming-Historian.md
@@ -38,8 +38,8 @@ ___2016___
 * Adam Crymble, 'Digital History Workshop', University of Hertfordshire, UK (Spring 2016).
 
 ___2015___
-* Shawn Graham, '[Digital Humanities](http://dhcu.ca/2015/what-is-a-tool-tutorial)', Carleton University, Canada (Autumn 2015).
-* Manan Ahmed, '[Borderlands: Towards a Spatial History of Empire](http://mananahmed.github.io/borderlands.html)', Columbia University, USA (Spring 2015).
+* Shawn Graham, 'Digital Humanities (formerly available from: http://dhcu.ca/2015/what-is-a-tool-tutorial)', Carleton University, Canada (Autumn 2015).
+* Manan Ahmed, 'Borderlands: Towards a Spatial History of Empire (formerly available from: http://mananahmed.github.io/borderlands.html)', Columbia University, USA (Spring 2015).
 * Andrew Ross, '[Exploring Digital Humanities (HIST 4170)](https://www.uoguelph.ca/history/sites/uoguelph.ca.history/files/syllabus/4170%20W15.pdf)', University of Guelph, Canada (Winter 2015).
 * Adam Crymble, '[Intro to Digital History](http://adamcrymble.org/intro-to-digital-history-2015/)', University of Hertfordshire, UK (Spring 2015).
 * John Russell, '[Digital Scholarship Methods](https://library.uoregon.edu/node/4570)', University of Oregon, USA (Winter 2015).
@@ -50,13 +50,13 @@ ___2014___
 * Lincoln Mullen, '[Clio 3: Programming for Historians (HIST 698)](http://lincolnmullen.com/files/clio3.syllabus.hist698.2014f.pdf)', George Mason University, USA (Autumn 2014).
 * Wilko Graf von Hardenberg, '[Digital History (History 795)](http://www.wilkohardenberg.net/content/Hardenberg_DigitalHistory_Hist795.pdf)', University of Wisconsin-Madison, USA (Spring 2014).
 * Christopher Church, '[Introduction to the Digital Humanities](http://www.christophermchurch.com/draft-for-new-course-digital-toolbox-for-historians-unr/)', University of Nevada - Reno, USA (2014).
-* Jason A. Heppler, '[Digital History: Concepts, Methods, Problems (History 205F)](http://stanford.edu/~jheppler/stanford.syllabus.hist205f.2014f.pdf)', Stanford University, USA (Autumn 2014).
+* Jason A. Heppler, 'Digital History: Concepts, Methods, Problems (History 205F) (formerly available from: http://stanford.edu/~jheppler/stanford.syllabus.hist205f.2014f.pdf)', Stanford University, USA (Autumn 2014).
 * Elisha E. Besherho-Bondar, '[Digital Humanities / Digital Studies](http://www.pitt.edu/~ebb8/DHDS/)', University of Pittsburg, USA (Autumn 2014).
 * Andrew M Shocket, '[Intro to DH (ACS 6820)](http://intro-dh-2014.andyschocket.net/syllabus/)', Bowling Green State University, USA (Spring 2014).
 * Jeff McClurken, '[Adventures in Digital History (HIST 428)](http://dh2014.umwblogs.org/syllabus/)', University of Mary Washington, USA (Spring 2014).
 * Jennifer Guiliano, '[Making/Building Digital History](http://devdh.org/files/downloads/Guiliano_Digital_History_Syllabus_Fall2014_IUPUI.pdf)', Indiana University-Purdue University Indianapolis, USA (Autumn 2014).
 * Andrew J. Torget, '[Introtudction to Digital Scholarship (HIST 5100)](http://torget.us/HIST5100/syllabus/)', University of North Texas, USA (Spring 2014).
-* Anne Mitchell Whisnant, '[Introduction to Public History (History 671)](http://publichistory.web.unc.edu/syllabus/)', UNC-Chapel Hill, USA (Autumn 2014).
+* Anne Mitchell Whisnant, 'Introduction to Public History (History 671) (formerly available from: http://publichistory.web.unc.edu/syllabus/)', UNC-Chapel Hill, USA (Autumn 2014).
 * Ian Milligan, '[Digital History (HIST 303)](https://ianmilli.files.wordpress.com/2014/01/w2014-hist-303.pdf)', University of Waterloo, Canada (Winter 2014).
 
 ___2013___

--- a/_posts/2018-05-22-Uses-Of-The-Programming-Historian.md
+++ b/_posts/2018-05-22-Uses-Of-The-Programming-Historian.md
@@ -1,0 +1,90 @@
+---
+title: Uses of the Programming Historian
+authors:
+    - Adam Crymble
+layout: post
+categories: posts 
+---
+
+If you're looking for inspiration into how you can use the _Programming Historian_ in your work, look no further. We've put together a list of some of the examples we've come across over the years. We're sure it's no where near complete, but it's great to see the hard work of our authors, reviewers, and team translating into real impact in a range of settings.
+
+If you are using the _Programming Historian_ in interesting ways, we'd love to hear from you.
+
+__Select Citations__
+
+* M.D. LeBlanc, "Towards Reproducibility in DH Experiments", _Book of Abstracts of Digital Humanities 2017 (2017).
+* A Berra, "Embedding Digital Humanities in a Classics Master Programme", _Digital Humanities_ (2017).
+F Nanni, "The Web as a Historical Corpus: Collecting, Analysing and Selecting Sources on the Recent Past of Academic Institutions" (2017).
+* D Miller, "Average Broadway", _Theatre Journal_ (2016).
+* S Fox Lee, "Digital methods for the history of psychology", _History of Psychology_ (2016).
+* Nicholas Terpstra, Colin Rose, 'Mapping Space, Sense, and Movement in Florence: Historical GIS and the Early Modern City' (Routledge, 2016).
+* Gary Osmond and Murray G. Phillips, 'Sport History in the Digital Era' (University of Illinois Press, 2015).
+* Tim Sherratt, '[Unremembering the Forgotten](http://discontents.com.au/unremembering-the-forgotten)', Keynote at DH2015, University of Western Australia (July 3, 2015).
+* Shawn Graham, Ian Milligan, and Scott Weingart, 'Exploring Big Historical Data: The Historian's Macroscope' (Imperial College Press, 2015).
+* Cheryl LaGuardia, '[Connecting Researchers to New Digital Tools | Not Dead Yet](http://lj.libraryjournal.com/2014/09/opinion/not-dead-yet/connecting-researchers-to-new-digital-tools-not-dead-yet/#_)', _Library Journal_ (18 September 2014).
+* William J. Turkel, Shenzan Muhammedi, Mary Beth Start, '[Grounding Digital History in the History of Computing](http://muse.jhu.edu/login?auth=0&type=summary&url=/journals/ieee_annals_of_the_history_of_computing/v036/36.2.turkel.html)', _IEEE Annals of the History of Computing_, Vol. 36, No. 2 (2014), pp. 72-75.
+* Elijah Meeks and Scott Weingart, '[The Digital Humanities Contribution to Topic Modeling](http://journalofdigitalhumanities.org/2-1/dh-contribution-to-topic-modeling/)', _Journal of Digital Humanities_, Vol. 2, No. 1 (2012).
+* Ted Underwood, '[What can topic models of PMLA teach us about the history of literary scholarship?](http://tedunderwood.com/2012/12/14/what-can-topic-models-of-pmla-teach-us-about-the-history-of-literary-scholarship/)' _The Stone and the Shell_ (2012).
+* Wingyan Chung, Edward A. Fox, Steven D. Sheetz, Seungwon Yang, '[LIKES: Educating the Next Generation of Knowledge Society Builders](http://aisel.aisnet.org/cgi/viewcontent.cgi?article=1072&context=amcis2009)', _Association for Information Systems: AMCIS Proceedings (2009). 
+
+__University Syllabi (2011-2016 only)__
+
+___2016___
+* John Garrigus, 'Transatlantic Revolutions and Transformations', University of Texas at Arlington (http://johngarrigus.com/syllabi/5360_f2016/)
+* Simon Dixon, University of Leicester
+* Aur&eacute;lien Berra, 'Classiques et numériquesLes humanités numériques dans un master d’antiquisants', Université Paris Ouest (http://classnum.hypotheses.org/)
+* Shawn Graham, '[Digital History Methods as Public History Performance](http://grad.craftingdigitalhistory.ca/weekly.html)', Carleton University, Canada (Spring 2016).
+* Adam Crymble, 'Intro to Digital History', University of Hertfordshire, UK (Spring 2016).
+* Adam Crymble, 'Digital History Workshop', University of Hertfordshire, UK (Spring 2016).
+
+___2015___
+* Shawn Graham, '[Digital Humanities](http://dhcu.ca/2015/what-is-a-tool-tutorial)', Carleton University, Canada (Autumn 2015).
+* Manan Ahmed, '[Borderlands: Towards a Spatial History of Empire](http://mananahmed.github.io/borderlands.html)', Columbia University, USA (Spring 2015).
+* Andrew Ross, '[Exploring Digital Humanities (HIST 4170)](https://www.uoguelph.ca/history/sites/uoguelph.ca.history/files/syllabus/4170%20W15.pdf)', University of Guelph, Canada (Winter 2015).
+* Adam Crymble, '[Intro to Digital History](http://adamcrymble.org/intro-to-digital-history-2015/)', University of Hertfordshire, UK (Spring 2015).
+* John Russell, '[Digital Scholarship Methods](https://library.uoregon.edu/node/4570)', University of Oregon, USA (Winter 2015).
+
+___2014___
+
+* Christopher Church, 'Introduction to Digital Humanities' (University of Nevada, Reno) (http://www.christophermchurch.com/draft-for-new-course-digital-toolbox-for-historians-unr/).
+* Lincoln Mullen, '[Clio 3: Programming for Historians (HIST 698)](http://lincolnmullen.com/files/clio3.syllabus.hist698.2014f.pdf)', George Mason University, USA (Autumn 2014).
+* Wilko Graf von Hardenberg, '[Digital History (History 795)](http://www.wilkohardenberg.net/content/Hardenberg_DigitalHistory_Hist795.pdf)', University of Wisconsin-Madison, USA (Spring 2014).
+* Christopher Church, '[Introduction to the Digital Humanities](http://www.christophermchurch.com/draft-for-new-course-digital-toolbox-for-historians-unr/)', University of Nevada - Reno, USA (2014).
+* Jason A. Heppler, '[Digital History: Concepts, Methods, Problems (History 205F)](http://stanford.edu/~jheppler/stanford.syllabus.hist205f.2014f.pdf)', Stanford University, USA (Autumn 2014).
+* Elisha E. Besherho-Bondar, '[Digital Humanities / Digital Studies](http://www.pitt.edu/~ebb8/DHDS/)', University of Pittsburg, USA (Autumn 2014).
+* Andrew M Shocket, '[Intro to DH (ACS 6820)](http://intro-dh-2014.andyschocket.net/syllabus/)', Bowling Green State University, USA (Spring 2014).
+* Jeff McClurken, '[Adventures in Digital History (HIST 428)](http://dh2014.umwblogs.org/syllabus/)', University of Mary Washington, USA (Spring 2014).
+* Jennifer Guiliano, '[Making/Building Digital History](http://devdh.org/files/downloads/Guiliano_Digital_History_Syllabus_Fall2014_IUPUI.pdf)', Indiana University-Purdue University Indianapolis, USA (Autumn 2014).
+* Andrew J. Torget, '[Introtudction to Digital Scholarship (HIST 5100)](http://torget.us/HIST5100/syllabus/)', University of North Texas, USA (Spring 2014).
+* Anne Mitchell Whisnant, '[Introduction to Public History (History 671)](http://publichistory.web.unc.edu/syllabus/)', UNC-Chapel Hill, USA (Autumn 2014).
+* Ian Milligan, '[Digital History (HIST 303)](https://ianmilli.files.wordpress.com/2014/01/w2014-hist-303.pdf)', University of Waterloo, Canada (Winter 2014).
+
+___2013___
+
+* Jim English, '[Empirical Method in Literary Studies](http://www.english.upenn.edu/~jenglish/Courses/Fall2014/505Syllabus.pdf)', University of Pennsylvania, USA (Autumn 2013).
+* Melissa Bailar and Lisa Spiro, '[Introduction to Digital Humanities](http://digitalhumanities.rice.edu/fall-2013-syllabus/)', Rice University, USA (Autumn 2013).
+* Devon Elliott, '[Digital History and American Popular Culture (HIST2897F)](http://www.huronuc.on.ca/Assets/website/Document/FASS/HIS/HIS2897FDElliott2013.pdf)', Huron College, Canada (Autumn 2013).
+* Chad Black, '[Theory and Practice of Digital History](http://dh.chadblack.net/info/syllabus/)', University of Tennessee, USA (Autumn 2013).
+* Aaron Shapiro, '[Seminar in Digital History and New Media (History 7970)](http://wp.auburn.edu/dighist/?page_id=127)', Auburn University, USA (2013).
+
+___2012___
+
+* Matthew Wilkens, '[Digital Humanities (English 90127)](http://www3.nd.edu/~mwilkens/Wilkens_DH_Syllabus_Init.pdf)', Notre Dame, USA (Autumn 2012).
+
+___2011___
+
+* Deena Engel '[Computing in the Humanities and the Arts](http://cs.nyu.edu/courses/spring11/V22.0380-001/HC_ResLiterature_sp11.htm)', NYU, USA (Spring 2011).
+
+__Other Teaching__
+
+___Using [the intro Jekyll lesson](http://programminghistorian.org/lessons/building-static-sites-with-jekyll-github-pages)___
+* [DH at Guelph Minimal Computing class](https://twitter.com/antimony27/status/730808295410311169) (Spring 2016).
+* Scott Weingart graduate teaching (Spring 2016)
+
+Websites Created__
+
+___Academic Jekyll-generated websites created___
+* [Stewart Varner](https://twitter.com/StewartVarner/status/722520696606298112)
+* [Eric Loy](https://twitter.com/eric_loy/status/758039397539409921)
+* [Jamie Howe](https://twitter.com/Gaymerbrarian/status/721490542366994432)
+* [Will Hanley](https://twitter.com/HanleyWill/status/725880236315934720) for [prosop.org](http://prosop.org)


### PR DESCRIPTION
Closes #851 and makes possible to delete https://github.com/programminghistorian/jekyll/wiki/People-who-use-the-Programming-Historian from the wiki.