### PR TITLE
Issue 959 - chicago manual of style to author guidelines

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -40,6 +40,10 @@ Because our site is hosted using [GitHub Pages](https://pages.github.com), **you
 
 The specific editor you choose is not important, but you should begin writing your lesson in plain text to avoid frustrations later on. For instance, stylized quotation marks automatically inserted by MS Word create formatting problems that can be hard to debug.
 
+### Endnote format
+
+Authors are asked to use the [Chicago Manual of Style](https://en.wikipedia.org/wiki/The_Chicago_Manual_of_Style) for endnote formatting.
+
 
 ### Choose a searchable name
 Name your new lesson file following these guidelines:

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -43,6 +43,8 @@ Puesto que nuestro sitio web se publica mediante [GitHub Pages](https://pages.gi
 
 El editor de textos que elijas no es relevante pero, por favor, comienza tu traducción o tutorial en texto plano para evitar problemas más tarde. No dudes en contactar con algún miembro de nuestro [equipo](/es/equipo-de-proyecto) si tienes preguntas o dudas.
 
+Se pide a los autores que usen el [Manual de estilo de Chicago](https://es.wikipedia.org/wiki/Manual_de_estilo_de_Chicago) para el formateo de las notas al final.
+
 ## Identifica tu archivo
 
 Identifica tu traduccion o lección nueva siguiendo estas instrucciones:

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -43,7 +43,7 @@ Puesto que nuestro sitio web se publica mediante [GitHub Pages](https://pages.gi
 
 El editor de textos que elijas no es relevante pero, por favor, comienza tu traducción o tutorial en texto plano para evitar problemas más tarde. No dudes en contactar con algún miembro de nuestro [equipo](/es/equipo-de-proyecto) si tienes preguntas o dudas.
 
-Se pide a los autores que usen el [Manual de estilo de Chicago](https://es.wikipedia.org/wiki/Manual_de_estilo_de_Chicago) para el formateo de las notas al final.
+Se pide a los autores que usen el [Manual de estilo de Chicago](https://es.wikipedia.org/wiki/Manual_de_estilo_de_Chicago) para el formateo de las notas situadas al final de la lección.
 
 ## Identifica tu archivo
 


### PR DESCRIPTION
as per #959, adds a recommendation to authors that we use the Chicago Manual of Style for endnotes.

I've tried to translate this for the Spanish page as well, but someone please check my Spanish.

French team (@spapastamkou and @mpuren) I can't find your translation of this yet. Sorry I would have made the update myself. Can you please make a note of this change?

closes #959 