### PR TITLE
adds missing line of code as per issue #902

### DIFF
--- a/en/lessons/introduction-to-stylometry-with-python.md
+++ b/en/lessons/introduction-to-stylometry-with-python.md
@@ -399,6 +399,7 @@ Let's look at the frequencies of each feature in each candidate's subcorpus, as 
 
 ```python
 # The main data structure
+features = [word for word,freq in whole_corpus_freq_dist]
 feature_freqs = {}
 
 for author in authors:


### PR DESCRIPTION
Thanks for the tutorial. I think there is a line of code missing in the Burrows' Delta Method section on the website. The following code fails because the features list is never created:
The main data structure

feature_freqs = {}

for author in authors:
# A dictionary for each candidate's features
feature_freqs[author] = {}

# A helper value containing the number of tokens in the author's subcorpus
overall = len(federalist_by_author_tokens[author])

# Calculate each feature's presence in the subcorpus
for feature in features:
    presence = federalist_by_author_tokens[author].count(feature)
    feature_freqs[author][feature] = presence / overall


---

The author has suggested the following fix:

Indeed there is a line missing, right before feature_freqs = {}

The missing line is: features = [word for word,freq in whole_corpus_freq_dist]

--

This has been implemented by this pull request