### PR TITLE
Add sortname field to Laramée

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -972,6 +972,7 @@
   email: fdl@francoisdominiclaramee.com
   team: true
   team_start: 2018
+  sortname: Laramée
   institution: Université de Montréal
   affiliation:
       en: |


### PR DESCRIPTION
closes #1115 

Adds the sortname field to the Laramée entry so it will appear in alphabetical order on the project team page