### PR TITLE
Add 'History of the Project' to About page.

### DIFF
--- a/en/about.md
+++ b/en/about.md
@@ -37,3 +37,7 @@ The project is grateful for the following support:
 * Funding for a writing workshop in Bogota, Colombia, supported by the [British Academy](https://www.britac.ac.uk/) [2018].
 
 The Programming Historian is a volunteer-driven project. It is published by the Editorial Board of the Programming Historian.
+
+## History of the Project
+
+*The Programming Historian* was founded in 2008 by William J. Turkel and Alan MacEachern. It focused heavily on Python and was published open access as a *Network in Canadian History & Environment* (NiCHE) ‘Digital Infrastructure’ project. In 2012, *The Programming Historian* expanded its editorial team and launched as an open access peer reviewed scholarly journal of methodology for digital historians. In 2016 we added a Spanish Language [sub-team](https://github.com/programminghistorian/jekyll/wiki/Additional-Language-Sub-Teams-Policy) to the initial English-language team and in 2017 started publishing translated lessons under the title *The Programming Historian en español*. In 2018 we [hosted our first Spanish-language writing workshop](https://programminghistorian.org/posts/bogota-workshop-report), issued a call for [new lessons in Spanish](https://programminghistorian.org/posts/convocatoria-de-tutoriales), and began to plan for translating lessons into English. In the same year we added a French language sub-team and will launch *The Programming Historian en français* in 2019.


### PR DESCRIPTION
add history of the project to about page (see https://github.com/programminghistorian/jekyll/issues/1102)

This needs an ES and FR translation as well.