### PR TITLE
Maria Jose to managing editor

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -136,6 +136,7 @@
         Maria José Afanador-Llach es profesora asistente de humanidades digitales e historia en la Universidad de los Andes, Bogotá (Colombia).
   team_roles:
    - spanish
+   - managing-es
    - ombuds-es
    - board
 
@@ -183,7 +184,6 @@
         Antonio Rojas Castro tiene un doctorado en Humanidades (Universitat Pompeu Fabra) y trabaja como investigador en el Cologne Center for eHumanities.
   team_roles:
    - spanish
-   - managing-es
    - board
 
 - name: Stephen Margheim

--- a/en/project-team.md
+++ b/en/project-team.md
@@ -8,7 +8,7 @@ redirect_from: /project-team
 Please direct correspondence in the first instance to:
 
 * <a href="mailto:anandi.silva.knuppel@emory.edu">Anandi Silva Knuppel</a> (English)
-* <a href="mailto:mj.afanador28@uniandes.edu.co"Maria José Afanador Llach</a> (Spanish)
+* <a href="mailto:mj.afanador28@uniandes.edu.co">Maria José Afanador Llach</a> (Spanish)
 
 You can follow the _Programming Historian_ on Twitter: [@proghist](http://twitter.com/proghist).
 

--- a/en/project-team.md
+++ b/en/project-team.md
@@ -8,7 +8,7 @@ redirect_from: /project-team
 Please direct correspondence in the first instance to:
 
 * <a href="mailto:anandi.silva.knuppel@emory.edu">Anandi Silva Knuppel</a> (English)
-* <a href="mailto:rojas.castro.antonio@gmail.com">Antonio Rojas Castro</a> (Spanish)
+* <a href="mailto:mj.afanador28@uniandes.edu.co"Maria José Afanador Llach</a> (Spanish)
 
 You can follow the _Programming Historian_ on Twitter: [@proghist](http://twitter.com/proghist).
 

--- a/es/contribuciones.md
+++ b/es/contribuciones.md
@@ -26,7 +26,7 @@ Escribir un tutorial es una de las mejores maneras de profundizar en un método 
 
 Nuestro objetivo no es aceptar o rechazar artículos como una revista académica tradicional. Por el contrario, nuestro equipo editorial colaborará y te ayudará a mejorar la escritura de la lección y cómo plantearla de manera adecuada para que resulte clara y útil. Nuestro proceso de revisión contribuye a mejorar las lecciones y tu destreza a la hora de escribir sobre temas técnicos o especializados. Por favor, no dudes en leer más sobre el proceso de [envío].
 
-Si quieres proponer una lección (escrita por ti o por otra persona), envía un email a [Antonio Rojas Castro].
+Si quieres proponer una lección (escrita por ti o por otra persona), envía un email a [Maria José Afanador Llach].
 
 
 ## Únete a nuestro equipo de revisores
@@ -36,7 +36,7 @@ Si quieres proponer una lección (escrita por ti o por otra persona), envía un 
 
 La revisión por pares es esencial para producir recursos fiables de calidad. El equipo de _The Programming Historian en español_ tiene en gran estima el proceso de revisión y, además, adopta una aproximación abierta y colaborativa en la que los revisores reciben crédito de manera pública y completa por su trabajo. Para más información sobre nuestra filosofía y forma de trabajar, por favor, consulta la Guía para [revisores].
 
-Te animamos a que te unas a nuestro equipo de revisores. El tiempo dedicado es flexible; de esta manera, contribuirás a mantener la calidad de los contenidos. Por favor, envía un email a [Antonio Rojas Castro] con una breve presentación y dinos en qué métodos, herramientas, temas o tecnologías estás interesado o interesada para que podamos encargarte la revisión de una lección apropiada.
+Te animamos a que te unas a nuestro equipo de revisores. El tiempo dedicado es flexible; de esta manera, contribuirás a mantener la calidad de los contenidos. Por favor, envía un email a [Maria José Afanador Llach] con una breve presentación y dinos en qué métodos, herramientas, temas o tecnologías estás interesado o interesada para que podamos encargarte la revisión de una lección apropiada.
 
 
 ## Conviértete en editor
@@ -70,7 +70,7 @@ Este proyecto se propone demostrar cómo deben ser las publicaciones académicas
 
 ## O simplemente ponte en contacto con nosotros
 
-Si se te ocurren más formas de participación, siempre puedes escribirnos un email a [Antonio Rojas Castro] con comentarios, preguntas, quejas o sugerencias. Nos comprometemos a responder a todos los mensajes tan pronto como sea posible.
+Si se te ocurren más formas de participación, siempre puedes escribirnos un email a [Maria José Afanador Llachf] con comentarios, preguntas, quejas o sugerencias. Nos comprometemos a responder a todos los mensajes tan pronto como sea posible.
 
 ¡Gracias por ayudarnos a mejorar _The Programming Historian en español_!
 
@@ -84,4 +84,5 @@ Si se te ocurren más formas de participación, siempre puedes escribirnos un em
 [WorldCat]: http://www.worldcat.org/title/programming-historian/oclc/951537099
 [University of Purdue library]: http://purdue-primo-prod.hosted.exlibrisgroup.com/primo_library/libweb/action/dlDisplay.do?vid=PURDUE&search_scope=everything&docId=PURDUE_ALMA51671812890001081&fn=permalink
 [Directory of Open Access Journals]: https://doaj.org/toc/2397-2068
-[Antonio Rojas Castro]: mailto:rojas.castro.antonio@gmail.com
+[Maria José Afanador Llach]: mailto:mj.afanador28@uniandes.edu.co
+

--- a/es/equipo-de-proyecto.md
+++ b/es/equipo-de-proyecto.md
@@ -6,7 +6,7 @@ original: project-team
 
 Por favor, dirige tu correspondencia, en primer lugar a:
 * <a href="mailto:anandi.silva.knuppel@emory.edu">Anandi Silva Knuppel</a> (en inglés)
-* <a href="mailto:rojas.castro.antonio@gmail.com">Antonio Rojas Castro</a> (español)
+* <a href="mailto:mj.afanador28@uniandes.edu.co">Maria José Afanador Llach</a> (español)
 
 Puedes seguir _Programming Historian_ en Twitter: [@proghist](http://twitter.com/proghist).
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -14,7 +14,7 @@ original: author-guidelines
 
 ## Traducir o proponer una lección nueva
 
-Si quieres traducir una lección, tienes una idea para una lección nueva o ya has escrito un tutorial que crees que puede adaptarse a *The Programming Historian en español*, contacta con [Antonio Rojas Castro]. Cuanto antes te pongas en contacto con nosotros, mucho mejor; de esta manera, te ayudaremos a plantear adecuadamente tu contribución, teniendo en cuenta el público objetivo y el nivel de conocimientos necesarios. También te asignaremos un editor para ayudarte a resolver dudas y a desarrollar la lección de la mejor manera.
+Si quieres traducir una lección, tienes una idea para una lección nueva o ya has escrito un tutorial que crees que puede adaptarse a *The Programming Historian en español*, contacta con [Maria José Afanador Llach]. Cuanto antes te pongas en contacto con nosotros, mucho mejor; de esta manera, te ayudaremos a plantear adecuadamente tu contribución, teniendo en cuenta el público objetivo y el nivel de conocimientos necesarios. También te asignaremos un editor para ayudarte a resolver dudas y a desarrollar la lección de la mejor manera.
 
 **¿Qué lecciones traducir?** Si quieres traducir una lección, por favor, revisa la lista de [traducciones pendientes] y ponte en contacto con nosotros. Buscamos traducciones rigurosas, de lectura amena y que, además, tengan en cuenta el contexto de España y América Latina y los recursos disponibles en lengua española.
 
@@ -348,7 +348,7 @@ Finalmente, el equipo editorial the *The Programming Historian en español* revi
 ¡Felicidades! ¡Ya has publicado tu traducción o lección en *The Programming Historian en español*!
 
 
-[Antonio Rojas Castro]: mailto:rojas.castro.antonio@gmail.com
+[Maria José Afanador Llach]: mailto:mj.afanador28@uniandes.co
 [traducciones pendientes]: https://github.com/programminghistorian/ph-submissions/blob/gh-pages/es/lista-de-traducciones.md
 [lecciones ya publicadas]: /es/lecciones
 [directrices para revisores]: /es/guia-para-revisores


### PR DESCRIPTION
Closes #983 . These changes replace @arojascastro with @mariajoafana on the managing editor references, as per the list on https://github.com/programminghistorian/jekyll/wiki/Managing-Editor-Handover