### PR TITLE
Remove redirect from metadata lesson

### DIFF
--- a/es/lecciones/analisis-de-corpus-con-antconc.md
+++ b/es/lecciones/analisis-de-corpus-con-antconc.md
@@ -19,7 +19,6 @@ translation-reviewer:
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/170
 layout: lesson
 original: corpus-analysis-with-antconc
-redirect_from: /es/lessons/corpus-analysis-with-antconc
 difficulty: 1
 activity: analyzing
 topics: [distant-reading]


### PR DESCRIPTION
As discussed here https://github.com/programminghistorian/jekyll/pull/922 `redirect` is not longer used, so I would like to remove it from here.