### PR TITLE
Shorten Editorial Guidelines - Issue 992

### DIFF
--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -55,22 +55,22 @@ Upon successful submission of the lesson, the editor will create a review ticket
 ### Open Peer Review
 The *Programming Historian* uses a model of open peer review, while we believe this helps maintain civility and the productive sharing of ideas, authors have the right (and we have a requirement to respect that right) to request a closed peer review. There are many reasons why someone might be hesitant to engage in an open review and we encourage authors to always pursue the option with which they are most comfortable.
 
-Before soliciting external reviews, the editor should read and try the tutorial and use their experience with the *Programming Historian* to help the author make initial improvements (if required). The editor should complete an initial sustainability overview of the submission to ensure that software versions and dependencies are clearly marked, specificities of software like screenshots are limited to those required to complete the lesson, and that the lesson makes use of existing software documentation whenever available and appropriate. Editors should also ensure that lessons try, as much as possible, to avoid software specific directions, such as "Right-click on the _x_ icon to access the _x_ menu," instead favoring general methodological overviews. The Editorial Checklist [contains more details about sustainability practices](#c-sustainability-review) for PH. 
+Before soliciting external reviews, the editor should read and try the tutorial and use their experience with the *Programming Historian* to help the author make initial improvements (if required). The editor should complete an initial sustainability overview of the submission to ensure that software versions and dependencies are clearly marked, specificities of software like screenshots are limited to those required to complete the lesson, and that the lesson makes use of existing software documentation whenever available and appropriate. Editors should also ensure that lessons try, as much as possible, to avoid software specific directions, such as "Right-click on the _x_ icon to access the _x_ menu," instead favoring general methodological overviews. The Editorial Checklist [contains more details about sustainability practices](#c-sustainability-review) for PH.
 
 Often editors need help clarifying the intended audience of a lesson, or identifying jargon that needs further explanation. This initial review helps let the external reviewers focus on improving the piece. This is normally done openly on our submission system (see below), but it can be a closed review at the request of either party.
 
-Once an author has revised the tutorial to the satisfaction of the editor, it is the editor's job to invite two formal external peer reviews. It is entirely up to the editor who these reviewers are, however in the interest of our [commitment to diversity](https://github.com/programminghistorian/jekyll/issues), we encourage editors to ask themselves if they have made a sufficient effort to draw from reviewers who are distinct from themselves either by gender, nationality, race, age, or academic background. Please try not to find two people who are very like you. 
+Once an author has revised the tutorial to the satisfaction of the editor, it is the editor's job to invite two formal external peer reviews. It is entirely up to the editor who these reviewers are, however in the interest of our [commitment to diversity](https://github.com/programminghistorian/jekyll/issues), we encourage editors to ask themselves if they have made a sufficient effort to draw from reviewers who are distinct from themselves either by gender, nationality, race, age, or academic background. Please try not to find two people who are very like you.
 
 To coordinate our requests for reviewers, please use the "Programming Historian - Reviewer Tracking" Google Spreadsheet. (Contact the managing editor or Jeri Wieringa if you need help accessing the spreadsheet.) Prior to sending a review request, check the list to make sure that the person has not been recently contacted by another editor. To avoid over-taxing reviewers, please limit requests to once a year. If a reviewer has been contacted in the past year, the "date_contacted" field will display as red.
 
-For each potential reviewer you do contact, regardless of response, please enter: 
+For each potential reviewer you do contact, regardless of response, please enter:
 
-+ the date contacted, 
-+ the reviewer's name, 
-+ your name as the editor, 
++ the date contacted,
++ the reviewer's name,
++ your name as the editor,
 + the lesson to be reviewed,
 + the response,
-+ and, if the response was "yes," the date completed. 
++ and, if the response was "yes," the date completed.
 
 Please enter the date using the `mm/dd/yyyy` format.
 
@@ -128,7 +128,7 @@ There are a few areas where you should intervene in the process from a technical
 The **Editor** should suggest a name for the new lesson file that conforms to these guidelines:
 
 - Make the filename short, but descriptive; this filename will eventually become the slug for the lesson's URL when published.
-- A good URL would fit nicely on a powerpoint slide, is easy to remember, and tells you something about the lesson. Our URLS take the following format: https://programminghistorian.org/en/lessons/FILENAME-HERE
+- A good URL would fit nicely on a powerpoint slide, is easy to remember, and tells you something about the lesson. Our URLS take the following format: `https://programminghistorian.org/en/lessons/FILENAME-HERE`
 - Do not put spaces in the filename; use hyphens instead.
 - The filename extension should be `.md` so that GitHub will generate a preview of the lesson.
 
@@ -254,7 +254,7 @@ abstract: [see guidance below]
 - **topics** can be any number of the things listed after "type:" in /\_data/topics.yml. You are also encouraged to create new topics that would help someone find the lesson. To do so, besides listing the topic(s) in the lesson's front matter, you should:
 1. Add the topic to any existing lesson(s) also described by the new topic
 2. Add the new topic(s) to /\_data/topics.yml following the format of the other topics there (note that topics can't have spaces—use hyphens if needed).
-3. Edit /js/lessonfilter.js so the filter button to filter the lesson page to that topic works. Search the file for the ten-line chunk of code beginning with "$('#filter-api')", copy and paste that chunk of code, and replace the *two* appearances of "api" with your new topic.
+3. Edit /js/lessonfilter.js so the filter button to filter the lesson page to that topic works. Search the file for the ten-line chunk of code beginning with `$('#filter-api')`, copy and paste that chunk of code, and replace the *two* appearances of "api" with your new topic.
 - **abstract** is a 1-3 sentence description of what you'll learn in the lesson. Try to avoid technical vocabulary when possible, as these summaries can help scholars without technical knowledge to try out something new.
 
 ### 4) Find an Image to represent the lesson
@@ -318,7 +318,7 @@ The editor should have left you a clear list of files that need to be published 
 
 There are several ways that you can perform a pull request to publish the files:
 
-* A) Follow our "Making Technical Contributions" guidelines, which uses the Github website GUI: https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions
+* A) Follow our ["Making Technical Contributions" guidelines](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions), which uses the Github website GUI.
 
 * B) Use `git` from the command line. The following instructions assume that you have already cloned both the `jekyll` and `ph-submissions` repositories to your local machine. (Our [lesson on using GitHub Desktop](/lessons/getting-started-with-github-desktop) may be helpful if this is new to you.) If you are not sure how to do that or have any questions, contact Matthew Lincoln for assistance.
 
@@ -327,7 +327,7 @@ There are several ways that you can perform a pull request to publish the files:
  3. Repeat Steps 1 and 2 for the `jekyll` repository on your local machine.
  4. Copy the lesson files and any related image and asset files from the `ph-submissions` directory on your machine to the appropriate places in the `jekyll` directory on your local machine. (You can use a command like `cp` on the Unix command line, or use your GUI file system if you are using GitHub Desktop.)
  5. From within the `jekyll` directory on your local machine, `git add` the new files and then `git commit` and `git push` the changes.
- 
+
 After the lesson has been moved to the `jekyll` repository, you'll also need to archive the submitted lesson on the `ph-submissions` repository.
 
 1. Go to the directory for your local `ph-submissions` repository.

--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -220,6 +220,7 @@ The following code should be added into the text of the lesson, usually before t
 
 ### 3) Add YAML metadata to the lesson file
 
+```
 title: ["YOUR TITLE HERE"]
 collection: lessons
 layout: lesson
@@ -246,6 +247,8 @@ difficulty: [see guidance below]
 activity: [ONE OF: acquiring, transforming, analyzing, presenting, sustaining]
 topics: [see guidance below]
 abstract: [see guidance below]
+
+```
 
 - **difficulty** To help readers evaluate which lessons best fit their goals and skill level, we provide "Recommended for ___ Users" information in the lesson YAML file. There are currently three tiers, which can be set with the following numerical codes: 1 (Beginning), 2 (Intermediate), 3 (Advanced). To add the difficulty level to the lesson, include the following in the YAML file:
 - **topics** can be any number of the things listed after "type:" in /\_data/topics.yml. You are also encouraged to create new topics that would help someone find the lesson. To do so, besides listing the topic(s) in the lesson's front matter, you should:

--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -193,27 +193,9 @@ If a tutorial contains a video it should be hosted on our YouTube channel (which
 
 ## Acceptance and Publication - Editorial Checklist
 
-Once you and the author are happy with a tutorial, the next step is to move the lesson from the Submissions site to our main repository that hosts the live website.
+Once you and the author are happy with a tutorial, the next step is to begin the publication process. This involves checking the files and adding some additional metadata:
 
-### 1) Move the Files
-
-The easiest way to publish the lesson is to use `git` from the command line. The following instructions assume that you have already cloned both the `jekyll` and `ph-submissions` repositories to your local machine. (Our [lesson on using GitHub Desktop](/lessons/getting-started-with-github-desktop) may be helpful if this is new to you.) If you are not sure how to do that or have any questions, contact Matthew Lincoln for assistance.
-
-1. Go to the directory for your local `ph-submissions` repository.
-2. `git pull` to get all of the newest changes on your machine (or `sync` if you are using GitHub Desktop)
-3. Repeat Steps 1 and 2 for the `jekyll` repository on your local machine.
-4. Copy the lesson files and any related image and asset files from the `ph-submissions` directory on your machine to the appropriate places in the `jekyll` directory on your local machine. (You can use a command like `cp` on the Unix command line, or use your GUI file system if you are using GitHub Desktop.)
-5. From within the `jekyll` directory on your local machine, `git add` the new files and then `git commit` and `git push` the changes.
-
-After the lesson has been moved to the `jekyll` repository, you'll also need to archive the submitted lesson on the `ph-submissions` repository.
-
-1. Go to the directory for your local `ph-submissions` repository.
-2. Add a new line to the YAML header of the now published lesson: `redirect_from: "/lessons/LESSON-SLUG"`
-3. Copy the now published lesson from `lessons/` into `lessons/published/`.
-4. Copy the image folder containing the images for the now published lesson from `images/` to `images/published/`.
-5. Use `git add`, `git commit`, and `git push` to finalize all the changes.
-
-### 2) Create an Author Bio
+### 1) Create an Author Bio
 
 If the lesson has been written by a new author, editors should add information about the author to the site's [authors directory](https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml). Follow the syntax for the examples already included there:
 
@@ -228,7 +210,7 @@ If the lesson has been written by a new author, editors should add information a
 
 **Whitespace is important**, so be sure that the indentation matches the other examples.
 
-### 3) Add a table of contents to the lesson
+### 2) Add a table of contents to the lesson
 
 The following code should be added into the text of the lesson, usually before the first subheader:
 
@@ -236,64 +218,43 @@ The following code should be added into the text of the lesson, usually before t
 {% raw %}{% include toc.html %}{% endraw %}
 ```
 
-### 4) Add reviewers and editors to the YAML file
+### 3) Add YAML metadata to the lesson file
 
-It is important that we acknowledge the work of our peer reviewers and editors. To the YAML file at the top of the tutorial, add the names of the reviewers who helped work on the piece as well as the names of any members of the community who contributed substantial open reviews. In addition, create an `editors` key and add yourself and any other editors who actively contributed to guiding the piece to publication. YAML formatting instructions can be found in the [Author Guidelines](/author-guidelines).
+title: ["YOUR TITLE HERE"]
+collection: lessons
+layout: lesson
+slug: [e.g. sentiment analysis]
+date: [YYYY-MM-DD]
+translation_date: [YYYY-MM-DD (translations only)]
+authors:
+- [FORENAME SURNAME 1]
+- [FORENAME SURNAME 2, etc]
+reviewers:
+- [FORENAME SURNAME 1]
+- [FORENAME SURNAME 2, etc]
+editors:
+- [FORENAME SURNAME]
+translator:
+- [FORENAME SURNAME (translations only)]
+translation-editor:
+- [FORNAME SURNAME (translations only)]
+translation-reviewer:
+- [FORNAME SURNAME (translations only)]
+original: [slug to original published lesson (translations only)]
+review-ticket: [e.g. https://github.com/programminghistorian/ph-submissions/issues/108]
+difficulty: [see guidance below]
+activity: [ONE OF: acquiring, transforming, analyzing, presenting, sustaining]
+topics: [see guidance below]
+abstract: [see guidance below]
 
-### 5) Add a difficulty indicator to the YAML file
-
-To help readers evaluate which lessons best fit their goals and skill level, we provide "Recommended for ___ Users" information in the lesson YAML file. There are currently three tiers, which can be set with the following numerical codes: 1 (Beginning), 2 (Intermediate), 3 (Advanced). To add the difficulty level to the lesson, include the following in the YAML file:
-
-```yaml
-difficulty: 1
-```
-
-### 6) Add the review ticket URL to the YAML file
-
-In order to promote transparency around the review process, create a `review-ticket` key in the YAML file and provide the URL to the peer review in the ph-submissions repository. This information will be used to provide a link back to the review ticket for the lesson.
-
-### 7) Update the date field in the YAML file
-
-Update the date in the YAML file to the date the lesson was moved to the jekyll repository and the added to the main site.
-
-### 8) Other lesson YAML finalization
-Looking at the example below, make sure all front matter on the lesson is properly filled out.  Common fields that need writing or editing at this point are:
-- **collection** should just say "collection: lessons"
-- **layout** should just say "layout: lesson"
-- **slug** should have the path to the lesson on the public PH site, which means the hyphenated text following programminghistorian.org/lessons/ (e.g. building-static-sites-with-jekyll-github-pages)
-- **activity** should use one (and only one) of these five options: *acquiring, transforming, analyzing, presenting, sustaining*. Pick whichever one best describes what the lesson teaches you to do with humanities data (e.g. a lesson on creating a new Omeka website would be about *presenting* humanities data through a web gallery).
+- **difficulty** To help readers evaluate which lessons best fit their goals and skill level, we provide "Recommended for ___ Users" information in the lesson YAML file. There are currently three tiers, which can be set with the following numerical codes: 1 (Beginning), 2 (Intermediate), 3 (Advanced). To add the difficulty level to the lesson, include the following in the YAML file:
 - **topics** can be any number of the things listed after "type:" in /\_data/topics.yml. You are also encouraged to create new topics that would help someone find the lesson. To do so, besides listing the topic(s) in the lesson's front matter, you should:
 1. Add the topic to any existing lesson(s) also described by the new topic
 2. Add the new topic(s) to /\_data/topics.yml following the format of the other topics there (note that topics can't have spaces—use hyphens if needed).
 3. Edit /js/lessonfilter.js so the filter button to filter the lesson page to that topic works. Search the file for the ten-line chunk of code beginning with "$('#filter-api')", copy and paste that chunk of code, and replace the *two* appearances of "api" with your new topic.
 - **abstract** is a 1-3 sentence description of what you'll learn in the lesson. Try to avoid technical vocabulary when possible, as these summaries can help scholars without technical knowledge to try out something new.
 
-Check out the example below to see what finished front matter should look like:
-
-    ---
-    title: "Getting Started with Topic Modeling and MALLET"
-    collection: lessons
-    layout: lesson
-    slug: topic-modeling-and-mallet
-    date: 2012-09-02
-    authors:
-    - Shawn Graham
-    - Scott Weingart
-    - Ian Milligan
-    reviewers:
-    - John Fink
-    - Alan MacEachern
-    - Adam Crymble
-    editors:
-    - Adam Crymble
-    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/14
-    difficulty: 2
-    activity: analyzing
-    topics: [distant-reading]
-    abstract: "In this lesson you will first learn what topic modeling is and why you might want to employ it in your research. You will then learn how to install and work with the MALLET natural language processing toolkit to do so."
-    ---
-
-### 9) Find an Image to represent the lesson
+### 4) Find an Image to represent the lesson
 
 We represent our lessons using an old image that we feel captures some element of the task described in the tutorial. You can see the full range of these on the [main Lessons directory](/lessons/). These images are selected by editors.
 
@@ -312,7 +273,7 @@ Then, create a new copy of the image. Crop it to a square without removing any i
 
 Upload the original image to the [gallery/originals](https://github.com/programminghistorian/jekyll/tree/gh-pages/gallery/originals) folder, and upload the edited image to the [gallery](https://github.com/programminghistorian/jekyll/tree/gh-pages/gallery) folder.
 
-### 10) Incorporate your lesson into our Twitter bot
+### 5) Incorporate your lesson into our Twitter bot
 In addition to the Twitter promotion outlined below, we also make use of a Twitter bot to regularly re-advertise older lessons. In order to add the new lesson to our pipeline, you need to add it as a row in [this spreadsheet](https://docs.google.com/spreadsheets/d/1o-C-3WwfcEYWipIFb112tkuM-XOI8pVVpA9_sag9Ph8/edit#gid=1625380994). Everyone on the editorial team should have the ability to make changes; email the google group if you have trouble. You will need to add a new row for your lesson to the end of the table with the following fields:
 
 * message_one (column A) - a twitter message to play early in the week.
@@ -321,7 +282,58 @@ In addition to the Twitter promotion outlined below, we also make use of a Twitt
 
 Leave column D blank and untouched - this field is used by the Twitter bot to log its progress through the list. Also note that this step should not replace your own promotion of the lesson. The bot goes through the lessons at random, one a week, so it could be months until your lesson comes up through this means.
 
-### 11) Confirm all links and YAML headers are functioning correctly
+### 6) Inform the Managing Editor to Publish
+
+The Managing Editor will publish the lesson by moving the files to the main website and check everything over. To make this person's job easier, post a list in the submission ticket of all files that need to be moved to publish the lesson. This should normally include:
+
+- The lesson .md file
+- The directory for any accompanying files (images, data, etc)
+- The gallery icons
+
+### 7) Thank Everyone and Encourage Promotion
+Once you have been given word that the Managing Editor has successfully published the lesson, close the submission ticket, linking to the published lesson. It's important to send an email or message to everyone involved thanking them for their efforts. In particular, thank the author for contributing and encourage them to think of us again in future. It's also worth giving the author some ideas on promoting their lesson. The most-used lessons always have authors' energies behind them. For example authors should be encouraged to:
+
+- Tweet at least 3 times about their lesson (with a link).
+- Retweet our tweets about their lesson ('liking' does not help spread the word)
+- Promote their lesson in presentations or publications about their research
+- Link to it in blog posts when relevant
+- Add it to lists of resources in relevant repositories (eg, Wikipedia, community groups, etc).
+
+People don't find lessons on their own. The hard work is done, so let's make sure it was worth it!
+
+# Managing Editor Checklist
+
+The Managing Editor is responsible for moving the files to the main website via a pull request. This is also a chance for the managing editor to familiarize him/herself with the new lesson, and to quickly check that everything looks ok.
+
+## 1) Look over the submission preview
+
+Check the submission preview for any obvious errors such as broken images or strange formatting. Inform the editor of any mistakes, which they are responsible for getting fixed.
+
+## 2) Move the Files
+
+The editor should have left you a clear list of files that need to be published on the submission ticket. If they have not done so, ask them to fix it before proceeding.
+
+There are several ways that you can perform a pull request to publish the files:
+
+* A) Follow our "Making Technical Contributions" guidelines, which uses the Github website GUI: https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions
+
+* B) Use `git` from the command line. The following instructions assume that you have already cloned both the `jekyll` and `ph-submissions` repositories to your local machine. (Our [lesson on using GitHub Desktop](/lessons/getting-started-with-github-desktop) may be helpful if this is new to you.) If you are not sure how to do that or have any questions, contact Matthew Lincoln for assistance.
+
+ 1. Go to the directory for your local `ph-submissions` repository.
+ 2. `git pull` to get all of the newest changes on your machine (or `sync` if you are using GitHub Desktop)
+ 3. Repeat Steps 1 and 2 for the `jekyll` repository on your local machine.
+ 4. Copy the lesson files and any related image and asset files from the `ph-submissions` directory on your machine to the appropriate places in the `jekyll` directory on your local machine. (You can use a command like `cp` on the Unix command line, or use your GUI file system if you are using GitHub Desktop.)
+ 5. From within the `jekyll` directory on your local machine, `git add` the new files and then `git commit` and `git push` the changes.
+ 
+After the lesson has been moved to the `jekyll` repository, you'll also need to archive the submitted lesson on the `ph-submissions` repository.
+
+1. Go to the directory for your local `ph-submissions` repository.
+2. Add a new line to the YAML header of the now published lesson: `redirect_from: "/lessons/LESSON-SLUG"`
+3. Copy the now published lesson from `lessons/` into `lessons/published/`.
+4. Copy the image folder containing the images for the now published lesson from `images/` to `images/published/`.
+5. Use `git add`, `git commit`, and `git push` to finalize all the changes (or follow the Making Technical Contributions instructions: https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions)
+
+## 3) Confirm all links and YAML headers are functioning correctly
 
 Once you push your changes on to the `gh-pages` branch of the [programminghistorian][ph_repo] repository, the site will be automatically tested by [Travis CI] ([Continuous Integration]).
 This test process checks three things: first, that all YAML and markdown code is parseable; second, that all the hyperlinks on the site point to valid, operational pages; and third, that internal links to pages on the _Programming Historian_ are all relative links that start with `/` rather than `https://programminghistorian.org/`
@@ -358,15 +370,6 @@ If your build has errored, you will need to consult the build logs to see what i
 
 [create a new issue]: https://github.com/programminghistorian/jekyll/issues/new
 
-### 12) Thank Everyone and Encourage Promotion
-It's important to send an email or message to everyone involved thanking them for their efforts. In particular, thank the author for contributing and encourage them to think of us again in future. It's also worth giving the author some ideas on promoting their lesson. The most-used lessons always have authors' energies behind them. For example authors should be encouraged to:
+## 4) Inform the Editor
 
-- Tweet at least 3 times about their lesson (with a link).
-- Retweet our tweets about their lesson ('liking' does not help spread the word)
-- Promote their lesson in presentations or publications about their research
-- Link to it in blog posts when relevant
-- Add it to lists of resources in relevant repositories (eg, Wikipedia, community groups, etc).
-
-People don't find lessons on their own. The hard work is done, so let's make sure it was worth it!
-
-
+Once the lesson has been published, inform the editor.

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -213,25 +213,7 @@ Si un tutorial contiene algún vídeo, éste debe publicarse en un canal de YouT
 
 Una vez el autor y tú como editor estéis satisfechos con el texto, sea una traducción o una lección nueva, el siguiente paso consiste en mover el archivo desde el repositorio de envíos al repositorio principal que aloja nuestro sitio web.
 
-### 1) Mueve el archivo
-
-La manera más fácil de publicar el texto es utilizar `git` en tu terminal de línea de comandos. Las siguientes instrucciones presuponen que ya has clonado en tu ordenador los repositorios `jekyll` y `ph-submissions/es` (si no es así, nuestra [introducción a GitHub](/lessons/getting-started-with-github-desktop) puedes ser útil). Si tienes alguna duda puedes contactar con Matthew Lincoln (en inglés) para que te ayude, o en español a través de Víctor Gayol.
-
-1. Sitúate en el director local de tu repositorio `ph-submissions/es`.
-2. Introduce `git pull` para descargar los últimos cambios en tu ordenador (o `sync` si utilizas GitHub Desktop).
-3. Repite los pasos 1 y 2 para el repositorio local de `jekyll` en tu máquina.
-4. Copia el texto, los archivos con datos y las imágenes guardados en `ph-submissions/es` y ponlos en el lugar apropiado del repositorio `jekyll` de tu ordenador. Si utilizas la línea de comandos, introduce `cp`; si, por el contrario, usas GitHub Desktop utiliza la interfaz gráfica de usuario para moverte por los directorios y mover los archivos.
-5. Dese tu repositorio local de `jekyll`, debes introducir `git add` para añadir los nuevos archivos, y a continuación `got commit`y `git push` para actualizar los cambios en el repositorio en línea.
-
-Después de haber movido la lección al repositorio local de `jekyll` tendrás además que guardar la lección que ya enviaste en el repositorio `ph-submissions`.
-
-1. Sitúate en el directorio local de tu repositorio `ph-submissions/es`.
-2. Añade una nueva línea en el encabezado YAML de la lección ya publicada: `original: "LESSON-SLUG"`
-3. Copia la lección ya publicada de `lessons/` a `lessons/published/`.
-4. Copia el folder de imágenes que contiene las imágenes de la lección ya publicada de `images/` a `images/published/`.
-5. Utiliza `git add`, `git commit`, y `git push` para finalizar todos los cambios.
-
-### 2) Crea una biografía para el autor
+### 1) Crea una biografía para el autor
 
 En el caso de las lecciones nuevas, si el tutorial ha sido escrito por un autor con el que no hemos trabajado anteriormente, los editores deben añadir información sobre el autor en la página [directorio de autores](https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml) del repositorio de *The programming historian*. En el caso de una trducción, debes traducir tambin la biografa incluyendo la clave `es`. Sigue la sintaxis de los ejemplos ya incluidos:
 
@@ -245,7 +227,7 @@ En el caso de las lecciones nuevas, si el tutorial ha sido escrito por un autor 
 
 **Los espacios en blanco son importantes**, así que asegúrate de que la identación se ajusta a la de los otros casos y utiliza espacios en blanco en vez de tabuladores.
 
-### 3) Agrega una tabla de contenidos a la lección
+### 2) Agrega una tabla de contenidos a la lección
 
 El siguiente código debe agregarse al texto de la lección, generalmente antes del primer subtítulo
 
@@ -253,34 +235,51 @@ El siguiente código debe agregarse al texto de la lección, generalmente antes 
 {% raw %}{% include toc.html %}{% endraw %}
 ```
 
-### 4) Añade traductor, revisores y editores al archivo YAML
+### 3) Agregar metadatos YAML al archivo de lección
 
-Es muy importante acreditar el trabajo de nuestros traductores, revisores y editores. Así, pues, localiza el  bloque YAML que se encuentra al inicio del tutorial, y añade el nombre de los revisores y de todos los miembros de nuestra comunidad que han contribuido durante el proceso de revisión. Además, crea un campo `editor` y añade tu nombre y de cuantos otros editores hayan contribuido en la publicación. Las instrucciones para dar formato al bloque de YAML se encuentran en la [guía para autores y traductores](/es/guia-para-autores).
+Añade traductor, revisores y editores al archivo YAML
+
+Es muy importante acreditar el trabajo de nuestros traductores, revisores y editores. Así, pues, localiza el bloque YAML que se encuentra al inicio del tutorial, y añade el nombre de los revisores y de todos los miembros de nuestra comunidad que han contribuido durante el proceso de revisión. Además, crea un campo `editor` y añade tu nombre y de cuantos otros editores hayan contribuido en la publicación. Las instrucciones para dar formato al bloque de YAML se encuentran en la [guía para autores y traductores](/es/guia-para-autores).
 
 Si se trata de una traducción, asegúrate de que se mantienen los datos del YAML original, e introduce un campo para el traductor (`translator`), otro para los revisores de la traducción (`translation-reviewer`) y otro más para el editor de la traducción (`translation-editor`).
 
-### 5) Añade un nivel de dificultad el archivo YAML
-
-Con el objetivo de ayudar a los lectores a evaluar si una lección se ajusta a sus necesidades y experiencia, proporcionamos un campo "Recomendado para usuarios ____" en el bloque YAML. Actualmente, contamos con tres niveles de dificultad, que se escogen mediante tres códigos numéricos: 1 (introductorio), 2 (intermedio) y 3 (avanzado). En el caso de las lecciones nuevas, para añadir el nivel de dificultad a la lección, debes incluir las siguientes líneas al archivo YAML:
-
-```yaml
-difficulty: 1
-```
-
-### 6) Añade la URL del tícket de revisión al archivo YAML
-
-Crea un metadato `review-ticket` en el encabezado YAML y proporciona la URL del tícket correspondiente al envío del archivo en el repositorio `ph-submissions`. Este procedimiento se realiza para incrementar la transparencia del proceso de revisión. La información, además, se utilizará para proporcionar un enlace al ticket de revisión.
-
-### 7) Actualiza la fecha en el archivo YAML
-
-Actualiza la fecha en el campo correspondiente del archivo YAML tomando como referencia el día en que el archivo fue movido al repositorio `jekyll`, salvo en el caso de las traducciones. Las traducciones, además, deben contener el metadato `translation_date`.
-
-### 8) Otros aspectos para concluir el YAML de la lección
-
 Teniendo como referencia el ejemplo de abajo, asegúrate que toda la parte preliminar de la lección está completada adecuadamente. Los campos comunes que necesitas escribir o editar en este punto son:
 
-- **collection** debe decir solamente "collection: lessons"
-- **layout** debe decir solamente "layout: lesson"
+Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML de la lección por completo (para tutoriales originales):
+
+```
+---
+title: |
+	[Título de la lección]	
+collection: lessons
+layout: lesson
+slug: [e.g. sentiment analysis]
+date: [Fecha original, YYYY-MM-DD]
+translation_date: [Fecha traducción YYYY-MM-DD] 
+authors:
+- [Nombre del autor 1]
+- [Nombre del autor 2]
+editors:
+- [Nombre del editor original]
+reviewers:
+- [Nombre del revisor original 1]
+- [Nombre del revisor original 2]
+translator:
+- [Nombre del traductor]
+translation-editor:
+- [Nombre del editor de la traducción]
+translation-reviewer:
+- [Nombre del revisor de la traducción 1]
+- [Nombre del revisor de la traducción 2]
+original: [slug del original (traducción)]
+difficulty: [mantener original (traducción)]
+activity: [mantener original (traducción)]
+topics: [mantener original (traducción)]
+abstract: "[Traducción del resumen del original]"
+---
+```
+
+- **difficulty** Con el objetivo de ayudar a los lectores a evaluar si una lección se ajusta a sus necesidades y experiencia, proporcionamos un campo "Recomendado para usuarios ____" en el bloque YAML. Actualmente, contamos con tres niveles de dificultad, que se escogen mediante tres códigos numéricos: 1 (introductorio), 2 (intermedio) y 3 (avanzado).
 - **slug** debe contener la ruta a la lección en el sitio público de _Programming Historian_, lo que significa un texto con guiones que sigue a programminghistorian.org/lessons/ (i.e. building-static-sites-with-jekyll-github-pages)
 - **activity** debe usarse una (y solo una) de las siguientes cinco opciones: *acquiring, transforming, analyzing, presenting, sustaining*. Escoge la que mejor describa lo que te enseña la lección acerca de datos en humanidades (i.e. una lección que muestre la creación de un sitio web con Omeka será sobre presentar (*presenting*) datos a través de una galería en la Web).
 - **topics** puede ser cualquier número de cosas listadas despues de "type:" en /\_data/topics.yml. Te invitamos a crear nuevos tópicos que ayuden a cualquiera a encontrar la lección. Para hacerlo, además de enlistar el o los nuevos tópicos en los preliminares de la leción, deberás:
@@ -289,64 +288,13 @@ Teniendo como referencia el ejemplo de abajo, asegúrate que toda la parte preli
 3. Edita el archivo /js/lessonfilter.js para que funcione adecuadamente el botón que filtra la página de la lección con ese tópico. Busca en el archivo el fragmento de diez líneas de código que empieza con "$('#filter-api')", copia y pega ese fragmento de código y reemplaza las dos veces que aparece "api" con tu nuevo tópico.
 - **abstract** es una descripción de una a tres frases sobre lo que se aprende en esa lección. Trata de evitar, en lo posible, un vocabulario técnico, para que estos resúmenes ayuden a los académicos sin un conocimiento técnico a probar nuevas cosas.
 
-Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML de la lección por completo (para tutoriales originales):
 
-    ---
-    title: "Getting Started with Topic Modeling and MALLET"
-    collection: lessons
-    layout: lesson
-    slug: topic-modeling-and-mallet
-    date: 2012-09-02
-    authors:
-    - Shawn Graham
-    - Scott Weingart
-    - Ian Milligan
-    reviewers:
-    - John Fink
-    - Alan MacEachern
-    - Adam Crymble
-    editors:
-    - Adam Crymble
-    review-ticket: https://github.com/programminghistorian/ph-submissions/issues/14
-    difficulty: 2
-    activity: analyzing
-    topics: [distant-reading]
-    abstract: "En esta lección aprenderás qué es el modelado tópico y por qué podrías querer emplearlo en tu investigación. A continuación, aprenderás a instalar y trabajar con MALLET, que es una herramienta para procesar lenguaje natural."
-    ---
-    
 Para las traducciones, no solo hay que añadir `translator`, `translation-reviewer`, `translation-editor` y `translation_date`. También hay que añadir el campo `original` tal y como se muestra aquí: 
-
-	---
-	title: Análisis de corpus con AntConc
-	authors:
-	- Heather Froehlich
-	date: 2015-11-24
-	translation_date: 2018-05-04
-	editors:
-	- Fred Gibbs
-	reviewers:
-	- Nabeel Siddiqui
-	- Rob Sieczkiewicz
-	translator:
-	- Carlos Manuel Varón Castañeda
-	translation-editor:
-	- Antonio Rojas Castro
-	translation-reviewer:
-	- Jennifer Isasi
-	- Antonio Rojas Castro
-	review-ticket: https://github.com/programminghistorian/ph-submissions/issues/170
-	layout: lesson
-	original: corpus-analysis-with-antconc
-	difficulty: 1
-	activity: analyzing
-	topics: [distant-reading]
-	abstract: "El análisis de corpus permite hacer comparaciones a gran escala entre objetos presentes en los textos; es decir, lo que se conoce como lectura distante."
-	---
 
 Es decir, con el nombre del archivo en inglés, sin extensión `.md` y sin indicar que se encuentra en el directorio `en`. En total, pues, las traducciones contienen cinco metadatos adicionales.
 
 
-### 9) Busca una imagen que represente la lección
+### 4) Busca una imagen que represente la lección
 
 Las lecciones se representan mediante una imagen `vintage` que refleja algún elemento de las tareas descritas en el tutorial. Puedes ver todas las imágenes en el [índice principal de lecciones](/es/lecciones). El editor es el encargado de seleccionar las imágenes.
 
@@ -366,7 +314,7 @@ A continuación, crea una copia de la imagen, córtala en un cuadrado sin elimin
 
 Sube la imagen original al directorio [gallery/originals](https://github.com/programminghistorian/jekyll/tree/gh-pages/gallery/originals) y la imagen editada al directorio [gallery](https://github.com/programminghistorian/jekyll/tree/gh-pages/gallery). Si se trata de una traducción, no hace falta buscar una imagen, pues se reutiliza la contenida en el original.
 
-### 10) Incorpora tu lección en nuestro Twitter bot
+### 5) Incorpora tu lección en nuestro Twitter bot
 
 Adicionalmente a la promoción vía Twitter descrita abajo, también utilizamos un Twitter bot para volver a promocionar lecciones pasadas. Para añadir la lección nueva a nuestro *pipeline* deberás añadirla como una fila en esta [hoja de cálculo](https://docs.google.com/spreadsheets/d/1o-C-3WwfcEYWipIFb112tkuM-XOI8pVVpA9_sag9Ph8/edit#gid=904817529). Todos los miembros del equipo editorial deben poder hacer cambios; envía un correo electrónico al grupo de google si tienes algún problema. Deberás insertar una nueva fila para tu lección al final de la tabla con los siguientes campos:
 
@@ -376,7 +324,56 @@ Adicionalmente a la promoción vía Twitter descrita abajo, también utilizamos 
 
 Deja la columna D en blanco y sin tocar - este campo es utilizado por el Twitter bot para registrar su progreso en la lista. Ten en cuenta además que este paso no reemplaza tu propia promoción de la lección. El bot escoge las lecciones aleatoriamente, una cada la semana, así que pueden pasar meses hasta que tu lección aparezca por este medio. 
 
-### 11) Confirma que todos los enlaces y encabezados YAML funcionen correctamente
+### 6) Informar al Jefe de redacción
+Al jefe de redacción publicará la lección moviendo los archivos al sitio web principal y comprobando todo. Para facilitar el trabajo de esta persona, publique una lista en el boleto de presentación de todos los archivos que deban moverse para publicar la lección:
+
+- es una lección .md file
+- el directorio de cualquier archivo de acompañamiento (imágenes, datos, etc)
+- los iconos de la galería
+
+### 7) Da las gracias a todo el mundo y difunde el tutorial
+
+Una vez que se le haya dado la palabra de que al jefe de redacción ha publicado satisfactoriamente la lección, cierre el ticket de envío, enlazando a la lección publicada. Es importante enviar un correo electrónico o un mensaje a todos los participantes para agradecerles el esfuerzo. En particular, da las gracias al autor o al traductor por enviar su texto y anímalo a volver a trabajar con nostros en el futuro. También puedes proporcionarle alguna idea sobre cómo difundir y anunciar su contribución. Las lecciones más visitadas suelen contar con la promoción del autor. Por ejemplo, el autor podría realizar las siguientes acciones:
+
+- Tuitear al menos tres veces la lección con el enlace a la web.
+- Retuitear nuestros tuits sobre la lección (darle al `like`no es suficiente).
+- Promocionar la lección en presentaciones y publicaciones.
+- Enlazar a la lección en entradas de blog.
+- Añadir la lección a algunos recursos colaborativos como Wikipedia u otros plataformas.
+
+¡Por favor, no abandones la lección a su suerte! Ya hemos realizado el trabajo, así que asegurémosnos que ha valido la pena.
+
+## Jefe de redacción - Lista de verificación
+
+### 1) Tener una lectura rápida
+
+Compruebe la vista previa de la presentación para ver si hay errores obvios como imágenes rotas o formato extraño. Informar al editor de cualquier error, que son responsables de ser arreglados.
+
+### 2) Mueve el archivo
+
+El editor de gestión es responsable de mover los archivos al sitio web principal a través de una 'pull request'. Esta es también una oportunidad para el editor de gestión para familiarizarse con la nueva lección, y para comprobar rápidamente que todo se ve bien.
+
+Sus opciones son:
+
+A) siga nuestras ["Making Technical Contributions" guidelines](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions) que utiliza el sitio web de github GUI.
+
+B) La manera más fácil de publicar el texto es utilizar git en tu terminal de línea de comandos. Las siguientes instrucciones presuponen que ya has clonado en tu ordenador los repositorios jekyll y ph-submissions/es (si no es así, nuestra [introducción a GitHub](/lessons/getting-started-with-github-desktop) puedes ser útil). Si tienes alguna duda puedes contactar con Matthew Lincoln (en inglés) para que te ayude, o en español a través de Víctor Gayol.
+
+1. Sitúate en el director local de tu repositorio `ph-submissions/es`.
+2. Introduce `git pull` para descargar los últimos cambios en tu ordenador (o `sync` si utilizas GitHub Desktop).
+3. Repite los pasos 1 y 2 para el repositorio local de `jekyll` en tu máquina.
+4. Copia el texto, los archivos con datos y las imágenes guardados en `ph-submissions/es` y ponlos en el lugar apropiado del repositorio `jekyll` de tu ordenador. Si utilizas la línea de comandos, introduce `cp`; si, por el contrario, usas GitHub Desktop utiliza la interfaz gráfica de usuario para moverte por los directorios y mover los archivos.
+5. Dese tu repositorio local de `jekyll`, debes introducir `git add` para añadir los nuevos archivos, y a continuación `got commit`y `git push` para actualizar los cambios en el repositorio en línea.
+
+Después de haber movido la lección al repositorio local de `jekyll` tendrás además que guardar la lección que ya enviaste en el repositorio `ph-submissions`.
+
+1. Sitúate en el directorio local de tu repositorio `ph-submissions/es`.
+2. Añade una nueva línea en el encabezado YAML de la lección ya publicada: `original: "LESSON-SLUG"`
+3. Copia la lección ya publicada de `lessons/` a `lessons/published/`.
+4. Copia el folder de imágenes que contiene las imágenes de la lección ya publicada de `images/` a `images/published/`.
+5. Utiliza `git add`, `git commit`, y `git push` para finalizar todos los cambios.
+
+### 3) Confirma que todos los enlaces y encabezados YAML funcionen correctamente
 
 Una vez que envíes tus cambios a la rama `gh-pages` del repositorio de [programminghistorian][ph_repo], el sitio será comprobado automáticamente por [Travis CI] ([Continuous Integration]).
 Este proceso comprueba tres cosas: primero, que todo el código de YAML y markdown sea compilable; segundo, que todos los hipervínculos del sitio apunten a páginas válidas y en funcionamiento; por último, que todos los hipervínculos internos a otras páginas de _The Programming Historian en español_ son relativos y empiezan con una barra lateral `/` en lugar de `https://programminghistorian.org/es`.
@@ -413,15 +410,6 @@ En caso de error, debes consultar la bitácora de compilación (*Build logs*) pa
 
 [abre un nuevo ticket]: https://github.com/programminghistorian/jekyll/issues/new
 
+### 4) Informe al editor
 
-### 12) Da las gracias a todo el mundo y difunde el tutorial
-
-Es importante enviar un correo electrónico o un mensaje a todos los participantes para agradecerles el esfuerzo. En particular, da las gracias al autor o al traductor por enviar su texto y anímalo a volver a trabajar con nostros en el futuro. También puedes proporcionarle alguna idea sobre cómo difundir y anunciar su contribución. Las lecciones más visitadas suelen contar con la promoción del autor. Por ejemplo, el autor podría realizar las siguientes acciones:
-
-- Tuitear al menos tres veces la lección con el enlace a la web.
-- Retuitear nuestros tuits sobre la lección (darle al `like`no es suficiente).
-- Promocionar la lección en presentaciones y publicaciones.
-- Enlazar a la lección en entradas de blog.
-- Añadir la lección a algunos recursos colaborativos como Wikipedia u otros plataformas.
-
-¡Por favor, no abandones la lección a su suerte! Ya hemos realizado el trabajo, así que asegurémosnos que ha valido la pena.
+Una vez que la lección haya sido publicada, informe al editor.

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -239,11 +239,9 @@ El siguiente código debe agregarse al texto de la lección, generalmente antes 
 
 Añade traductor, revisores y editores al archivo YAML
 
-Es muy importante acreditar el trabajo de nuestros traductores, revisores y editores. Así, pues, localiza el bloque YAML que se encuentra al inicio del tutorial, y añade el nombre de los revisores y de todos los miembros de nuestra comunidad que han contribuido durante el proceso de revisión. Además, crea un campo `editor` y añade tu nombre y de cuantos otros editores hayan contribuido en la publicación. Las instrucciones para dar formato al bloque de YAML se encuentran en la [guía para autores y traductores](/es/guia-para-autores).
+Así, pues, localiza el bloque YAML que se encuentra al inicio del tutorial, y añade el nombre de los revisores y de todos los miembros de nuestra comunidad que han contribuido durante el proceso de revisión. Además, crea un campo `editor` y añade tu nombre y de cuantos otros editores hayan contribuido en la publicación. Las instrucciones para dar formato al bloque de YAML se encuentran en la [guía para autores y traductores](/es/guia-para-autores).
 
 Si se trata de una traducción, asegúrate de que se mantienen los datos del YAML original, e introduce un campo para el traductor (`translator`), otro para los revisores de la traducción (`translation-reviewer`) y otro más para el editor de la traducción (`translation-editor`).
-
-Teniendo como referencia el ejemplo de abajo, asegúrate que toda la parte preliminar de la lección está completada adecuadamente. Los campos comunes que necesitas escribir o editar en este punto son:
 
 Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML de la lección por completo (para tutoriales originales):
 
@@ -289,7 +287,7 @@ abstract: "[Traducción del resumen del original]"
 - **abstract** es una descripción de una a tres frases sobre lo que se aprende en esa lección. Trata de evitar, en lo posible, un vocabulario técnico, para que estos resúmenes ayuden a los académicos sin un conocimiento técnico a probar nuevas cosas.
 
 
-Para las traducciones, no solo hay que añadir `translator`, `translation-reviewer`, `translation-editor` y `translation_date`. También hay que añadir el campo `original` tal y como se muestra aquí: 
+Para las traducciones, no solo hay que añadir `translator`, `translation-reviewer`, `translation-editor` y `translation_date`. También hay que añadir el campo `original`: 
 
 Es decir, con el nombre del archivo en inglés, sin extensión `.md` y sin indicar que se encuentra en el directorio `en`. En total, pues, las traducciones contienen cinco metadatos adicionales.
 


### PR DESCRIPTION
Closes #992 

As per our discussion, this reduces the length of the editorial guidelines by condensing the instructions on checking the YAML header, and moves some responsibilities for pull requests to the "Managing Editor".

I have only done this for the ENGLISH page. Can someone please look over it in ENGLISH and if we're happy I will do my best to fix the Spanish page too, to save everyone work. Please do not merge this until we also have the Spanish page ready.