### PR TITLE
Added team role tags for @spapastamkou

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -989,4 +989,7 @@
             Sofia Papastamkou es historiadora e investigadora en Humanidades Digitales en el Centre national de la recherche scientifique  (CNRS). Actualmente, su labor está asociada con Maison européenne des sciences de l'homme et de la société Lille Nord de France.
         fr: |
             Sofia Papastamkou est docteure en histoire et ingénieure d'études en humanités numériques au CNRS. Elle est affectée à la Maison européenne des sciences de l'homme et de la société Lille Nord de France.
-        
+   team_roles:
+   - french
+   - managing-fr
+   - board


### PR DESCRIPTION
I noticed we hadn't assigned @spapastamkou any roles on the project team page.

This adds her to the French Editorial, Managing Editor (FR), and Board teams.
