### PR TITLE
Updates to Introduction to MySQL with R: Edit lesson for MySQL 8 and use of RMariaDB package instead of RMySQL.

### DIFF
--- a/assets/getting-started-with-mysql-using-r/sample-data-submarine.csv
+++ b/assets/getting-started-with-mysql-using-r/sample-data-submarine.csv
@@ -1637,8 +1637,3 @@
 "THE STORY OF THE YEAR","1915-01-02","http://newspapers.library.wales/view/3611399/3611402/8/","German+Submarine"
 "The Apostle of OptimismI","1915-09-10","http://newspapers.library.wales/view/4121425/4121433/110/","German+Submarine"
 "Advertising","1915-10-01","http://newspapers.library.wales/view/3886280/3886284/29/","German+Submarine"
-
------------------------------7e128f2d40492
-Content-Disposition: form-data; name="overwrite"
-
-0

--- a/en/lessons/getting-started-with-mysql-using-r.md
+++ b/en/lessons/getting-started-with-mysql-using-r.md
@@ -294,7 +294,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE, SHOW VIEW ON newspaper_search_res
 
 When a user is created in MySQL 8 Workbench the **Authentication Type** is defaulted to **caching_sha2_password**. That type of authentication causes an error for the R package we will use to connect to the database later in this lesson. The error is *Authentication plugin 'caching_sha2_password' cannot be loaded* and it is described in [Stack Overflow](https://stackoverflow.com/questions/49194719/authentication-plugin-caching-sha2-password-cannot-be-loaded).
 
-To avoid this error we can change the user's Authentication Type to Standard. Do this this, run this command:
+To avoid this error we can change the user's Authentication Type to Standard. To do this, run this command:
 
 ```
 ALTER USER 'newspaper_search_results_user'@'localhost' IDENTIFIED WITH mysql_native_password BY 'SomethingDifficult';
@@ -472,7 +472,7 @@ SELECT story_title, story_date_published FROM tbl_newspaper_search_results;
 
 Let's do this using R! Below is an expanded version of the R Script we used above to connect to the database. For brevity, the first 3 comments we had in the R Script above are removed.  We no longer need them.
 
-In line 4 of the program below, remember to change the path to the rmysql.settingsfile that matches your computer.
+In line 4 of the program below, remember to change the path to the rmariadb.settingsfile that matches your computer.
 
 ```
 library(RMariaDB)
@@ -725,34 +725,37 @@ rmariadb.db<-"newspaper_search_results"
 storiesDb<-dbConnect(RMariaDB::MariaDB(),default.file=rmariadb.settingsfile,group=rmariadb.db) 
 
 searchTermUsed="German+Submarine"
-# Query a count of the number of stories matching searchTermUsed that were published each month
+# Query a count of the number of stories matching searchTermUsed that were published each month.
 query<-paste("SELECT ( COUNT(CONCAT(MONTH(story_date_published), ' ',YEAR(story_date_published)))) as 'count' 
-             FROM tbl_newspaper_search_results
-             WHERE search_term_used='",searchTermUsed,"'
-             GROUP BY YEAR(story_date_published),MONTH(story_date_published)
-             ORDER BY YEAR(story_date_published),MONTH(story_date_published);",sep="")
+    FROM tbl_newspaper_search_results
+    WHERE search_term_used='",searchTermUsed,"'
+    GROUP BY YEAR(story_date_published),MONTH(story_date_published)
+    ORDER BY YEAR(story_date_published),MONTH(story_date_published);",sep="")
+
 print(query)
 rs = dbSendQuery(storiesDb,query)
 dbRows<-dbFetch(rs)
 
 countOfStories<-c(as.integer(dbRows$count))
 
-#Put the results of the query into a time series
+# Put the results of the query into a time series.
 qts1 = ts(countOfStories, frequency = 12, start = c(1914, 8))
 print(qts1)
-#Plot the qts1 time series data with line width of 3 in the color red.
-plot(xlim=c(1914,1919), 
-     ylim=c(0,150), 
-     qts1, 
-     lwd=3,
-     col = "red",
-     xlab="Month of the war",
-     ylab="Number of newspaper stories",
-     main=paste("Number of stories in Welsh newspapers matching the search terms listed below.",sep=""),
-     sub="Search term legend: Red = German+Submarine. Green = Allotment And Garden.")
+
+# Plot the qts1 time series data with a line width of 3 in the color red.
+plot(qts1, 
+    lwd=3,
+    col = "red",
+    xlab="Month of the war",
+    ylab="Number of newspaper stories",
+    xlim=c(1914,1919), 
+    ylim=c(0,150), 
+    main=paste("Number of stories in Welsh newspapers matching the search terms listed below.",sep=""),
+    sub="Search term legend: Red = German+Submarine. Green = Allotment And Garden.")
 
 searchTermUsed="AllotmentAndGarden"
-#Query a count of the number of stories matching searchTermUsed that were published each month
+
+# Query a count of the number of stories matching searchTermUsed that were published each month.
 query<-paste("SELECT (  COUNT(CONCAT(MONTH(story_date_published),' ',YEAR(story_date_published)))) as 'count'   FROM tbl_newspaper_search_results   WHERE search_term_used='",searchTermUsed,"'   GROUP BY YEAR(story_date_published),MONTH(story_date_published)   ORDER BY YEAR(story_date_published),MONTH(story_date_published);",sep="")
 print(query)
 rs = dbSendQuery(storiesDb,query)
@@ -760,17 +763,17 @@ dbRows<-dbFetch(rs)
 
 countOfStories<-c(as.integer(dbRows$count))
 
-#Put the results of the query into a time series
+# Put the results of the query into a time series.
 qts2 = ts(countOfStories, frequency = 12, start = c(1914, 8))
-#Add this line with the qts2 time series data to the the existing plot 
+
+# Add this line with the qts2 time series data to the the existing plot.
 lines(qts2, lwd=3,col="darkgreen")
 
 # Clear the result
 dbClearResult(rs)
 
-#disconnect to clean up the connection to the database
+# Disconnect to clean up the connection to the database.
 dbDisconnect(storiesDb)
-
 
 ```
 ## Explanation of the select and plot data program.
@@ -807,15 +810,15 @@ qts1 = ts(countOfStories, frequency = 12, start = c(1914, 8))
 ```
 Below, the data in the *qts1* time series is plotted on a graph
 ```
-plot(xlim=c(1914,1919), 
-     ylim=c(0,150), 
-     qts1, 
-     lwd=3,
-     col = "red",
-     xlab="Month of the war",
-     ylab="Number of newspaper stories",
-     main=paste("Number of stories in Welsh newspapers matching the search terms listed below.",sep=""),
-     sub="Search term legend: Red = German+Submarine. Green = Allotment And Garden.")
+plot(qts1, 
+    lwd=3,
+    col = "red",
+    xlab="Month of the war",
+    ylab="Number of newspaper stories",
+    xlim=c(1914,1919), 
+    ylim=c(0,150), 
+    main=paste("Number of stories in Welsh newspapers matching the search terms listed below.",sep=""),
+    sub="Search term legend: Red = German+Submarine. Green = Allotment And Garden.")
 ```
 What is different about the part of the program that plots the stories matching the search "Allotment And Garden"? Not very much at all.  We just use the *lines()* function to plot those results on the same plot we made above.
 ```

--- a/en/lessons/getting-started-with-mysql-using-r.md
+++ b/en/lessons/getting-started-with-mysql-using-r.md
@@ -88,7 +88,7 @@ Below are tips on the installation for the PC and Mac:
 
 ##### Installation tips for a PC
 
-Once the file is downloaded, double click on the downloaded file to install it.  Follow the prompts to accept the licence.
+Using the MySQL Installer for Windows is the recommended way to install the components of MySQL. Once the file is downloaded, double click on the downloaded file to install it.  Follow the prompts to accept the licence.
 After the products are installed, you will be prompted for options:
 
 
@@ -636,7 +636,7 @@ Once you see your test record, TRUNCATE tbl_newspaper_search_results to remove t
 
 In the next part of the lesson we'll query the database table.  Our goal is to have enough data in the table to make a graph. To prepare for that let's load some sample data from comma separated value (.csv) text files.
 
-Download these .csv files to your R working directory.
+Download these .csv files to your R working directory. These files are stored in GitHub so download the Raw version of the files.
 1. [sample-data-allotment-garden.csv](/assets/getting-started-with-mysql-using-r/sample-data-allotment-garden.csv) This is a list of Welsh newspaper stories published during World War I that match the search terms allotment and garden.
 2. [sample-data-submarine.csv](/assets/getting-started-with-mysql-using-r/sample-data-submarine.csv) This is a list of Welsh newspaper stories published during World War I that match the search terms German and submarine.
 

--- a/en/lessons/getting-started-with-mysql-using-r.md
+++ b/en/lessons/getting-started-with-mysql-using-r.md
@@ -692,14 +692,16 @@ sampleGardenData <- read.csv(file="sample-data-allotment-garden.csv", header=TRU
 # This statement trims any story_titles that are any longer to 99 characters.
 sampleGardenData$story_title <- substr(sampleGardenData$story_title,0,99)
 
+# This statement formats story_date_published to represent a DATETIME.
+sampleGardenData$story_date_published <- paste(sampleGardenData$story_date_published," 00:00:00",sep="")
+
 dbWriteTable(storiesDb, value = sampleGardenData, row.names = FALSE, name = "tbl_newspaper_search_results", append = TRUE ) 
 
 # read in the sample data from a newspaper search of German+Submarine
 sampleSubmarineData <- read.csv(file="sample-data-submarine.csv", header=TRUE, sep=",")
 
-# The story_title column in the database table can store values up to 99 characters long.  
-# This statement trims any story_titles that are any longer to 99 characters.
 sampleSubmarineData$story_title <- substr(sampleSubmarineData$story_title,0,99)
+sampleSubmarineData$story_date_published <- paste(sampleSubmarineData$story_date_published," 00:00:00",sep="")
 
 dbWriteTable(storiesDb, value = sampleSubmarineData, row.names = FALSE, name = "tbl_newspaper_search_results", append = TRUE ) 
 

--- a/en/lessons/getting-started-with-mysql-using-r.md
+++ b/en/lessons/getting-started-with-mysql-using-r.md
@@ -117,6 +117,8 @@ Check: TCP/IP.  Port number: 3306.
 
 {% include figure.html filename="getting-started-with-mysql-8.png" caption="Development Machine TCPIP port 3306" %}
 
+###### 5. Accounts and Roles
+
 {% include figure.html filename="getting-started-with-mysql-9.png" caption="Write down and then type in a root password" %}
 
 ###### 6. Windows Service


### PR DESCRIPTION
Modifications to the lesson fix a bug when the lesson is used with MySQL version 8, as described in this issue:
[https://github.com/programminghistorian/jekyll/issues/1016](https://github.com/programminghistorian/jekyll/issues/1016)

At line 302 are instructions to set a MySQL user to have a standard authentication type:
ALTER USER 'newspaper_search_results_user'@'localhost' IDENTIFIED WITH mysql_native_password BY 'SomethingDifficult';

The R programs have been changed to use RMariaDB which is a newer package than RMySQL and is better maintained.

Testing found that the sample data file sample-data-submarine.csv asset hade 5 extra lines that caused some errors.

Only these files were modified:
en/lessons/getting-started-with-mysql-using-r.md
assets/getting-started-with-mysql-using-r/sample-data-submarine.csv

End of request.
