### PR TITLE
Translate treasurer and sponsorship coord roles

### DIFF
--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -78,7 +78,7 @@
 - type: sponsorship
   label:
     en: Sponsorship Coordinator
-    es: Cordinación de patrocinio
+    es: Coordinación de patrocinio
   definition:
     en: Responsible for managing relationships with our sponsors
     es: Responsable de coordinar las relaciones con las y los patrocinadores

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -71,17 +71,17 @@
 - type: treasurer
   label:
     en: Treasurer
-    es: 
+    es: Tesorería
   definition:
     en: Responsible for project finances
-    es: 
+    es: Responsable de las finanzas del proyecto
 - type: sponsorship
   label:
     en: Sponsorship Coordinator
-    es: 
+    es: Cordinación de patrocinio
   definition:
     en: Responsible for managing relationships with our sponsors
-    es: 
+    es: Responsable de coordinar las relaciones con las y los patrocinadores
 # --- Derived roles ---
 - type: ombuds-es
   label:


### PR DESCRIPTION
Hi @acrymble @drjwbaker @jenniferisasi @spapastamkou !

As I said here #1035 , the terms to refer to the person in charge of the Treasury are "tesorero" for men and "tesorera" for women. In such a way is that I chose Treasury (the function). In the other hand, Coordinator of sponsorship is "coordinador" (male) and "coordinadora" (female), and I chose "Coordinación de patrocinio". If the person is already designated, I suggest modifying the term according to gender. The mechanism will be the same in French as the language differentiates genres.

Happy to hear any thought!