### PR TITLE
Update link to War and Peace text

### DIFF
--- a/en/lessons/intro-to-bash.md
+++ b/en/lessons/intro-to-bash.md
@@ -197,7 +197,7 @@ But wait! There's a trick to make things a bit quicker. Go up one directory (`cd
 
 Now you need to find a basic text file to help us with the example. Why don't you use a book that you know is long, such as Leo Tolstoy's epic *War and Peace*. The text file is availiable via [Project Gutenberg](http://www.gutenberg.org/ebooks/2600). If you have already installed [wget](/lessons/applied-archival-downloading-with-wget), you can just type
 
-`wget http://www.gutenberg.org/cache/epub/2600/pg2600.txt`
+`wget http://www.gutenberg.org/files/2600/2600-0.txt`
 
 If you do not have wget installed, download the text itself using your browser. Go to the link above, and, in your browser, use the 'Save Page as..' command in your 'file menu.' Save it in your new 'ProgHist-Text directory.' Now, when you type
 


### PR DESCRIPTION
Doing a wget of http://www.gutenberg.org/cache/epub/2600/pg2600.txt was downloading a binary, not the text of War and Peace as expected.

NOTICE: Are you attempting to submit a lesson to the Programming Historian? We no longer accept lesson submissions by pull request to this repository. Please consult our [guidelines for submitting a lesson](http://programminghistorian.org/new-lesson-workflow) for further instructions.

If your pull request instead concerns some issue with the formatting or functioning of our site, or some error in an existing lesson, please see our technical contribution guidelines: https://github.com/programminghistorian/jekyll/wiki/Making-technical-contributions
