### PR TITLE
Add Editorial team (french) and reorder entries

### DIFF
--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -5,20 +5,6 @@
 # definition: Brief description of that editorial team. If this is a derived label that uses the definition of another role, instead use...
 # source_role: The role type where the definition for this derived role can be found (e.g. pointing from an ES variant of a role to the original EN definition)
 
-- type: editorial
-  label:
-    en: Editorial Team (English)
-    es: Equipo editorial (Inglés)
-  definition:
-    en: Responsible for editorial work resulting in the review and publication of English-language lessons
-    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en inglés
-- type: community
-  label:
-    en: Community Engagement
-    es: Proyección hacia la comunidad
-  definition:
-    en: Responsible for project outreach and impact
-    es: Responsable de la proyección e impacto del proyecto
 - type: board
   label:
     en: Editorial Board
@@ -26,13 +12,13 @@
   definition:
     en: A fully-fledged member of the project team, involved in directing the project's future
     es: Miembro de pleno derecho del equipo del proyecto, encargado de su dirección a futuro
-- type: ombuds
+- type: editorial
   label:
-    en: Ombudsperson
-    es: Mediador
+    en: Editorial Team (English)
+    es: Equipo editorial (Inglés)
   definition:
-    en: A person that authors and reviewers can turn to if they have queries or concerns about any part of the peer review and publication process
-    es: Persona a la que los autores y revisores pueden recurrir si tienen preguntas o inquietudes sobre cualquier parte del proceso de revisión por pares y publicación
+    en: Responsible for editorial work resulting in the review and publication of English-language lessons
+    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en inglés
 - type: spanish
   label:
     en: Editorial Team (Spanish)
@@ -40,13 +26,20 @@
   definition:
     en: Responsible for editorial work resulting in the review and publication of Spanish-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en español
-- type: technical
+- type: french
   label:
-    en: Technical Team
-    es: Equipo técnico
+    en: Editorial Team (French)
+    es: Equipo editorial (francés)
   definition:
-    en: Responsible for the technical features that bring the content and peer review to our community
-    es: Responsable de las características técnicas respecto al contenido y la revisión por pares a nuestra comunidad
+    en: Responsible for editorial work resulting in the review and publication of French-language lessons
+    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
+- type: community
+  label:
+    en: Community Engagement
+    es: Proyección hacia la comunidad
+  definition:
+    en: Responsible for project outreach and impact
+    es: Responsable de la proyección e impacto del proyecto
 - type: managing-en
   label:
     en: Managing Editor
@@ -54,6 +47,20 @@
   definition:
     en: First point of contact for authors with lesson ideas
     es: Primer contacto para autores con ideas de lecciones
+- type: ombuds
+  label:
+    en: Ombudsperson
+    es: Mediador
+  definition:
+    en: A person that authors and reviewers can turn to if they have queries or concerns about any part of the peer review and publication process
+    es: Persona a la que los autores y revisores pueden recurrir si tienen preguntas o inquietudes sobre cualquier parte del proceso de revisión por pares y publicación
+- type: technical
+  label:
+    en: Technical Team
+    es: Equipo técnico
+  definition:
+    en: Responsible for the technical features that bring the content and peer review to our community
+    es: Responsable de las características técnicas respecto al contenido y la revisión por pares a nuestra comunidad
 - type: archive
   label:
     en: Archivist
@@ -67,8 +74,18 @@
     en: Ombudsperson (Spanish)
     es: Mediador (español)
   source_role: ombuds
+- type: ombuds-fr
+  label:
+    en: Ombudsperson (French)
+    es: Mediador (francés)
+  source_role: ombuds
 - type: managing-es
   label:
     en: Managing Editor (Spanish)
     es: Jefe de redacción (español)
+  source_role: managing-en
+- type: managing-fr
+  label:
+    en: Managing Editor (French)
+    es: Jefe de redacción (francés)
   source_role: managing-en


### PR DESCRIPTION
As per #867 this adds a new role for French Editorial team, ombudsperson, and managing editor.
I've also reordered entries so that all Editorial Team entries appear together and at the top (I hope)
Closes #867