### PR TITLE
fix two internal links in Spanish guidelines for authors and translators

### DIFF
--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -20,7 +20,7 @@ Si quieres traducir una lección, tienes una idea para una lección nueva o ya h
 
 **¿Qué tipo de lección queremos?** Aceptamos tutoriales relevantes para las humanidades, dirigidos a cualquier nivel de aptitud técnica y experiencia, que se centren en un problema o proceso, que puedan ser sostenibles a largo plazo y que estén dirigidos a una audiencia global. El alcance y la longitud del tutorial han de corresponderse con la complejidad de la tarea que se enseña. Los tutoriales no deben exceder las 8.000 palabras (incluyendo el código) sin el permiso explícito del editor y que se otorgará únicamente en circunstancias excepcionales. Esperamos que la mayoría de las lecciones tengan entre 4.000 y 6.000 palabras. Puede que pidamos dividir en varios tutoriales las lecciones más largas.
 
-**En resumen, aceptamos todo tipo de propuestas.** Consulta nuestras [lecciones publicadas], lee nuestras [directrices para revisores] o explora las [lecciones actualmente en desarrollo](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons) para hacerte una mejor idea de lo que publicamos. Animamos al envío de propuestas de lecciones sobre temas ya cubiertos o en desarrollo, siempre que la lección nueva haga una contribución propia.
+**En resumen, aceptamos todo tipo de propuestas.** Consulta nuestras [lecciones ya publicadas], lee nuestras [directrices para revisores] o explora las [lecciones actualmente en desarrollo](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons) para hacerte una mejor idea de lo que publicamos. Animamos al envío de propuestas de lecciones sobre temas ya cubiertos o en desarrollo, siempre que la lección nueva haga una contribución propia.
 
 A fin de que nuestras lecciones sean sostenibles a largo plazo, se anima a los autores a proponer tutoriales que no dependan de un programa o de una interfaz especfica. De lo contrario, los tutoriales dejarían de ser estables y necesitarían cambios con cada actualización. En aras de una mayor conservación, es mejor enseñar conceptos que a 'clicar sobre un botón X'.
 
@@ -351,7 +351,7 @@ Finalmente, el equipo editorial the *The Programming Historian en español* revi
 [Antonio Rojas Castro]: mailto:rojas.castro.antonio@gmail.com
 [traducciones pendientes]: https://github.com/programminghistorian/ph-submissions/blob/gh-pages/es/lista-de-traducciones.md
 [lecciones ya publicadas]: /es/lecciones
-[guía para revisores]: /es/guia-para-revisores
+[directrices para revisores]: /es/guia-para-revisores
 [lecciones en desarrollo]: https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons
   [Ian Milligan]: mailto:i2millig@uwaterloo.ca
   [Lesson Pipeline wiki page]: https://github.com/programminghistorian/jekyll/wiki/Lesson-Pipeline


### PR DESCRIPTION
Hi, I think these little changes are fixing broken internal links found in our Spanish guidelines for authors and translators. 

Please check the changes and approve the pull request once it has passed all the Travis checks. Thanks in advance.