### PR TITLE
Add Jennifer Isasi to technical team

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -945,6 +945,7 @@
   team_roles:
     - spanish
     - board
+    - technical
 
 - name: Jon MacKay
   team: false


### PR DESCRIPTION
As per issue #1009

@jenniferisasi has volunteered to join the technical team to act as a point person on the Spanish team for pull requests. We'll do this in the first instance on a one-year basis, with obviously the option for her to rotate off if she finds she doesn't want to do this.

Closes #1009