### PR TITLE
repair most recent 404 links

### DIFF
--- a/_posts/2018-07-09-PH-espanol-in-DH2018.md
+++ b/_posts/2018-07-09-PH-espanol-in-DH2018.md
@@ -23,7 +23,7 @@ The growth of the *Programming Historian en español*, has also brought about cr
         <img src="/images/dh2018blog/talk-grab.png" alt=""/></a><figcaption>
     Conference attendees enjoyed the talk!</figcaption></figure></p>
 
-We were humbled to discover that the paper was nominated for the [2018 Paul Fortier Prize](http://adho.org/announcements/2018/six-nominees-2018-paul-fortier-prize), given for the best paper by a young scholar/early stage researcher at the conference. Although we did not win, we are proud that the hard work of the editorial team of the *Programming Historian* and its commitment to geographic and linguistic diversity has been recognized by the global digital humanities community.
+We were humbled to discover that the paper was nominated for the 2018 Paul Fortier Prize, given for the best paper by a young scholar/early stage researcher at the conference. Although we did not win, we are proud that the hard work of the editorial team of the *Programming Historian* and its commitment to geographic and linguistic diversity has been recognized by the global digital humanities community.
 
 The conference was also an opportunity for the project team to meet, in many cases for the first time! The *Programming Historian* editors at DH2018 included [Marie Puren](https://github.com/mpuren), a member of our nascent [French language initiative](https://github.com/programminghistorian/jekyll/issues?q=french+label%3Afrench), who along with the rest of the project team distributed 200 [Programming Historian en español stickers](https://github.com/programminghistorian/jekyll/tree/gh-pages/images/logos) to conference delegates.
 

--- a/en/lessons/sonification.md
+++ b/en/lessons/sonification.md
@@ -29,7 +29,7 @@ redirect_from: /lessons/sonification
 
 I am too tired of seeing the past. There are any number of guides that will help you _visualize_ that past which cannot be seen, but often we forget what a creative act visualization is. We are perhaps too tied to our screens, too much invested in ‘seeing’. Let me hear something of the past instead.
 
-While there is a deep history and literature on archaeoacoustics and soundscapes that try to capture the sound of a place _as it was_ ([see for instance the Virtual St. Paul's](https://www.digitalstudies.org/articles/10.16995/dscn.58) or the work of [Jeff Veitch on ancient Ostia](https://jeffdveitch.wordpress.com/)), I am interested instead to ’sonify' what I have _right now_, the data themselves. I want to figure out a grammar for representing data in sound that is appropriate for history. [Drucker](#Drucker) [famously reminds us](http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html) that ‘data’ are not really things given, but rather things captured, things transformed: that is to say, ‘capta’. In sonifying data, I literally perform the past in the present, and so the assumptions, the transformations, I make are foregrounded. The resulting aural experience is a literal ‘deformance’ (portmanteau of ‘deform’ and ‘perform’) that makes us hear modern layers of the past in a new way. 
+While there is a deep history and literature on archaeoacoustics and soundscapes that try to capture the sound of a place _as it was_ ([see for instance the Virtual St. Paul's](https://www.digitalstudies.org/articles/10.16995/dscn.58) or the work of [Jeff Veitch on ancient Ostia](https://jeffdveitch.wordpress.com/)), I am interested instead to ’sonify' what I have _right now_, the data themselves. I want to figure out a grammar for representing data in sound that is appropriate for history. [Drucker](#Drucker) [famously reminds us](http://web.archive.org/web/20190203083307/http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html) that ‘data’ are not really things given, but rather things captured, things transformed: that is to say, ‘capta’. In sonifying data, I literally perform the past in the present, and so the assumptions, the transformations, I make are foregrounded. The resulting aural experience is a literal ‘deformance’ (portmanteau of ‘deform’ and ‘perform’) that makes us hear modern layers of the past in a new way.
 
 I want to hear the meaning of the past, but I know that I can’t. Nevertheless, when I hear an instrument, I can imagine the physicality of the player playing it; in its echoes and resonances I can discern the physical space. I can feel the bass; I can move to the rhythm. The music engages my whole body, my whole imagination. Its associations with sounds, music, and tones I’ve heard before create a deep temporal experience, a system of embodied relationships between myself and the past. Visual? We have had visual representations of the past for so long, we have almost forgotten the artistic and performative aspect of those grammars of expression.
 
@@ -37,9 +37,9 @@ In this tutorial, you will learn to make some noise from your data about the pas
 
 ## Objectives
 
-In this tutorial, I will introduce you to three different ways of generating sound or music from your data. 
+In this tutorial, I will introduce you to three different ways of generating sound or music from your data.
 
-In the first, we will use a freely available and free-to-use system developed by Jonathan Middleton called _Musicalgorithms_, to introduce some of the issues and key terms involved. In the second, we will use a small python library to 'parameter map' our data against the 88 key keyboard, and introduce some artistry into our work. Finally, we will learn how to load our data into the open source live-coding environment for sound and music, _Sonic Pi_, at which time I will leave you to explore that project's copious tutorials and resources. 
+In the first, we will use a freely available and free-to-use system developed by Jonathan Middleton called _Musicalgorithms_, to introduce some of the issues and key terms involved. In the second, we will use a small python library to 'parameter map' our data against the 88 key keyboard, and introduce some artistry into our work. Finally, we will learn how to load our data into the open source live-coding environment for sound and music, _Sonic Pi_, at which time I will leave you to explore that project's copious tutorials and resources.
 
 You will see that 'sonification' moves us along the spectrum from mere 'visualization/auralization' to actual performance.
 
@@ -56,12 +56,12 @@ You will see that 'sonification' moves us along the spectrum from mere 'visualiz
 
 # Some Background on Sonification
 
-Sonification is the practice of mapping aspects of the data to produce sound signals. In general, a technique can be called ‘sonification’ if it meets certain conditions. These include reproducibility (the same data can be transformed the same ways by other researchers and produce the same results) and what might be called intelligibility - that the ‘objective’ elements of the original data are reflected systematically in the resulting sound (see [Hermann](#Hermann) [2008](http://www.icad.org/Proceedings/2008/Hermann2008.pdf) for a taxonomy of sonification). [Last and Usyskin](#Last) [(2015)](https://www.researchgate.net/publication/282504359_Listen_to_the_Sound_of_Data) designed a series of experiments to determine what kinds of data-analytic tasks could be performed when the data were sonified. Their experimental results (Last and Usyskin 2015) have shown that even untrained listeners (listeners with no formal training in music) can make useful distinctions in the data. They found listeners could discriminate in the sonified data common data exploration tasks such as classification and clustering. (Their sonified outputs mapped the underlying data to the Western musical scale.) 
+Sonification is the practice of mapping aspects of the data to produce sound signals. In general, a technique can be called ‘sonification’ if it meets certain conditions. These include reproducibility (the same data can be transformed the same ways by other researchers and produce the same results) and what might be called intelligibility - that the ‘objective’ elements of the original data are reflected systematically in the resulting sound (see [Hermann](#Hermann) [2008](http://www.icad.org/Proceedings/2008/Hermann2008.pdf) for a taxonomy of sonification). [Last and Usyskin](#Last) [(2015)](https://www.researchgate.net/publication/282504359_Listen_to_the_Sound_of_Data) designed a series of experiments to determine what kinds of data-analytic tasks could be performed when the data were sonified. Their experimental results (Last and Usyskin 2015) have shown that even untrained listeners (listeners with no formal training in music) can make useful distinctions in the data. They found listeners could discriminate in the sonified data common data exploration tasks such as classification and clustering. (Their sonified outputs mapped the underlying data to the Western musical scale.)
 
-Last and Usyskin focused on time-series data.  They argue that time-series data are particularly well suited to sonification because there are natural parallels with musical sound. Music is sequential, it has duration, and it evolves over time; so too with time-series data [(Last and Usyskin 2015: 424)](https://www.researchgate.net/publication/282504359_Listen_to_the_Sound_of_Data). It becomes a problem of matching the data to the appropriate sonic outputs. In many applications of sonification, a technique called ‘parameter mapping’ is used to marry aspects of the data along various auditory dimensions such as [pitch](#pitch), variation, brilliance, and onset. The problem with this approach is that where there is no temporal relationship (or rather, no non-linear relationship) between the original data points, the resulting sound can be ‘confusing’ (2015: 422). 
+Last and Usyskin focused on time-series data.  They argue that time-series data are particularly well suited to sonification because there are natural parallels with musical sound. Music is sequential, it has duration, and it evolves over time; so too with time-series data [(Last and Usyskin 2015: 424)](https://www.researchgate.net/publication/282504359_Listen_to_the_Sound_of_Data). It becomes a problem of matching the data to the appropriate sonic outputs. In many applications of sonification, a technique called ‘parameter mapping’ is used to marry aspects of the data along various auditory dimensions such as [pitch](#pitch), variation, brilliance, and onset. The problem with this approach is that where there is no temporal relationship (or rather, no non-linear relationship) between the original data points, the resulting sound can be ‘confusing’ (2015: 422).
 
 ## Hearing the Gaps
-There is also the way that we fill in gaps in the sound with our expectations. Consider this video where the [mp3](#mp3) has been converted to [MIDI](#midi) back to mp3; the music has been 'flattened' so that all sonic information is being played by one instrument. (Generating this effect is rather like saving a webpage as .txt, opening it in Word, and then resaving it as .html). All sounds (including vocals) have been translated to their corresponding note values, and then turned back into an mp3. 
+There is also the way that we fill in gaps in the sound with our expectations. Consider this video where the [mp3](#mp3) has been converted to [MIDI](#midi) back to mp3; the music has been 'flattened' so that all sonic information is being played by one instrument. (Generating this effect is rather like saving a webpage as .txt, opening it in Word, and then resaving it as .html). All sounds (including vocals) have been translated to their corresponding note values, and then turned back into an mp3.
 
 It is noisy; yet we perceive meaning. Consider the video below:
 
@@ -71,13 +71,13 @@ What's going on here? If that song was already known to you, you probably heard 
 
 Consider the implications for history. If we sonify our data, and begin to hear patterns in the sound, or odd outliers, our cultural expectations about how music works (our memories of similar snippets of music, heard in particular contexts) are going to colour our interpretation. This I would argue is true about all representations of the past, but sonifying is just odd enough to our regular methods that this self-awareness will help us identify or communicate the critical patterns in the (data of the) past.
 
-We will progress through three different tools for sonifying data, noting how choices in one tool affect the output, and can be mitigated by reimagining the data via another tool. Ultimately, there is nothing any more objective in 'sonification' than there is in 'visualization', and so the investigator has to be prepared to justify her choices, and to make these choices transparent and reproducible for others. (And lest we think that sonification and algorithmically generated music is somehow a 'new' thing, I direct the interested reader to [Hedges, (1978)](#hedges).) 
+We will progress through three different tools for sonifying data, noting how choices in one tool affect the output, and can be mitigated by reimagining the data via another tool. Ultimately, there is nothing any more objective in 'sonification' than there is in 'visualization', and so the investigator has to be prepared to justify her choices, and to make these choices transparent and reproducible for others. (And lest we think that sonification and algorithmically generated music is somehow a 'new' thing, I direct the interested reader to [Hedges, (1978)](#hedges).)
 
 In each section, I will give a conceptual introduction, followed by a walkthrough using sample archaeological or historical data.
 
 # Musicalgorithms
 
-There are a wide variety of tools out there to sonify data. Some for instance are packages for the widely-used [R statistical environment](https://cran.r-project.org/), such as ‘[playitbyR](https://cran.r-project.org/web/packages/playitbyr/index.html)’ and ‘[AudiolyzR](https://cran.r-project.org/web/packages/audiolyzR/index.html)’. The first of these however has not been maintained or updated to work with the current version of R (its last update was a number of years ago), and the second requires considerable configuration of extra software to make it work properly. 
+There are a wide variety of tools out there to sonify data. Some for instance are packages for the widely-used [R statistical environment](https://cran.r-project.org/), such as ‘[playitbyR](https://cran.r-project.org/web/packages/playitbyr/index.html)’ and ‘[AudiolyzR](https://cran.r-project.org/web/packages/audiolyzR/index.html)’. The first of these however has not been maintained or updated to work with the current version of R (its last update was a number of years ago), and the second requires considerable configuration of extra software to make it work properly.
 
 By contrast, the [Musicalgorithms](http://musicalgorithms.org/) site is quite easy to use. The Musicalgorithms site has been online for over a decade. Though it is not open source, it represents a long-term research project in computational music by its creator, Jonathan Middleton. It is currently in its third major iteration (earlier iterations remain usable online). We will begin with Musicalalgorithms because it allows us to quickly enter and tweak our data to produce a MIDI file representation. Make sure to select '[Version 3](http://musicalgorithms.org/3.0/index.html).'
 
@@ -86,7 +86,7 @@ By contrast, the [Musicalgorithms](http://musicalgorithms.org/) site is quite ea
 Musicalgorithms effects a number of transformations on the data. In the sample data below (the default from the site itself), there is but one row of data, even if it looks like several rows. The sample data is comprised of comma separated fields that are themselves space delimited.
 
 ```
-# Of Voices, Text Area Name, Text Area Data 
+# Of Voices, Text Area Name, Text Area Data
 1,morphBox,
 ,areaPitch1,2 7 1 8 2 8 1 8 2 8 4 5 9 0 4 5 2 3 5 3 6 0 2 8
 ,dAreaMap1,2 7 1 8 2 8 1 8 2 8 4 5 9 0 4 5 2 3 5 3 6 0 2 8
@@ -98,7 +98,7 @@ Musicalgorithms effects a number of transformations on the data. In the sample d
 This data represents the source data and its transformations; sharing this data would allow another investigator to replicate or extend the sonification using other tools. When one begins however, only the basic data below is needed (a list of data points):
 
 ```
-# Of Voices, Text Area Name, Text Area Data 
+# Of Voices, Text Area Name, Text Area Data
 1,morphBox,
 ,areaPitch1,24 72 12 84 21 81 14 81 24 81 44 51 94 01 44 51 24 31 5 43 61 04 21 81
 ```
@@ -109,7 +109,7 @@ The key field for us is ‘areaPitch1,’ which contains the space-delimited inp
 
 Now, as you page across the various tabs in the interface (‘[duration](#duration) input’, ‘[pitch mapping](#pitch mapping)’, ‘duration mapping’, ‘scale options’) you can effect various transformations. In ‘pitch mapping’, there are a number of mathematical options for mapping the data against the full 88 keys/pitches of a piano keyboard (in a linear mapping, the _mean_ of one’s data would be mapped to middle C, or 40). One can also choose the kind of scale, whether it is a minor or major and so on. At this point, once you've selected your various transformations, you should save the text file. On the file tab, ‘play’, one can download a midi file. Your default audio program can play midi files (often defaulting to a piano tone). More complicated instrumentation can be assigned by opening the midi file in music mixing programs such as GarageBand (Mac) or [LMMS](https://lmms.io/) (Windows, Mac, Linux). (Using Garageband or LMMS are outside the scope of this tutorial. A video tutorial on LMMS is available [here](https://youtu.be/4dYxV3tqTUc), while Garageband tutorials proliferate online. Lynda.com has [an excellent one](http://www.lynda.com/GarageBand-tutorials/Importing-audio-tracks/156620/164050-4.html))
 
-If you had several columns of data for the same points - say, in our example from Roman Britain, we also wanted to sonify counts of a pottery type for those same towns - you can reload your next data series, effect the transformations and mappings, and generate another MIDI file. Since Garageband and LMMS allow for overlaying of voices, you can begin to build up complicated sequences of music. 
+If you had several columns of data for the same points - say, in our example from Roman Britain, we also wanted to sonify counts of a pottery type for those same towns - you can reload your next data series, effect the transformations and mappings, and generate another MIDI file. Since Garageband and LMMS allow for overlaying of voices, you can begin to build up complicated sequences of music.
 
 {% include figure.html filename="sonification-garageband-john-adams-3.png" caption="Screenshot of Garageband, where the midi files are sonified topics from John Adams' Diary. In the Garageband interface (LMMS is similar), each midi file is dragged-and-dropped into place. The instrumentation for each midi file (ie track) can be selected from Garageband's menus. The labels for each track have here been changed to reflect the key words in each topic. The green area to the right represents a visualization of the notes in each track. You can watch this interface in action and listen to the music [here](https://youtu.be/ikqRXtI3JeA)." %}
 
@@ -120,12 +120,12 @@ _There is no 'right' way to represent your data as sound_, at least not yet: but
 But what about time? Historical data often has a punctuation point, a distinct 'time when' something occured. Thus, the amount of time between two data points has to be taken into account. This is where our next tool becomes quite useful, for when our data points have a relationship to one another in temporal space. We begin to move from sonfication (data points) to music (relationships between points).
 
 ### Practice
-The [sample dataset](/assets/sonification-roman-data.csv) provided contains counts of Roman coins in its first column and counts of other Roman materials from the same locations, as contained in the Portable Antiquities Scheme database from the British Museum. A sonification of this data might reveal or highlight aspects of the economic situation along Watling street, a major route through Roman Britain. The data points are organized geographically from North West to South East; thus as the sound plays out, we are hearing movement over space. Each note represents another stop along the way. 
+The [sample dataset](/assets/sonification-roman-data.csv) provided contains counts of Roman coins in its first column and counts of other Roman materials from the same locations, as contained in the Portable Antiquities Scheme database from the British Museum. A sonification of this data might reveal or highlight aspects of the economic situation along Watling street, a major route through Roman Britain. The data points are organized geographically from North West to South East; thus as the sound plays out, we are hearing movement over space. Each note represents another stop along the way.
 
 1. Open the[sonification-roman-data.csv](/assets/sonification-roman-data.csv) in a spreadsheet. Copy the first column into a text editor. Delete the line endings so that the data is all in a single row.
 2. Add the following column information like so:
 ```
-# Of Voices, Text Area Name, Text Area Data 
+# Of Voices, Text Area Name, Text Area Data
 1,morphBox,
 ,areaPitch1,
 ```
@@ -133,7 +133,7 @@ The [sample dataset](/assets/sonification-roman-data.csv) provided contains coun
 
 3. Go to the [Musicalgorithms](http://musicalgorithms.org/3.0/index.html) site (version 3), and hit the load button. In the pop-up, click the blue 'load' button and select the file saved in step 2. The site will load your materials and display a green check mark if it loaded successfully. If it did not, make sure that your values are separated by spaces, and that they follow immediately the last comma in the code block in step 2. You may also try loading up the [demo file for this tutorial](/assets/sonification-romancoin-data-music.csv) instead.{% include figure.html filename="sonification-musicalgorithms-upload-4.png" caption="Click 'load' on the main screen to get this dialogue box. Then 'load csv'. Select your file; it will appear in the box. Then click the bottom load button." %}
 4. Click on 'Pitch Input'. You'll see the values of your data. For now, **do not select** any further options on this page (thus using the site's default values).
-5. Click on 'Duration Input'. **Do not select any options here for now**. The options here will map various transformations against your data that will alter the duration for each note. Do not worry about these options for now; move on. 
+5. Click on 'Duration Input'. **Do not select any options here for now**. The options here will map various transformations against your data that will alter the duration for each note. Do not worry about these options for now; move on.
 6. Click on 'Pitch Mapping'. This is the most crucial choice, as it will transform (that is, scale) your raw data to a mapping against the keys of the keyboard. Leave the `mapping` set to 'division'.  (The other options are modulo or logarithmic). The option `Range` 1 to 88 uses the full 88 keys of the keyboard; thus your lowest value would accord to the deepest note on the piano and your highest value with the highest note. You might wish instead to constrain your music around middle C, so enter 25 to 60 as your range. The output should change to: `31,34,34,34,25,28,30,60,28,25,26,26,25,25,60,25,25,38,33,26,25,25,25` These are no longer your counts; they are notes on the keyboard.{% include figure.html filename="sonification-musicalgorithms-settings-for-pitch-mapping-5.png" caption="Click into the 'range' box and set it to 25. The values underneath will change automatically. Click into the 'to' box and set it to 60. Click back into the other box; the values will update." %}
 7. Click on 'Duration Mapping'. Like Pitch Mapping, this takes a range of times that you specify and uses the various mathematical options to map that range of possibilities against your notes. If you mouse over the `i` you will see how the numbers correspond with whole notes, quarter notes, eigth notes, and so on. Leave the default values for now.
 8. Click on 'Scale Options'. Here we can begin to select something of what might be called the 'emotional' aspect to sound. We commonly think of major scales being 'happy' while minor scales are 'sad'; for an accessible discussion see [this blog post](http://www.ethanhein.com/wp/2010/scales-and-emotions/). For now, select 'scale by: major'. Leave the 'scale' as `C`.
@@ -141,7 +141,7 @@ The [sample dataset](/assets/sonification-roman-data.csv) provided contains coun
 You have now sonified one column of data! Click on the 'save' button, then 'save csv'. {% include figure.html filename="sonification-musicalgorithms-save-6.png" caption="The save data dialogue box." %}You'll have a file that looks something like this:
 
 ```
-# Of Voices, Text Area Name, Text Area Data 
+# Of Voices, Text Area Name, Text Area Data
 1,morphBox,
 ,areaPitch1,80 128 128 128 1 40 77 495 48 2 21 19 1 1 500 1 3 190 115 13 5 1 3
 ,dAreaMap1,2 7 1 8 2 8 1 8 2 8 4 5 9 0 4 5 2 3 5 3 6 0 2
@@ -155,7 +155,7 @@ You can see your original data in the 'areaPitch1' field, and your subsequent ma
 Go back to the beginning, and load both columns of data into this template:
 
 ```
-# Of Voices, Text Area Name, Text Area Data 
+# Of Voices, Text Area Name, Text Area Data
 2,morphBox,
 ,areaPitch1,
 ,areaPitch2,
@@ -167,9 +167,9 @@ When you have multiple voices of data, what stands out? Note that in this approa
 
 # A quick word about getting Python set up
 
-The next section of this tutorial requires Python. If you haven't experimented with Python yet, you will need to spend some time [becoming familiar with the command line (PC) or terminal (OS)](/lessons/intro-to-bash). You might find this quick [guide to installing python 'modules'](/lessons/installing-python-modules-pip) handy (but come back to it after you read the rest of this section). 
+The next section of this tutorial requires Python. If you haven't experimented with Python yet, you will need to spend some time [becoming familiar with the command line (PC) or terminal (OS)](/lessons/intro-to-bash). You might find this quick [guide to installing python 'modules'](/lessons/installing-python-modules-pip) handy (but come back to it after you read the rest of this section).
 
-Mac users will already have Python installed on their machine. You can test this by holding down the COMMAND button and the spacebar; in the search window, type `terminal` and click on the terminal application. At the prompt, eg, the cursor blinking at `$` type `python --version` and the computer will respond with what version of python you have. _This next section of the tutorial assumes Python 2.7; it has not been tested on Python 3_. 
+Mac users will already have Python installed on their machine. You can test this by holding down the COMMAND button and the spacebar; in the search window, type `terminal` and click on the terminal application. At the prompt, eg, the cursor blinking at `$` type `python --version` and the computer will respond with what version of python you have. _This next section of the tutorial assumes Python 2.7; it has not been tested on Python 3_.
 
 For Windows users, Python is not installed by default on your machine so [this page](http://docs.python-guide.org/en/latest/starting/install/win/) will help you get started, though things are a bit more complicated than that page makes out. First, download the `.msi` file that that page recommends (Python 2.7). Double click the file, and it should install itself in a new directory, eg `C:\Python27\`. Then, we have to tell Windows the location of where to look for Python whenever you run a python program; that is, you put the location of that directory into your 'path', or the environment variable that windows always checks when confronted with a new command. There are a couple ways of doing this, but perhaps the easiest is to search your computer for the program `Powershell` (type 'powershell' into your windows computer search). Open Powershell, and at the `>` prompt, paste this entire line:
 
@@ -183,19 +183,19 @@ Finally, when you have python code you want to run, you can enter it in your tex
 
 # MIDITime
 
-MIDITime is a python package developed by [Reveal News (formerly, the Centre for Investigative Reporting)](https://www.revealnews.org/). Its [Github repository is here](https://github.com/cirlabs/miditime). Miditime is built explicitly for time series data (that is, a sequence of observations collected over time). 
+MIDITime is a python package developed by [Reveal News (formerly, the Centre for Investigative Reporting)](https://www.revealnews.org/). Its [Github repository is here](https://github.com/cirlabs/miditime). Miditime is built explicitly for time series data (that is, a sequence of observations collected over time).
 
 While the Musicalgorithms tool has a more-or-less intuitive interface, the investigator sacrifices the ability to know what, exactly, is going on under the hood. In principle, one could examine the underlying code for the MIDITime package to see exactly what's going on. More importantly, the previous tool had no ability to account for data where the points are distant from one another in clock-time. MIDITime lets us take into account that our data might be clustering in time.
 
 Let us assume that you have a historic diary to which you've fitted a [topic model](/lessons/topic-modeling-and-mallet). The resulting output might have diary entries as rows, and the percentage composition each topic contributes to that entry as the columns. In which case, _listening_ to these values might help you understand the patterns of thought in the diary in a way that visualizing as a graph might not. Outliers or recurrent musical patterns could stand out to the ear in a way the grammar of graphs obscures.
 
 ### Installing MIDITime
-Installing miditime is straightforward using [pip](/lessons/installing-python-modules-pip): 
+Installing miditime is straightforward using [pip](/lessons/installing-python-modules-pip):
 
 `$ pip install miditime` or `$ sudo pip install miditime` for a Mac or Linux machine;
 `> python pip install miditime` on a Windows machine. (Windows users, if the instructions above didn't quite work for you, you might want to try [this helper program](https://sites.google.com/site/pydatalog/python/pip-for-windows) instead to get Pip working properly on your machine).
 
-### Practice 
+### Practice
 Let us look at the sample script provided. Open your text editor, and copy and paste the sample script in:
 
 ```python
@@ -225,7 +225,7 @@ Save this script as `music1.py`. At your terminal or command prompt, run the scr
 
 `$ python music1.py`
 
-A new file, `myfile.mid` will be written to your directory. To hear this file, you can open it with Quicktime or Windows Media Player. (You can add instrumentation to it by opening it in Garageband or [LMMS](https://lmms.io/)). 
+A new file, `myfile.mid` will be written to your directory. To hear this file, you can open it with Quicktime or Windows Media Player. (You can add instrumentation to it by opening it in Garageband or [LMMS](https://lmms.io/)).
 
 `Music1.py` imports miditime (remember, you must do `pip install miditime` before running the script). Then, it creates an output file destination and sets the tempo. The notes are all listed individually, where the first number is the time when the note should be played, the pitch of the note (ie, the actual note!), how hard or rythmically the note is hit (the [attack](#attack)), and then how long the note lasts. The notes are then written to the track, and then the track is written to `myfile.mid`.
 
@@ -259,11 +259,11 @@ my_data = [
 
 One could approach the problem of getting our data into that format using regular expressions; it might be easier to just open our topic model in a spreadsheet. Copy the topic data to a new sheet, and leave columns to the left and to the right of the data. In the example below, I put it in column D, and then filled in the rest of the data around it, like so:
 
-|   | A | B | C | D | E |
-|---|---|---|---|---|---|
-|1 | {'event_date': datetime |(1753,6,8)  |, 'magnitude':  |0.0024499630  |},  |
-|2 | | | | | |
-|3 | | | | | |
+|     | A                       | B          | C              | D            | E   |
+| --- | ----------------------- | ---------- | -------------- | ------------ | --- |
+| 1   | {'event_date': datetime | (1753,6,8) | , 'magnitude': | 0.0024499630 | },  |
+| 2   |                         |            |                |              |     |
+| 3   |                         |            |                |              |     |
 
 Then copy and paste the elements that do not change to fill up the entire column. The date element has to be (year,month,day). Once you've filled up the table, you can copy and paste it into your text editor so that it becomes part of the `my_data` array, like so:
 
@@ -293,13 +293,13 @@ mymidi = MIDITime(108, 'johnadams1.mid', 3, 4, 1)
 ```
 
 The values after MIDITime, `MIDITime(108, 'johnadams1.mid', 3, 4, 1)` set
-+ the beats per minute (108), 
-+ the output file ('johnadams1.mid'), 
-+ the number of seconds to represent a year in the music (3 seconds to a calendar year, so all of the notes for diary entries from 1753 will be scaled against 3 seconds; there are 50 years in the data, so the final song will be 50 x 3 seconds long, or a bit over two minutes), 
-+ the base octave for the music (middle C is conventionally represented as C5, so here 4 represents one octave below middle C), 
-+ and how many octaves to map the pitches against. 
- 
-Now we pass our data into the script by feeding it into the `my_data` array (this gets pasted in next): 
++ the beats per minute (108),
++ the output file ('johnadams1.mid'),
++ the number of seconds to represent a year in the music (3 seconds to a calendar year, so all of the notes for diary entries from 1753 will be scaled against 3 seconds; there are 50 years in the data, so the final song will be 50 x 3 seconds long, or a bit over two minutes),
++ the base octave for the music (middle C is conventionally represented as C5, so here 4 represents one octave below middle C),
++ and how many octaves to map the pitches against.
+
+Now we pass our data into the script by feeding it into the `my_data` array (this gets pasted in next):
 
 ```python
 my_data = [
@@ -324,7 +324,7 @@ my_data_timed = [{'beat': mymidi.beat(d['days_since_epoch']), 'magnitude': d['ma
 start_time = my_data_timed[0]['beat']
 ```
 
-This part works out the timing between your different diary entries; diaries that are close together in time will therefore have their notes sounding closer together. Finally, we define how the data get mapped against the pitch. Remembering that our data are percentages ranging from 0.01 (ie 1%) to 0.99 (99%), we `scale_pct` between 0 and 1. If you weren't dealing with percentages, you'd use your lowest value and your highest value (if for instance your data were counts of some element of interest, as in the archaology data used earlier). Thus, we paste in: 
+This part works out the timing between your different diary entries; diaries that are close together in time will therefore have their notes sounding closer together. Finally, we define how the data get mapped against the pitch. Remembering that our data are percentages ranging from 0.01 (ie 1%) to 0.99 (99%), we `scale_pct` between 0 and 1. If you weren't dealing with percentages, you'd use your lowest value and your highest value (if for instance your data were counts of some element of interest, as in the archaology data used earlier). Thus, we paste in:
 
 ```python
 def mag_to_pitch_tuned(magnitude):
@@ -367,7 +367,7 @@ For each column of data in your original data, **have a unique script and rememb
 
 # Sonic Pi
 
-Having unique midifiles that you arrange (in Garageband or some other music composition program) moves you from 'sonifying' towards composition and sound art. In this final section, I do not offer you a full tutorial on using [Sonic Pi](http://sonic-pi.net), but rather point you towards this environment that allows for the actual live-coding and performance of your data (see [this video](https://www.youtube.com/watch?v=oW-3HVOeUQA) for an actual live-coding performance). Sonic Pi's built-in tutorials will show you something of the potential of using your computer as an actual musical instrument (where you type Ruby code into its built-in editor while the interpreter plays what you encode). 
+Having unique midifiles that you arrange (in Garageband or some other music composition program) moves you from 'sonifying' towards composition and sound art. In this final section, I do not offer you a full tutorial on using [Sonic Pi](http://sonic-pi.net), but rather point you towards this environment that allows for the actual live-coding and performance of your data (see [this video](https://www.youtube.com/watch?v=oW-3HVOeUQA) for an actual live-coding performance). Sonic Pi's built-in tutorials will show you something of the potential of using your computer as an actual musical instrument (where you type Ruby code into its built-in editor while the interpreter plays what you encode).
 
 Why would you want to do this? As has progressively become clear in tutorial, when you sonify your data you begin to make choices about how the data maps into sound, and these choices reflect implicit or explicit decisions about which data matter. There is a continuum of 'objectivity', if you will. At one end, a sonification that supports an argument about the past; at the other, a performance about the past as riveting and personal as any well-done public lecture. Sonification moves our data off the page and into the ears of our listeners: it is a kind of public history. Performing our data... imagine that!
 
@@ -385,13 +385,13 @@ data = CSV.parse(File.read("/path/to/your/directory/data.csv"), {:headers => tru
 use_bpm 100
 ```
 
-Remember, `path/to/your/directory/` is the actual location of your data on your machine. Make sure it is either called `data.csv` or that you change the line above so that it actually loads your file! 
+Remember, `path/to/your/directory/` is the actual location of your data on your machine. Make sure it is either called `data.csv` or that you change the line above so that it actually loads your file!
 
 Now, let's load that data into our music:
 
 ```
-#this bit of code will run only once, unless you comment out the line with 
-#'live_loop', and also comment out the final 'end' at the bottom 
+#this bit of code will run only once, unless you comment out the line with
+#'live_loop', and also comment out the final 'end' at the bottom
 # of this code block
 #'commenting out' means removing the # sign.
 
@@ -451,13 +451,13 @@ Sonifying our data forces us to confront the ways our data are often not so much
 + **Pitch**,<a name="pitch"></a> the actual note itself (middle C, etc)
 + **Attack**,<a name="attack"></a> how the note is played or hit
 + **Duration**,<a name="duration"></a> how long the note lasts (whole notes, quarter notes, eighth notes etc)
-+ **Pitch Mapping & Duration Mapping**, <a name="pitch mapping"></a> scaling data values against a range of notes or the length of the note 
++ **Pitch Mapping & Duration Mapping**, <a name="pitch mapping"></a> scaling data values against a range of notes or the length of the note
 + **Amplitude**, <a name="amplitude"></a>roughly, the loudness of the note
 
 # References
 <a name="Baio"></a>Baio, Andy. 2015. 'If Drake Was Born A Piano'. Waxy. [http://waxy.org/2015/12/if_drake_was_born_a_piano/](http://waxy.org/2015/12/if_drake_was_born_a_piano/)
 
-<a name="Drucker"></a>Drucker, Johanna. 2011. Humanities Approaches to Graphical Display. DHQ 5.1 [http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html](http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html)
+<a name="Drucker"></a>Drucker, Johanna. 2011. Humanities Approaches to Graphical Display. DHQ 5.1 [http://web.archive.org/web/20190203083307/http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html](http://web.archive.org/web/20190203083307/http://www.digitalhumanities.org/dhq/vol/5/1/000091/000091.html)
 
 <a name="Hedges"></a>Hedges, Stephen A. 1978. “Dice Music in the Eighteenth Century”. Music & Letters 59 (2). Oxford University Press: 180–87. [http://www.jstor.org/stable/734136](http://www.jstor.org/stable/734136).
 

--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -270,11 +270,11 @@ which contains some useful metadata.
 Let's now create a simple document in Markdown. Open a plain-text editor
 of your choice and begin typing. It should look like this:
 
-    ---  
-    title: Plain Text Workflow  
-    author: Dennis Tenen, Grant Wythoff  
-    date: January 20, 2014  
-    ---  
+    ---
+    title: Plain Text Workflow
+    author: Dennis Tenen, Grant Wythoff
+    date: January 20, 2014
+    ---
 
 Pandoc-flavored Markdown stores each of the above values, and "prints"
 them in the appropriate location of your outputted document once you are
@@ -284,9 +284,9 @@ contains three sections, each subdivided into two subsections. Leave a
 blank line after last three dashes in the YAML block and paste the
 following:
 
-    # Section 1  
+    # Section 1
 
-    ## Subsection 1.1  
+    ## Subsection 1.1
     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
     Next paragraph should start like this. Do not indent.
@@ -331,11 +331,11 @@ At this point, your `main.md` should look something like the following.
 You can download this sample .md file
 [here](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/sample.md).
 
-    ---  
-    title: Plain Text Workflow  
-    author: Dennis Tenen, Grant Wythoff  
-    date: January 20, 2014  
-    ---  
+    ---
+    title: Plain Text Workflow
+    author: Dennis Tenen, Grant Wythoff
+    date: January 20, 2014
+    ---
 
     # Section 1
 
@@ -669,7 +669,7 @@ affiliated [mailing
 list](https://groups.google.com/forum/#!forum/pandoc-discuss). At least
 two "Question and Answer" type sites can field questions on Pandoc:
 [Stack Overflow](http://stackoverflow.com/questions/tagged/pandoc) and
-[Digital Humanities Q&A](http://digitalhumanities.org/answers/).
+[Digital Humanities Q&A](http://web.archive.org/web/20190203062832/http://digitalhumanities.org/answers/).
 Questions may also be asked live, on Freenode IRC, \#Pandoc channel,
 frequented by a friendly group of regulars. As you learn more about
 Pandoc, you can also explore one of its most powerful features: [filters](https://github.com/jgm/pandoc/wiki/Pandoc-Filters).

--- a/en/lessons/visualizing-with-bokeh.md
+++ b/en/lessons/visualizing-with-bokeh.md
@@ -24,9 +24,9 @@ layout: lesson
 
 # Overview
 
-The ability to load raw data, sample it, and then visually explore and present it is a valuable skill across disciplines. In this tutorial, you will learn how to do this in Python by using the Bokeh and Pandas libraries. Specifically, we will work through visualizing and exploring aspects of WWII bombing runs conducted by Allied powers. 
+The ability to load raw data, sample it, and then visually explore and present it is a valuable skill across disciplines. In this tutorial, you will learn how to do this in Python by using the Bokeh and Pandas libraries. Specifically, we will work through visualizing and exploring aspects of WWII bombing runs conducted by Allied powers.
 
-At the end of the lesson you will be able to: 
+At the end of the lesson you will be able to:
 
 - Load tabular CSV data
 - Perform basic data manipulation, such as aggregating and sub-sampling raw data
@@ -47,7 +47,7 @@ The dataset used in this tutorial is contained in [thor_wwii.csv](https://raw.gi
 
 We'll use Bokeh and Pandas to address some of the following questions:
 
-- What types and weights of munitions were dropped during World War II (WWII)? What patterns can we discern in the use of different types of munitions? 
+- What types and weights of munitions were dropped during World War II (WWII)? What patterns can we discern in the use of different types of munitions?
 - How did the types and weights of munitions dropped change over the course of WWII? How do these changes correspond to major military events?
 - What targets were munitions dropped on during the war? Were particular types of munitions limited to certain theaters of operations or targets?
 
@@ -69,17 +69,17 @@ All three datasets contain comparable quantitative, qualitative, and temporal da
 
 This tutorial can be completed using any operating systems. It requires Python 3 and a web browser. You may use any text editor to write your code.
 
-This tutorial assumes that you have a basic knowledge of the Python language and its associated data structures, particularly lists. 
+This tutorial assumes that you have a basic knowledge of the Python language and its associated data structures, particularly lists.
 
-If you work in Python 2, you will need to create a virtual environment for Python 3, and even if you work in Python 3, creating a virtual environment for this tutorial is good practice. 
+If you work in Python 2, you will need to create a virtual environment for Python 3, and even if you work in Python 3, creating a virtual environment for this tutorial is good practice.
 
 ## Creating a Python 3 Virtual Environment
 
 A Python virutal environment is an isolated environment in which you can install libraries and execute code. Many different virtual evironments can be created to work with different versions of Python and Python libraries. Virtual environments are useful because they ensure you have only the necessary libraries installed and that you do not encounter version conflicts. An additional benefit of virtual environments is that you can pass them to others so that you know your code will execute on another machine.
 
-[Miniconda](https://conda.io/miniconda.html) is one easy way to create virtual environments that is simple to install across operating systems. You should download Miniconda and follow the instructions for [Windows](https://conda.io/docs/user-guide/install/windows.html), [Mac](https://conda.io/docs/user-guide/install/macos.html), or [Linux](https://conda.io/docs/user-guide/install/linux.html) as appropriate for your operating system.
+[Miniconda](https://conda.io/miniconda.html) is one easy way to create virtual environments that is simple to install across operating systems. You should download Miniconda and follow the instructions for [Windows](https://conda.io/projects/conda/en/latest/user-guide/install/windows.html), [Mac](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html), or [Linux](https://conda.io/projects/conda/en/latest/user-guide/install/linux.html) as appropriate for your operating system.
 
-Once you have downloaded and installed Miniconda for your operating system, you can check that it has installed correctly by opening a command line and typing: 
+Once you have downloaded and installed Miniconda for your operating system, you can check that it has installed correctly by opening a command line and typing:
 ```python
 conda info
 ```
@@ -94,7 +94,7 @@ We'll use Miniconda to create a Python 3 virtual environment named *bokeh-env* f
 ```python
 conda create --name bokeh-env python=3.6
 ```
-Say 'yes' when you are prompted to install new packages. 
+Say 'yes' when you are prompted to install new packages.
 
 To activate the *bokeh-env* virtual environment, the command differs slightly depending on your operating system.
 ```python
@@ -146,7 +146,7 @@ Bokeh is a library for creating interactive data visualizations in a web browser
 
 Matplotlib has existed since 2002 and has long been a standard of Python data visualization. Bokeh emerged in 2013. This difference in age means that Matplotlib matured long before Bokeh was released; however, in a short period of time, Bokeh has reached a high level of maturity.
 
-The intended uses of matplotlib and Bokeh are quite different. Matplotlib creates static graphics that are useful for quick and simple visualizations, or for creating publication quality images. Bokeh creates visualizations for display on the web (whether locally or embedded in a webpage) and most importantly, the visualizations are meant to be highly interactive. Matplotlib does not offer either of these features. 
+The intended uses of matplotlib and Bokeh are quite different. Matplotlib creates static graphics that are useful for quick and simple visualizations, or for creating publication quality images. Bokeh creates visualizations for display on the web (whether locally or embedded in a webpage) and most importantly, the visualizations are meant to be highly interactive. Matplotlib does not offer either of these features.
 
 If would you like to visually interact with your data in an exploratory manner or you would like to distribute interactive visual data to a web audience, Bokeh is the library for you! If your main interest is producing finalized visualizations for publication, matplotlib may be better, although Bokeh does offer a way to create static graphics.
 
@@ -154,11 +154,11 @@ With this differences in mind, as we work through the lesson, I'll emphasize the
 
 ## Your First Plot
 
-First, create a new file called `my_first_plot.py` in the same directory as  `wwii_thor.csv` and then open it up in a text editor. We'll be adding lines to this file to run. 
+First, create a new file called `my_first_plot.py` in the same directory as  `wwii_thor.csv` and then open it up in a text editor. We'll be adding lines to this file to run.
 
 ```python
 #my_first_plot.py
-from bokeh.plotting import figure, output_file, show	
+from bokeh.plotting import figure, output_file, show
 ```
 
 To implement and use Bokeh, we first import some basics that we need from the `bokeh.plotting` module.
@@ -190,11 +190,11 @@ p.triangle(y, x, color='gold', size=10, legend='triangle')
 
 {% include alert.html text="`p` is a common variable name for a `figure` object, since a figure is a type of plot." %}
 
-After instantiating the figure, we call the `circle` , `line`, and `triangle` methods to plot our data. These types of methods are known as a *glyph method*. The term *glyph* in Bokeh refers to the lines, circles, bars, and other shapes that are added to plots to display data. 
+After instantiating the figure, we call the `circle` , `line`, and `triangle` methods to plot our data. These types of methods are known as a *glyph method*. The term *glyph* in Bokeh refers to the lines, circles, bars, and other shapes that are added to plots to display data.
 
-If we wanted, we could just keep adding glyphs to the plot! In addition to the `circle`, `line`,   and `triangle` glyphs, there are many others, including:  `asterisk`, `circle_cross`, `circle_x`, `cross`, `diamond`, `diamond_cross`, `inverted_triangle`, `square`, `square_cross`, `square_x`, and `x`. 
+If we wanted, we could just keep adding glyphs to the plot! In addition to the `circle`, `line`,   and `triangle` glyphs, there are many others, including:  `asterisk`, `circle_cross`, `circle_x`, `cross`, `diamond`, `diamond_cross`, `inverted_triangle`, `square`, `square_cross`, `square_x`, and `x`.
 
-When calling a glyph method, at a minimum, we must pass the data we would like to plot, but frequently we might add styling arguments. Here, we set a size, color, and legend name for each glyph. 
+When calling a glyph method, at a minimum, we must pass the data we would like to plot, but frequently we might add styling arguments. Here, we set a size, color, and legend name for each glyph.
 
 ```python
 p.legend.click_policy='hide'
@@ -215,7 +215,7 @@ python my_first_plot.py
 
 {% include figure.html filename="visualizing-with-bokeh-1.png" caption="Plotting a Single Glyph" %}
 
-A web browser will now appear showing the html file with your visualization. The red circles, blue line, and gold triangles are the result of our glyph method calls. Clicking the legend in the upper right corner will show/hide each glyph type. Note that Bokeh has automatically handled the creation of the grid-lines and tick labels. 
+A web browser will now appear showing the html file with your visualization. The red circles, blue line, and gold triangles are the result of our glyph method calls. Clicking the legend in the upper right corner will show/hide each glyph type. Note that Bokeh has automatically handled the creation of the grid-lines and tick labels.
 
 Along the right-hand side, the default toolbar is also displayed. The tools include drag, box zoom, wheel zoom, save, reset, and help. Using these tools, a user can pan along the plot or zoom in on interesting portions of the data. Since this is a stand-alone HTML page, which includes a reference to BokehJS, it can be immediately passed to a co-worker for exploration or posted to the web.
 
@@ -268,11 +268,11 @@ The output should look like:
 ```
 Some of these column names are self explanatory, but it's worth pointing out the following: MSNDATE (mission date), NAF (numbered airforce responsible for mission), AC_ATTACKING (number of aircraft), TONS_HE (high-explosives), TONS_IC (incendiary devices), TONS_FRAG (fragmentation bombs).
 
-When it comes to accessing data within a `DataFrame`, in this tutorial we use one basic approach: indexing. Here to access a single column we pass a string to our dataframe's indexer: e.g. `df['MSNDATE']`.  To access multiple columns, we pass a list of names to our dataframe's indexer: e.g. `df[['MSNDATE', 'THEATER']]`. 
+When it comes to accessing data within a `DataFrame`, in this tutorial we use one basic approach: indexing. Here to access a single column we pass a string to our dataframe's indexer: e.g. `df['MSNDATE']`.  To access multiple columns, we pass a list of names to our dataframe's indexer: e.g. `df[['MSNDATE', 'THEATER']]`.
 
 ## The Bokeh ColumnDataSource
 
-Now that we've learned how to create a Bokeh plot and how to load tabular data into Pandas, it's time to learn how to link Pandas' `DataFrame` with Bokeh visualizations. The Bokeh object `ColumnDataSource` provides this integration. 
+Now that we've learned how to create a Bokeh plot and how to load tabular data into Pandas, it's time to learn how to link Pandas' `DataFrame` with Bokeh visualizations. The Bokeh object `ColumnDataSource` provides this integration.
 
 The object's constructor accepts a Pandas `DataFrame` as an argument. After it is created, the `ColumnDataSource` can then be passed to glyph methods via the `source` parameter and other parameters, such as our x and y data, can then reference column names within our source. Let's go through an example of this.
 
@@ -302,8 +302,8 @@ Since we don't want to plot all 170,000+ rows in our scatterplot (which would re
 
 ```python
 p = figure()
-p.circle(x='TOTAL_TONS', y='AC_ATTACKING', 
-         source=source, 
+p.circle(x='TOTAL_TONS', y='AC_ATTACKING',
+         source=source,
          size=10, color='green')
 ```
 Next, we create our `figure` object and call the `circle` glyph method to plot our data. This is where the `source` variable that holds our `ColumnDataSource` comes into play. It's passed as our `source` argument to the glyph method and the column names holding the number of attacking aircraft (AC_ATTACKING) and tons of munitions dropped (TOTAL_TONS) are passed as our `x` and `y` arguments.
@@ -341,15 +341,15 @@ Finally, we make sure to add the line to show the plot. Now we can run `column_d
 
 {% include figure.html filename="visualizing-with-bokeh-2.png" caption="Plotting with the ColumnDataSource and More Styling Options" %}
 
-Note that because we are randomly sampling the data, our plot will look different each time we run the code. 
+Note that because we are randomly sampling the data, our plot will look different each time we run the code.
 
-At the top and along the axes of the plot, we see the labels that we added. There is also a new tool in the toolbar. This is the hover tool that we added. To see it in action, hover over any data point in the scatterplot. A window will pop up showing the columns we set in our `tooltip` property! 
+At the top and along the axes of the plot, we see the labels that we added. There is also a new tool in the toolbar. This is the hover tool that we added. To see it in action, hover over any data point in the scatterplot. A window will pop up showing the columns we set in our `tooltip` property!
 
-Before moving to the next section of the lesson, try returning to the example above and adding/removing other variables and changing display names. 
+Before moving to the next section of the lesson, try returning to the example above and adding/removing other variables and changing display names.
 
 # Categorical Data and Bar Charts: Munitions Dropped by Country
 
-In the preceding example, we plotted quantitative data. Frequently, though, we want to plot categorical data. Categorical data, in contrast to quantitative, is data that can be divided into groups, but that does not necessarily have a numerical aspect to it. For example, while your height is numerical, your hair color is categorical. From the perspective of our dataset, features like attacking country hold categorical data, while features like the weight of munitions hold quantitative data. 
+In the preceding example, we plotted quantitative data. Frequently, though, we want to plot categorical data. Categorical data, in contrast to quantitative, is data that can be divided into groups, but that does not necessarily have a numerical aspect to it. For example, while your height is numerical, your hair color is categorical. From the perspective of our dataset, features like attacking country hold categorical data, while features like the weight of munitions hold quantitative data.
 
 In this section, we'll learn how to use categorical data as our x-axis values in Bokeh and how to use the `vbar` glyph method to create a vertical bar chart (an `hbar` glyph method functions similarly to create a horizontal bar chart). In addition, we'll learn about preparing categorical data in Pandas by grouping data. Further, we'll add to our knowledge of Bokeh styling and the hover tool.
 
@@ -372,7 +372,7 @@ df = pd.read_csv('thor_wwii.csv')
 ```
 First, we import the Pandas library and the basic elements from Bokeh (i.e. `figure`, `output_file`, `show`, and `ColumnDataSource`). We also make two new imports: `Spectral5` is a pre-made five color pallette, one of Bokeh's many [pre-made color palettes](https://bokeh.pydata.org/en/latest/docs/reference/palettes.html), and `factor_cmap` is a helper method for mapping colors to bars in a bar-charts.
 
-After the imports, we set our `output_file`  and load the thor_wwii.csv file into a `DataFrame`.   
+After the imports, we set our `output_file`  and load the thor_wwii.csv file into a `DataFrame`.
 
 We now need to get from the 170,000+ records of individual missions to one record per attacking country with the total munitions dropped.
 
@@ -381,13 +381,13 @@ grouped = df.groupby('COUNTRY_FLYING_MISSION')['TOTAL_TONS', 'TONS_HE', 'TONS_IC
 ```
 Pandas lets us do this in a single line of code by using the `groupby` dataframe method. This method accepts a column by which to group the data and one or more aggregating methods that tell Pandas how to group the data together. The output is a new dataframe.
 
-Let's take this one piece at a time. The `groupby('COUNTRY_FLYING_MISSION')` sets the column that we are grouping on. In other words, this says that we want the resulting dataframe to have one row per unique entry in the column `COUNTRY_FLYING_MISSION`. Since we don't care about aggregating all 19 columns in the dataframe, we choose just the tons of munitions columns with the indexer, `['TOTAL_TONS', 'TONS_HE', 'TONS_IC', 'TONS_FRAG']`. Finally, we use the `sum` method to let Pandas know how to aggregate all of the different rows. Other methods also exist for aggregating, such as `count`, `mean`, `max`, and `min`. 
+Let's take this one piece at a time. The `groupby('COUNTRY_FLYING_MISSION')` sets the column that we are grouping on. In other words, this says that we want the resulting dataframe to have one row per unique entry in the column `COUNTRY_FLYING_MISSION`. Since we don't care about aggregating all 19 columns in the dataframe, we choose just the tons of munitions columns with the indexer, `['TOTAL_TONS', 'TONS_HE', 'TONS_IC', 'TONS_FRAG']`. Finally, we use the `sum` method to let Pandas know how to aggregate all of the different rows. Other methods also exist for aggregating, such as `count`, `mean`, `max`, and `min`.
 
 If you execute `print(grouped)`, you'll see that Pandas has grouped by the five unique countries in our dataset and summed the total tons dropped by each. You can also see the dataset has some problems: South Africa and New Zealand dropped more high explosives than the total tons column. Problems like this are typical of large, manually-created datasets and this is a great reminder why is so important to explore and visualize your data before creating research results.
 
 ```
                         TOTAL_TONS     TONS_HE     TONS_IC  TONS_FRAG
-COUNTRY_FLYING_MISSION                                               
+COUNTRY_FLYING_MISSION
 AUSTRALIA                   479.89      453.90      13.600      18.64
 GREAT BRITAIN           1112598.95   868277.23  209036.158    1208.00
 NEW ZEALAND                2629.06     4263.70     166.500       0.00
@@ -415,7 +415,7 @@ To do this, we create a list of countries from our source object, using `source.
 
 
 ```python
-color_map = factor_cmap(field_name='COUNTRY_FLYING_MISSION', 
+color_map = factor_cmap(field_name='COUNTRY_FLYING_MISSION',
                     palette=Spectral5, factors=countries)
 
 p.vbar(x='COUNTRY_FLYING_MISSION', top='TOTAL_TONS', source=source, width=0.70, color=color_map)
@@ -427,7 +427,7 @@ p.yaxis.axis_label = 'Kilotons of Munitions'
 
 Now we plot our data as individually colored bars and add basic labels. To color our bars we use the `factor_cmap` helper function. This creates a special color map that matches an individual color to each category (i.e. what Bokeh calls a *factor*). The color map is then passed as the color argument to our `vbar` glyph method.
 
-For the data in our glyph method, we're passing a source and again referencing column names. Instead of using a `y` parameter, however, the `vbar` method takes a `top` parameter. A `bottom` parameter can equally be specified, but if left out, its default value is 0. 
+For the data in our glyph method, we're passing a source and again referencing column names. Instead of using a `y` parameter, however, the `vbar` method takes a `top` parameter. A `bottom` parameter can equally be specified, but if left out, its default value is 0.
 
 ```python
 hover = HoverTool()
@@ -441,7 +441,7 @@ p.add_tools(hover)
 show(p)
 ```
 
-We add a hover tool again, but now we see that we can use multiple data variables in a single line and add in our own text so the hover popup will list the kilotons of each type of explosive. The `hover.mode` is new. Three modes exist for the hover tool: `mouse`, `vline`, and `hline`. These tell the hover tool when to show the popup. `mouse` is the default value and shows a popup when directly over a glyph. `vline` and `hline` tell the popup to show when a vertical or horizontal line crosses a glyph. With `vline` set here, anytime your mouse passes through an imaginary vertical line extending from each bar, a popup will show. 
+We add a hover tool again, but now we see that we can use multiple data variables in a single line and add in our own text so the hover popup will list the kilotons of each type of explosive. The `hover.mode` is new. Three modes exist for the hover tool: `mouse`, `vline`, and `hline`. These tell the hover tool when to show the popup. `mouse` is the default value and shows a popup when directly over a glyph. `vline` and `hline` tell the popup to show when a vertical or horizontal line crosses a glyph. With `vline` set here, anytime your mouse passes through an imaginary vertical line extending from each bar, a popup will show.
 
 {% include figure.html filename="visualizing-with-bokeh-3.png" caption="A Bar Chart with Categorical Data and Coloring" %}
 
@@ -449,7 +449,7 @@ We add a hover tool again, but now we see that we can use multiple data variable
 
 # Stacked Bar Charts and Sub-sampling Data: Types of Munitions Dropped by Country
 
-Because the previous plot shows that the USA and Great Britain account for the overwhelming majority of bombings, we now focus on these two countries and learn how to make a stacked bar chart that shows the types of munitions each country used. 
+Because the previous plot shows that the USA and Great Britain account for the overwhelming majority of bombings, we now focus on these two countries and learn how to make a stacked bar chart that shows the types of munitions each country used.
 
 We'll start a new file called `munitions_by_country_stacked.py`
 
@@ -484,7 +484,7 @@ grouped = df.groupby('COUNTRY_FLYING_MISSION')['TONS_IC', 'TONS_FRAG', 'TONS_HE'
 grouped = grouped / 1000
 ```
 
-Now that we have reduced the dataframe to show only records for the USA and Great Britain, we group our data with `groupby` and aggregate the three columns that hold bomb types with `sum`. 
+Now that we have reduced the dataframe to show only records for the USA and Great Britain, we group our data with `groupby` and aggregate the three columns that hold bomb types with `sum`.
 
 ```python
 source = ColumnDataSource(grouped)
@@ -495,13 +495,13 @@ p = figure(x_range=countries)
 As in the previous example, we create a source object from our grouped data and make sure our figure uses categorical data for the x-axis by setting the `x_range` to the list of countries.
 
 ```python
-p.vbar_stack(stackers=['TONS_HE', 'TONS_FRAG', 'TONS_IC'], 
-             x='COUNTRY_FLYING_MISSION', source=source, 
+p.vbar_stack(stackers=['TONS_HE', 'TONS_FRAG', 'TONS_IC'],
+             x='COUNTRY_FLYING_MISSION', source=source,
              legend = ['High Explosive', 'Fragmentation', 'Incendiary'],
              width=0.5, color=Spectral3)
 ```
 
-To create the stacked bar chart, we call the `vbar_stack` glyph method. Rather than passing a single column name to a `y` parameter, we instead pass a list of column names as `stackers`. The order of this list determines the order that the columns will be stacked from bottom to top (after you've worked through this example, try switching the column order to see what happens). The `legend` argument supplies text for each stacker and the `Spectral3` palette provides colors for each stacker. 
+To create the stacked bar chart, we call the `vbar_stack` glyph method. Rather than passing a single column name to a `y` parameter, we instead pass a list of column names as `stackers`. The order of this list determines the order that the columns will be stacked from bottom to top (after you've worked through this example, try switching the column order to see what happens). The `legend` argument supplies text for each stacker and the `Spectral3` palette provides colors for each stacker.
 
 ```python
 p.title.text ='Types of Munitions Dropped by Allied Country'
@@ -552,11 +552,11 @@ p.yaxis.axis_label = 'Kilotons of Munitions Dropped'
 show(p)
 ```
 
-Take a minute to seriously look through this code and see what you recognize. Two items should stand out as new. 
+Take a minute to seriously look through this code and see what you recognize. Two items should stand out as new.
 
 First, the statement `df['MSNDATE'] = pd.to_datetime(df['MSNDATE'], format='%m/%d/%Y')` makes sure our MSNDATE column is a datetime. This is important because often data loaded from a csv file will not be properly typed as datetime. Supplying the `format` argument is not required, but doing so significantly speeds up the process.
 
-Second, we pass the argument `x_axis_type='datetime'` to our figure constructor to tell it that our x data will be datetimes. Otherwise, Bokeh works seamlessly with time data just like any other type of numerical data! 
+Second, we pass the argument `x_axis_type='datetime'` to our figure constructor to tell it that our x data will be datetimes. Otherwise, Bokeh works seamlessly with time data just like any other type of numerical data!
 
 Looking at the output, though, you might notice a major issue.
 
@@ -570,7 +570,7 @@ Thankfully, Pandas offers a quick and easy way to do this. By modifying a single
 
 Resampling time-series data can involve either upsampling (creating more records) or downsampling (creating fewer records). For example, a list of daily temperatures could be upsampled to a list of hourly temperatures or downsampled to a list of weekly temperatures. We'll only be downsampling in this tutorial, but upsampling is very useful when you're trying to match a sporadically-measured dataset with one that's more periodically measured.
 
-To resample our data, we use a Pandas `Grouper` object, to which we pass the column name holding our datetimes and a code representing the desired resampling frequency. In the case of our data, the statement `pd.Grouper(key='MSNDATE', freq='M') ` will be used to resample our MSNDATE column by *M*onth. We could equally resample by *W*eek, *Y*ear, *H*our, and [so forth](http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases). These frequency designations can also be prefaced with numbers so that, for example, `freq='2W'` resamples at two week intervals! 
+To resample our data, we use a Pandas `Grouper` object, to which we pass the column name holding our datetimes and a code representing the desired resampling frequency. In the case of our data, the statement `pd.Grouper(key='MSNDATE', freq='M') ` will be used to resample our MSNDATE column by *M*onth. We could equally resample by *W*eek, *Y*ear, *H*our, and [so forth](http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases). These frequency designations can also be prefaced with numbers so that, for example, `freq='2W'` resamples at two week intervals!
 
 To complete the process of resampling and plotting our data, we pass the above `Grouper` object to our `groupby` function in place of the raw column name. The `groupby` statement from the previous code example should now look like this:
 
@@ -627,11 +627,11 @@ show(p)
 
 {% include figure.html filename="visualizing-with-bokeh-7.png" caption="A Time-Series Plot of the ETO with Data Resampled to Months" %}
 
-A few patterns emerge in the ETO data. First we see a very clear escalation of overall bombings leading up to June 6, 1944 and a notable dip during the winter of 1944/1945. Incendiary munitions show three spikes and confirm that the fourth spike seen in the preceding example was directed at the bombing of Japan after Germany's surrender. The pattern of fragmentation bombs is harder to read, but it's now clear that they were only seriously used in the European Theater after D-Day. 
+A few patterns emerge in the ETO data. First we see a very clear escalation of overall bombings leading up to June 6, 1944 and a notable dip during the winter of 1944/1945. Incendiary munitions show three spikes and confirm that the fourth spike seen in the preceding example was directed at the bombing of Japan after Germany's surrender. The pattern of fragmentation bombs is harder to read, but it's now clear that they were only seriously used in the European Theater after D-Day.
 
 {% include alert.html text="Try your hand at resampling this data using any of [Pandas' time frequencies ](http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases) to see what other trends might emerge. Remember, you can preface these frequencies with numbers as well (e.g. if you were working with historical stock market data, 2Q would give you bi-quarterly data!)" %}
 
-Since we have established that 6 June 1944 and the winter of 1944/1945 mark changes to the bombing patterns in the ETO, let's highlight these trends using Bokeh's annotation features. 
+Since we have established that 6 June 1944 and the winter of 1944/1945 mark changes to the bombing patterns in the ETO, let's highlight these trends using Bokeh's annotation features.
 
 To do this, we'll create a `BoxAnnotation` and then add these to our `figure` before showing it. First, we need to add an additional import statement to our code.
 
@@ -639,14 +639,14 @@ To do this, we'll create a `BoxAnnotation` and then add these to our `figure` be
 from bokeh.models import BoxAnnotation
 ```
 
-To create the box, we first need to determine its coordinates. Coordinates for Bokeh annotations can be either absolute (i.e. positioned using screen units), meaning they always stay in one place, or they can be positioned in relation to data. Our annotations will all be positioned using data coordinates. 
+To create the box, we first need to determine its coordinates. Coordinates for Bokeh annotations can be either absolute (i.e. positioned using screen units), meaning they always stay in one place, or they can be positioned in relation to data. Our annotations will all be positioned using data coordinates.
 
 ```python
 box_left = pd.to_datetime('6-6-1944')
 box_right = pd.to_datetime('16-12-1944')
 ```
 
-The left of the box will be 6 June 1944 (D-Day) and for the right of the box we'll choose the first day of the Battle of the Bulge: 16 December 1944. In this case, the dates follow a month-day-year format, but `to_datetime` also works with [day-first and year-first formats](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.to_datetime.html). 
+The left of the box will be 6 June 1944 (D-Day) and for the right of the box we'll choose the first day of the Battle of the Bulge: 16 December 1944. In this case, the dates follow a month-day-year format, but `to_datetime` also works with [day-first and year-first formats](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.to_datetime.html).
 
 We pass these coordinates to the `BoxAnnotation` constructor along with some styling arguments. Then, we add it to the our figure using the `add_layout()` method.
 
@@ -680,7 +680,7 @@ from bokeh.models import ColumnDataSource, Range1d
 from bokeh.layouts import layout
 from bokeh.palettes import Spectral3
 from bokeh.tile_providers import CARTODBPOSITRON
-from pyproj import Proj, transform 
+from pyproj import Proj, transform
 output_file('mapping_targets.html')
 
 #helper function to convert lat/long to easting/northing for mapping
@@ -701,7 +701,7 @@ df['E'], df['N'] = zip(*df.apply(lambda x: LongLat_to_EN(x['TGT_LONGITUDE'], x['
 The boilerplate imports and our conversion function are defined. Next, we load our data and apply our conversion function to create new E and N columns that store our Web Mercator easting and northing.
 
 ```python
-grouped = df.groupby(['E', 'N'])['TONS_IC', 
+grouped = df.groupby(['E', 'N'])['TONS_IC',
 'TONS_FRAG'].sum().reset_index()
 
 filter = grouped['TONS_FRAG']!=0
@@ -710,7 +710,7 @@ grouped = grouped[filter]
 source = ColumnDataSource(grouped)
 ```
 
-Because a single target can appear in multiple records, we need to group the data by E and N to get unique target locations. Otherwise, we would map the same target every time it appears in a record. 
+Because a single target can appear in multiple records, we need to group the data by E and N to get unique target locations. Otherwise, we would map the same target every time it appears in a record.
 
 The `reset_index` function applied after aggregating is new here. By default, when Pandas groups these two columns it will make E and N the index for each row in the new dataframe. Since we just want E and N to remain as normal columns for mapping, we call `reset_index`.
 
@@ -723,7 +723,7 @@ top = 11000000
 p = figure(x_range=Range1d(left, right), y_range=Range1d(bottom, top))
 ```
 
-To set bounds for our map, we'll set a minimum and maximum value for our plot's `x_range` and `y_range`. We use the `Range1D` object, which represents bounded 1-dimensional data in Bokeh. 
+To set bounds for our map, we'll set a minimum and maximum value for our plot's `x_range` and `y_range`. We use the `Range1D` object, which represents bounded 1-dimensional data in Bokeh.
 
 ```python
 p.add_tile(CARTODBPOSITRON)

--- a/en/research.md
+++ b/en/research.md
@@ -18,7 +18,7 @@ The project team and members of the wider community are involved in a number of 
 ## Published Research
 * Katrina Navickas and Adam Crymble, ['From Chartist Newspaper to Digital Map of Grass-roots Meetings, 1841-44: Documenting Workflows'](http://www.tandfonline.com/doi/full/10.1080/13555502.2017.1301179), _Journal of Victorian Culture_, (2017).
 * Adam Crymble, ['Identifying and Removing Gender Barriers in Open Learning Communities: The Programming Historian'](http://researchprofiles.herts.ac.uk/portal/files/10476604/Blip_2016_Autumn_2016_Final_Autumn_2016.pdf), _Blended Learning in Practice_, (2016), 49-60. [[pre-print pdf](/researchpapers/openLearningCommunities2016.pdf)]
-* Fred Gibbs, ['Editorial Sustainability and Open Peer Review at Programming Historian',](http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian) _DH Commons_, Vol. 1 (2015).
+* Fred Gibbs, ['Editorial Sustainability and Open Peer Review at Programming Historian',](http://web.archive.org/web/20180713014622/http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian) _DH Commons_, Vol. 1 (2015).
 * Shawn Graham, Ian Milligan, and Scott Weingart, [_Exploring Big Historical Data: The Historian's Macroscope_](http://www.themacroscope.org/2.0/), (Imperial College Press, 2015).
 
 ## Workshops & Events
@@ -35,7 +35,7 @@ The project team and members of the wider community are involved in a number of 
 * Adam Crymble, 'Python Programming for Humanists', _Day of Digital Ideas_, University of Edinburgh (26 May 2015).
 
 ## Posters, Conference Papers, & Invited Talks
-* Afanador, Maria José. 'The Programming Historian en español: estrategias y retos para la construcción de una comunidad global de humanidades digitales.' Ponencia presentada en la Conferencia de Humanidades Digitales DH2018, Ciudad de México, México, (2018, junio). 
+* Afanador, Maria José. 'The Programming Historian en español: estrategias y retos para la construcción de una comunidad global de humanidades digitales.' Ponencia presentada en la Conferencia de Humanidades Digitales DH2018, Ciudad de México, México, (2018, junio).
 * Caleb McDaniel, 'Open Access, Transparent Peer Review', Annual Meeting of the Organizations of American Historians, Sacremento, California, (14 April 2018).
 * James Baker, '[The Programming Historian: Open Access, Open Source, Open Project](https://www.slideshare.net/drjwbaker/the-programming-historian-open-access-open-source-open-project)', Research Hive Seminar on 'Open publication: exploring alternative models and practices', University of Sussex (22 March 2018).
 * Adam Crymble, 'White, Male, and North American: Challenges of Diversifying the Programming Historian', Universit&eacute; de Lausanne, Switzerland (23-24 March 2017).

--- a/es/investigacion.md
+++ b/es/investigacion.md
@@ -68,6 +68,6 @@ El equipo del proyecto y los miembros de la comunidad en general están involucr
 [Review of the Programming Historian]: http://jitp.commons.gc.cuny.edu/review-of-the-programming-historian
 ['Identifying and Removing Gender Barriers in Open Learning Communities: The Programming Historian']: http://researchprofiles.herts.ac.uk/portal/files/10476604/Blip_2016_Autumn_2016_Final_Autumn_2016.pdf
 ['pre-print pdf']: /researchpapers/openLearningCommunities2016.pdf
-[Editorial Sustainability and Open Peer Review at Programming Historian]: http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian
+[Editorial Sustainability and Open Peer Review at Programming Historian]: http://web.archive.org/web/20180713014622/http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian
 ['Digital Project Consultations']: https://dhatasa2015.wordpress.com/
 [Library Carpentry: software skills training for library professionals]: https://www.liberquarterly.eu/articles/10176/

--- a/es/lecciones/escritura-sostenible-usando-pandoc-y-markdown.md
+++ b/es/lecciones/escritura-sostenible-usando-pandoc-y-markdown.md
@@ -113,16 +113,16 @@ date: 20 de enero de 2014
 El Markdown "Pandoc-flavored" almacena cada uno de los valores anteriores y los "imprime" en la ubicación apropiada de tu documento de salida una vez que está listo para la composición tipográfica. Más adelante aprenderemos a incluir campos más potentes en YAML. Por ahora, vamos a suponer que estamos escribiendo un documento compuesto por tres secciones, cada una subdividida en dos. Hay que dejar una línea en blanco después de los tres últimos guiones del bloque YAML para que puedas pegar lo que sigue:
 
 ```
-# Sección 1  
+# Sección 1
 
-## Subsección 1.1  
+## Subsección 1.1
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 El siguiente párrafo debe empezar como éste, sin sangría:
 
 ## Subsección 1.2
 Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque  ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-    
+
 # Sección 2
 
 ## Subsección 2.1
@@ -153,16 +153,16 @@ author: Gabriel García
 date: 20 de enero de 2014
 ---
 
-# Sección 1  
+# Sección 1
 
-## Subsección 1.1  
+## Subsección 1.1
 Lorem *ipsum* dolor sit amet, **consectetur** adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 El siguiente párrafo debe empezar como este, sin sangría:
 
 ## Subsección 1.2
 Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque  ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-    
+
 # Sección 2
 
 ## Subsección 2.1
@@ -333,7 +333,7 @@ Trata tus archivos de origen como versiones autorizadas de tu texto y los archiv
 
 ## Recursos útiles
 
-En caso de meterte en problemas no hay un mejor lugar para empezar a buscar soluciones que el [sitio web de Pandoc](http://johnmacfarlane.net/pandoc/) de John MacFarlane y la [lista de correos](https://groups.google.com/forum/#!forum/pandoc-discuss) afiliada (en inglés). Al menos en dos sitios de tipo "Pregunta y respuesta" puedes encontrar respuestas a preguntas sobre Pandoc: [Stack Overflow](http://stackoverflow.com/questions/tagged/pandoc) y [Digital Humanities Q&A](http://digitalhumanities.org/answers/). Puedes hacer preguntas en vivo en Freenode IRC, \#Pandoc channel, frecuentado por un amistoso grupo de asiduos. A medida que aprendas más acerca de Pandoc, puedes explorar una de sus particularidades más poderosa: [filtros](https://github.com/jgm/pandoc/wiki/Pandoc-Filters).
+En caso de meterte en problemas no hay un mejor lugar para empezar a buscar soluciones que el [sitio web de Pandoc](http://johnmacfarlane.net/pandoc/) de John MacFarlane y la [lista de correos](https://groups.google.com/forum/#!forum/pandoc-discuss) afiliada (en inglés). Al menos en dos sitios de tipo "Pregunta y respuesta" puedes encontrar respuestas a preguntas sobre Pandoc: [Stack Overflow](http://stackoverflow.com/questions/tagged/pandoc) y [Digital Humanities Q&A](http://web.archive.org/web/20190203062832/http://digitalhumanities.org/answers/). Puedes hacer preguntas en vivo en Freenode IRC, \#Pandoc channel, frecuentado por un amistoso grupo de asiduos. A medida que aprendas más acerca de Pandoc, puedes explorar una de sus particularidades más poderosa: [filtros](https://github.com/jgm/pandoc/wiki/Pandoc-Filters).
 
 Aunque te sugerimos comenzar con un simple editor de texto plano, hay muchas más alternativas (más de 70, de acuerdo con [esta entrada de blog](http://web.archive.org/web/20140120195538/http://mashable.com/2013/06/24/markdown-tools/) a MS Word para trabajar específicamente con Markdown, disponibles en línea y a menudo sin costo. Para las autónomas nos gustan [Mou](http://mouapp.com/), [Write Monkey](http://writemonkey.com), y [Sublime Text](http://www.sublimetext.com/). Varias plataformas web que han surgido recientemente proporcionan interfaces gráficas adecuadas para desarrollar una escritura colaborativa con seguimiento de cambios en las versiones utilizando Markdown. Éstas incluyen: [prose.io](http://prose.io), [Authorea](http://www.authorea.com), [Penflip](http://www.penflip.com), [Draft](http://www.draftin.com), y [StackEdit](https://stackedit.io).
 

--- a/fr/recherche.md
+++ b/fr/recherche.md
@@ -18,7 +18,7 @@ L'équipe du projet et les membres de la communauté plus large qui la compose s
 ## Publications scientifiques
 * Katrina Navickas et Adam Crymble, ['From Chartist Newspaper to Digital Map of Grass-roots Meetings, 1841-44: Documenting Workflows'](http://www.tandfonline.com/doi/full/10.1080/13555502.2017.1301179), _Journal of Victorian Culture_, (2017).
 * Adam Crymble, ['Identifying and Removing Gender Barriers in Open Learning Communities: The Programming Historian'](http://researchprofiles.herts.ac.uk/portal/files/10476604/Blip_2016_Autumn_2016_Final_Autumn_2016.pdf), _Blended Learning in Practice_, (2016), 49-60. [[pre-print pdf](/researchpapers/openLearningCommunities2016.pdf)]
-* Fred Gibbs, ['Editorial Sustainability and Open Peer Review at Programming Historian',](http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian) _DH Commons_, Vol. 1 (2015).
+* Fred Gibbs, ['Editorial Sustainability and Open Peer Review at Programming Historian',](http://web.archive.org/web/20180713014622/http://dhcommons.org/journal/issue-1/editorial-sustainability-and-open-peer-review-programming-historian) _DH Commons_, Vol. 1 (2015).
 * Shawn Graham, Ian Milligan et Scott Weingart, [_Exploring Big Historical Data: The Historian's Macroscope_](http://www.themacroscope.org/2.0/), (Imperial College Press, 2015).
 
 ## Ateliers et manifestations


### PR DESCRIPTION
I saw a bunch of 404 links today caused by the ongoing problems that ADHO is having with its various domains. I've switched almost everything over to the wayback links.

This also fixes a change in the paths of some Anaconda documentation linked to by one of our lessons.