### PR TITLE
Markdownify abstracts

### DIFF
--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -23,7 +23,7 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   <h3 class="above-title">{{ include.authors }}</h3>
   <a href="{{ lesson.url }}"><h2 class="title">{{ lesson.title }}</h2></a>
 
-  <p class="abstract">{{ lesson.abstract }}</p>
+  <p class="abstract">{{ lesson.abstract | markdownify }}</p>
 
   {% comment %}
  Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is publication date for english lesson, and translation date for spanish lessons.

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -35,7 +35,7 @@ layout: base
         </div>
 
         <div class="header-abstract">
-          <p>{{ page.abstract }}</p>
+          {{ page.abstract | markdownify }}
         </div>
 
         <div class="container expanded">

--- a/doaj_xml/doaj.xml
+++ b/doaj_xml/doaj.xml
@@ -28,7 +28,7 @@ Generates an XML file with metadata for all lessons for the Directory of Open Ac
       </author>
       {% endfor %}
     </authors>
-    <abstract language="{{ lesson_lang }}">{{ lesson.abstract }}</abstract>
+    <abstract language="{{ lesson_lang }}">{{ lesson.abstract | xml_escape }}</abstract>
     <fullTextUrl format="html">https://programminghistorian.org{{ lesson.url }}</fullTextUrl>
     <keywords language="eng">
       {% for keyword in lesson.topics %}

--- a/en/lessons/json-and-jq.md
+++ b/en/lessons/json-and-jq.md
@@ -13,7 +13,7 @@ difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/23
 activity: transforming
 topics: [data-manipulation]
-abstract: "Working with data from an art museum API and from the Twitter API, this lesson teaches how to use the command-line utility [jq] to filter and parse complex JSON files into flat CSV files."
+abstract: "Working with data from an art museum API and from the Twitter API, this lesson teaches how to use the command-line utility _jq_ to filter and parse complex JSON files into flat CSV files."
 redirect_from: /lessons/json-and-jq
 ---
 


### PR DESCRIPTION
Closes #1054 

Almost none of the lessons use markdown in their abstracts... but when they do, this ensures that it displays ok.