### PR TITLE
Links to images should be https

### DIFF
--- a/_plugins/validate_yaml.rb
+++ b/_plugins/validate_yaml.rb
@@ -28,7 +28,7 @@ module MyModule
       valid_difficulties = [1, 2, 3]
 
       # Fields required on ALL lessons
-      required_fields = ["layout", "reviewers", "authors", "date", "title", "difficulty", "activity", "topics", "abstract", "editors", "review-ticket"] 
+      required_fields = ["layout", "reviewers", "authors", "date", "title", "difficulty", "activity", "topics", "abstract", "editors", "review-ticket"]
 
       # Fields required only on es lessons
       es_required_fields = ["translator", "translation-reviewer", "original", "translation_date", "translation-editor"]
@@ -46,9 +46,14 @@ module MyModule
 
         page_errors = Array.new
 
-        # Warn if any lesson content matches this regex
+        # Warn if any lesson content contains absolute links
         if Regexp.new("[\\(<]https?://programminghistorian.org/*") =~ p["content"]
           page_errors.push('It looks this lesson contains a full link to "https://programminghistorian.org". All internal links should start with "/" followed by the relative page path, and not use the full domain name.')
+        end
+
+        # Warn if any lesson content contains inesure image content
+        if Regexp.new("\\(http://\\S*(png|svg|jpg|jpeg|gif|tiff)") =~ p["content"]
+          page_errors.push('It looks like you are linking to an image using an "http" URL. Make sure all image links use "https".')
         end
 
         # Any fields listed in exclude_from_check YAML variable will not be checked.
@@ -126,7 +131,7 @@ module MyModule
         unless page_errors.empty?
           # Throw a warning with the filename
           warn format_red("* In #{p.dir}#{p.name}:")
-          
+
           # Add some formatting to the errors and then throw them
           unit_errors = page_errors.map{|e| "  - [ ] #{e}"}
 
@@ -154,11 +159,11 @@ module MyModule
             end
           end
         end
-        
+
         unless post_errors.empty?
           # Throw a warning with the filename
           warn format_red("* In #{p.data["slug"]}:")
-          
+
           # Add some formatting to the errors and then throw them
           unit_errors = post_errors.map{|e| "  - [ ] #{e}"}
 

--- a/en/lessons/getting-started-with-markdown.md
+++ b/en/lessons/getting-started-with-markdown.md
@@ -242,11 +242,11 @@ One example is the [Programming Historian][1] website.
 
 Images can be referenced using `!`, followed by some alt-text in square brackets, followed by the image URL and an optional title. These will not be displayed in your plain text document, but would be embedded into a rendered HTML page.
 
-`![Wikipedia logo](http://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")`
+`![Wikipedia logo](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")`
 
 **This renders as:**
 
-![Wikipedia logo](http://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")
+![Wikipedia logo](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")
 
 #### Horizontal Rules
 

--- a/en/lessons/intro-to-beautiful-soup.md
+++ b/en/lessons/intro-to-beautiful-soup.md
@@ -79,7 +79,7 @@ With sudo, the command is:
 sudo pip install beautifulsoup4
 ```
 
-{% include figure.html filename="http://imgs.xkcd.com/comics/sandwich.png" caption="The power of sudo: 'Sandwich' by XKCD" %}
+{% include figure.html filename="https://imgs.xkcd.com/comics/sandwich.png" caption="The power of sudo: 'Sandwich' by XKCD" %}
 
 Application: Extracting names and URLs from an HTML page
 --------------------------------------------------------

--- a/es/lecciones/introduccion-a-markdown.md
+++ b/es/lecciones/introduccion-a-markdown.md
@@ -5,8 +5,8 @@ authors:
 - Sarah Simpkin
 date: 2015-11-13
 translation_date: 2017-07-31
-editors: 
-- Ian Milligan 
+editors:
+- Ian Milligan
 reviewers:
 - John Fink
 - Nancy Lemay
@@ -78,10 +78,10 @@ Primer nivel de encabezado
 
 Segundo nivel de encabeado
 --------------------------
-``` 
+```
 
 Estos se representarán como:
- 
+
 # Primer nivel de encabezado
 
 ## Segundo nivel de encabezado
@@ -131,7 +131,7 @@ Añade énfasis a una frase utilizando estos métodos:
 
 Lo cual queda representado así:
 
-¡Estoy **muy** entusiasmado con los tutoriales de _The Programming Historian en español_! 
+¡Estoy **muy** entusiasmado con los tutoriales de _The Programming Historian en español_!
 
 #### Listados
 
@@ -216,11 +216,11 @@ Observa cómo el bloque de código se representa a renglón seguido.
 Escribe el siguiente texto en la caja de texto:
 
 ```
-> Hola. Éste es un párrafo de texto incluido en un bloque de cita. Fíjate que tengo una sangría con respecto al margen izquierdo. 
+> Hola. Éste es un párrafo de texto incluido en un bloque de cita. Fíjate que tengo una sangría con respecto al margen izquierdo.
 ```
 Lo cual se representará:
 
-> Hola. Éste es un párrafo de texto incluido como un bloque de cita textual. Fíjate que tengo una sangría con respecto al margen izquierdo. 
+> Hola. Éste es un párrafo de texto incluido como un bloque de cita textual. Fíjate que tengo una sangría con respecto al margen izquierdo.
 
 #### Enlaces de Internet
 
@@ -253,11 +253,11 @@ Un ejemplo es el sitio *[The Programming Historian en español][1]*
 
 Se pueden referir las imágenes mediante el uso de `!`, seguido de un texto alternativo entre corchetes, seguido a su vez por el URL de la imagen y un título opcional entre comillas. Esto no se representará como texto en tu documento pero te permitirá incluir la imagen en la visualización de una página en HTML.
 
-`![Logo de Wikipedia](http://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")`
+`![Logo de Wikipedia](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")`
 
 **Esto aparece como:**
 
-![Logo de Wikipedia](http://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")
+![Logo de Wikipedia](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg "Wikipedia logo")
 
 #### Reglas y líneas horizontales
 
@@ -297,7 +297,7 @@ Para crear una tabla en GitHub, usa barras verticales `|`para separar columnas y
 | renglón 2, columna 1 | renglón 2, columna 2 | renglón 2, columna 3|
 | renglón 3, columna 1 | renglón 3, columna 2 | renglón 3, columna 3|
 
-Para especificar la alineación del contenido de cada columna se pueden agregar dos puntos `:`al renglón de los encabezados como sigue: 
+Para especificar la alineación del contenido de cada columna se pueden agregar dos puntos `:`al renglón de los encabezados como sigue:
 
 ```
 | Alineado-izquierda | Centrado | Alineado-derecha |


### PR DESCRIPTION
Closes a minor technical problem where I was getting page build warnings because some of our https pages were embedding images that used http links instead.