### PR TITLE
Updating Brew Instructions for Wget Lesson, Resolves #1151

### DIFF
--- a/en/lessons/automated-downloading-with-wget.md
+++ b/en/lessons/automated-downloading-with-wget.md
@@ -134,7 +134,7 @@ next to Command Line Tools. We are now ready to install a package
 manager.
 
 The easiest package manager to install is *Homebrew*. Go to
-<http://mxcl.github.io/homebrew/> and review the instructions. There are
+<https://brew.sh> and review the instructions. There are
 many important commands, like wget, that are not included by default in
 OS X. This program facilitates the downloading and installation of all
 required files.
@@ -143,7 +143,7 @@ To install *Homebrew*, open up your terminal window and type the
 following:
 
 ``` bash
-ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
 This uses the ruby programming language, built into OS X, to install

--- a/es/lecciones/descarga-automatizada-con-wget.md
+++ b/es/lecciones/descarga-automatizada-con-wget.md
@@ -99,7 +99,7 @@ El gestor de paquetes más fácil de instalar es *Homebrew*. Ve a <https://brew.
 Para instalar *Homebrew*, abre la ventana de Terminal y escribe:
 
 ``` bash
-ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
 Esta instalación de *Hombrew* utiliza el lenguaje de programación Ruby, integrado en OS X. Para ver si la instalación fue correcta, escribe la siguiente orden en la ventana de tu Terminal:


### PR DESCRIPTION
The brew installation command has changed on the [brew homepage](https://brew.sh). This pull request updates the command on both the English and Spanish lessons, and also updates the link on the English lesson (the Spanish link was perfect).

I have tested locally.