### PR TITLE
Metadata spacing

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,11 +5,11 @@
 <footer role="contentinfo" style="background-color: {{site.data.snippets.background_color[page.lang] }}">
 
 
-<div class="d-flex justify-content-center footer-head">
+<div class="d-flex flex-wrap justify-content-center footer-head">
   {{ site.data.snippets.footer.license[page.lang] | markdownify }}
 </div>
 
-<div class="d-flex justify-content-around">
+<div class="d-flex flex-wrap justify-content-around">
   <div class="mx-4">
     {% for l in site.data.snippets.language-list %} {% if page.lang == l %}
     <strong>{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,16 +4,13 @@
 
 <footer role="contentinfo" style="background-color: {{site.data.snippets.background_color[page.lang] }}">
 
-<div class="container-fluid">
 
-<div class="row">
-  <div class="col-sm-12 footer-head">
-    {{ site.data.snippets.footer.license[page.lang] | markdownify }}
-  </div>
+<div class="d-flex justify-content-center footer-head">
+  {{ site.data.snippets.footer.license[page.lang] | markdownify }}
 </div>
 
-<div class="row">
-  <div class="col-sm-2">
+<div class="d-flex justify-content-around">
+  <div class="mx-4">
     {% for l in site.data.snippets.language-list %} {% if page.lang == l %}
     <strong>{% endif %}
       <p>
@@ -21,28 +18,27 @@
       </p>
       {% if page.lang == l %}</strong>{% endif %} {% endfor %}
   </div>
-  <div class="col-sm-2">
+  <div class="mx-4">
     <i class="fab fa-github" aria-hidden="true"></i>
     <a href="https://github.com/programminghistorian/jekyll">{{ site.data.snippets.footer.gh-hosted[page.lang] }}</a>
   </div>
 
-  <div class="col-sm-4">
+  <div class="mx-4">
   <i class="fa fa-calendar" aria-hidden="true"></i>
     <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages">{{ site.data.snippets.footer.last-updated[page.lang] }} {{ site.time | date_to_long_string }}</a>
   </div>
 
-  <div class="col-sm-2">
+  <div class="mx-4">
   <i class="fa fa-history" aria-hidden="true"></i>
   <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">{{ site.data.snippets.footer.rev-history[page.lang] }}</a>
   </div>
 
-  <div class="col-sm-2">
+  <div class="mx-4">
   <i class="fa fa-bolt" aria-hidden="true"></i>
   <a href="{{site.baseurl}}{{ site.data.snippets.menu-contribute-feedback[page.lang].link }}">{{ site.data.snippets.footer.suggestion[page.lang] }}</a>
   </div>
 
   </div>
-</div>
 
 </footer>
 

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -63,9 +63,17 @@ layout: base
 
   <div class="container-fluid header-helpers">
   <div class="container expanded">
-    <div class="d-flex flex-wrap justify-content-between">
-      <div class="mr-auto">
-        <h3 class="text-left">{{site.data.snippets.editor[page.lang]}}</h3>
+  {% comment %}
+  If the page is an original, and thus has no translator info, wrap the editor & reviewer in a smaller column
+  {% endcomment %}
+  {% unless page.original %}
+    <div class="col-6 p-0 m-0">
+  {% else %}
+    <div>
+  {% endunless %}
+    <div class="d-flex flex-wrap flex-md-row flex-column justify-content-between">
+      <div>
+        <h3>{{site.data.snippets.editor[page.lang]}}</h3>
         <ul>
         {% for editor in page.editors %}
           <li>{{editor}}</li>
@@ -73,8 +81,8 @@ layout: base
         </ul>
       </div>
 
-      <div class="mr-auto">
-        <h3 class="text-left">{{site.data.snippets.reviewers[page.lang]}}</h3>
+      <div>
+        <h3>{{site.data.snippets.reviewers[page.lang]}}</h3>
           <ul>
           {% for reviewer in page.reviewers %}
             <li>{{reviewer}}</li>
@@ -83,8 +91,8 @@ layout: base
       </div>
 
       {% if page.translator %}
-      <div class="mr-auto">
-        <h3 class="text-left">{{site.data.snippets.translator[page.lang]}}</h3>
+      <div>
+        <h3>{{site.data.snippets.translator[page.lang]}}</h3>
         <ul>
         {% for translator in page.translator %}
           <li>{{translator}}</li>
@@ -94,8 +102,8 @@ layout: base
       {% endif %}
 
       {% if page.translation-editor %}
-      <div class="mr-auto">
-        <h3 class="text-left">{{site.data.snippets.translation-editors[page.lang]}}</h3>
+      <div>
+        <h3>{{site.data.snippets.translation-editors[page.lang]}}</h3>
         <ul>
         {% for translation-editor in page.translation-editor %}
           <li>{{translation-editor}}</li>
@@ -106,7 +114,7 @@ layout: base
 
       {% if page.translation-reviewer %}
       <div>
-        <h3 class="text-left">{{site.data.snippets.translation-reviewers[page.lang]}}</h3>
+        <h3>{{site.data.snippets.translation-reviewers[page.lang]}}</h3>
         <ul>
         {% for editor in page.translation-reviewer %}
           <li>{{editor}}</li>
@@ -114,7 +122,7 @@ layout: base
         </ul>
       </div>
       {% endif %}
-
+    </div>
     </div>
     </div> <!-- end row -->
   </div>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -121,7 +121,7 @@ layout: base
 
   <div class="container-fluid header-bottom">
     <div class="container expanded">
-      <div class="d-flex flex-wrap justify-content-between">
+      <div class="d-flex flex-wrap flex-md-row flex-column justify-content-between">
       <div class="metarow"><h4>{{site.data.snippets.published[page.lang]}}</h4> {{ page.date | date:"%Y-%m-%d" }}</div>
       {% if page.translation_date %}
       <div class="metarow"><h4>{{site.data.snippets.translated-date[page.lang]}}</h4> <span id="translated-date">{{ page.translation_date | date:"%Y-%m-%d" }}</span></div>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -39,27 +39,20 @@ layout: base
         </div>
 
         <div class="container expanded">
-          <div class="row">
-            <div class="col-md-3">
-              {% if page.reviewers or page.review-ticket %}
-              <div class="peer-review">
-                <p>
-                {% if page.review-ticket %}
-                <a href="{{ page.review-ticket }}">{% endif %}<i class="fas fa-user-check"></i> {{ site.data.snippets.peer-review[page.lang] }}{% if page.review-ticket %}</a>{% endif %}
-                </p>
-              </div>
-              </div>
-              {% endif %}
-
-              {% if page.reviewers or page.review-ticket %}
-              <div class="col-md-3">
-              {% else %}
-              <div class="col-md-8">
-              {% endif %}
-              <div class="open-license">
-                <p><a href="https://creativecommons.org/licenses/by/4.0/deed.en"><i class="fas fa-lock-open"></i> CC-BY 4.0</a></p>
-              </div>
-              </div>
+          <div class="row d-flex justify-content-left">
+            {% if page.reviewers or page.review-ticket %}
+            <div class="peer-review mr-5">
+              <p>
+              {% if page.review-ticket %}<a href="{{ page.review-ticket }}">{% endif %}
+              <i class="fas fa-user-check"></i> {{ site.data.snippets.peer-review[page.lang] }}
+              {% if page.review-ticket %}</a>{% endif %}
+              </p>
+            </div>
+            {% endif %}
+            <div class="open-license mr-5">
+              <p><a href="https://creativecommons.org/licenses/by/4.0/deed.en"><i class="fas fa-lock-open"></i> CC-BY 4.0</a></p>
+            </div>
+          </div>
           </div>
         </div>
 
@@ -68,18 +61,10 @@ layout: base
   </div>
 </div>
 
-{% capture editor-style %}{% if page.translator %}col-md-3{% else %}col-md-4 offset-md-4{% endif %}{% endcapture %}
-{% capture reviewers-style %}{% if page.translator %}col-md-3{% else %}col-md-4{% endif %}{% endcapture %}
-{% capture date-style %}{% if page.translation_date %}col-md-3{% else %}col-md-4{% endif %}{% endcapture %}
-
-
   <div class="container-fluid header-helpers">
-
-    <div class="container expanded">
-
-    <div class="row">
-
-      <div class="{{editor-style}}">
+  <div class="container expanded">
+    <div class="d-flex flex-wrap justify-content-between">
+      <div class="mr-5">
         <h3 class="text-left">{{site.data.snippets.editor[page.lang]}}</h3>
         <ul>
         {% for editor in page.editors %}
@@ -88,7 +73,7 @@ layout: base
         </ul>
       </div>
 
-      <div class="{{reviewers-style}}" >
+      <div class="mr-5">
         <h3 class="text-left">{{site.data.snippets.reviewers[page.lang]}}</h3>
           <ul>
           {% for reviewer in page.reviewers %}
@@ -98,7 +83,7 @@ layout: base
       </div>
 
       {% if page.translator %}
-      <div class="col-md-2" >
+      <div class="mr-5">
         <h3 class="text-left">{{site.data.snippets.translator[page.lang]}}</h3>
         <ul>
         {% for translator in page.translator %}
@@ -109,7 +94,7 @@ layout: base
       {% endif %}
 
       {% if page.translation-editor %}
-      <div class="col-md-2" >
+      <div class="mr-5">
         <h3 class="text-left">{{site.data.snippets.translation-editors[page.lang]}}</h3>
         <ul>
         {% for translation-editor in page.translation-editor %}
@@ -120,7 +105,7 @@ layout: base
       {% endif %}
 
       {% if page.translation-reviewer %}
-      <div class="col-md-2" >
+      <div class="mr-5">
         <h3 class="text-left">{{site.data.snippets.translation-reviewers[page.lang]}}</h3>
         <ul>
         {% for editor in page.translation-reviewer %}
@@ -136,17 +121,17 @@ layout: base
 
   <div class="container-fluid header-bottom">
     <div class="container expanded">
-      <div class="row">
-      <div class="{{ date-style }} metarow"><h4>{{site.data.snippets.published[page.lang]}}</h4> {{ page.date | date:"%Y-%m-%d" }}</div>
+      <div class="d-flex flex-wrap justify-content-between">
+      <div class="metarow"><h4>{{site.data.snippets.published[page.lang]}}</h4> {{ page.date | date:"%Y-%m-%d" }}</div>
       {% if page.translation_date %}
-      <div class="{{ date-style }} metarow"><h4>{{site.data.snippets.translated-date[page.lang]}}</h4> <span id="translated-date">{{ page.translation_date | date:"%Y-%m-%d" }}</span></div>
+      <div class="metarow"><h4>{{site.data.snippets.translated-date[page.lang]}}</h4> <span id="translated-date">{{ page.translation_date | date:"%Y-%m-%d" }}</span></div>
       {% endif %}
       {% if page.retired %}
-      <div class="{{ date-style }} metarow"><h4>{{site.data.snippets.retired-date[page.lang]}}</h4> <span id="retired-date">{{ page.retired_date | date:"%Y-%m-%d" }}</span></div>
+      <div class="metarow"><h4>{{site.data.snippets.retired-date[page.lang]}}</h4> <span id="retired-date">{{ page.retired_date | date:"%Y-%m-%d" }}</span></div>
       {% else %}
-      <div class="{{ date-style }} metarow"><h4>{{site.data.snippets.modified[page.lang]}}</h4> <span id="modified-date">{{ page.date | date:"%Y-%m-%d" }}</span></div>
+      <div class="metarow"><h4>{{site.data.snippets.modified[page.lang]}}</h4> <span id="modified-date">{{ page.date | date:"%Y-%m-%d" }}</span></div>
       {% endif %}
-      <div class="{{ date-style }} metarow"><h4>{{site.data.snippets.difficulty[page.lang]}}</h4> {% include difficulty.html %}</div>
+      <div class="metarow"><h4>{{site.data.snippets.difficulty[page.lang]}}</h4> {% include difficulty.html %}</div>
     </div>
     </div>
   </div>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -49,7 +49,7 @@ layout: base
               </p>
             </div>
             {% endif %}
-            <div class="open-license mr-5">
+            <div class="open-license">
               <p><a href="https://creativecommons.org/licenses/by/4.0/deed.en"><i class="fas fa-lock-open"></i> CC-BY 4.0</a></p>
             </div>
           </div>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -64,7 +64,7 @@ layout: base
   <div class="container-fluid header-helpers">
   <div class="container expanded">
     <div class="d-flex flex-wrap justify-content-between">
-      <div class="mr-5">
+      <div class="mr-auto">
         <h3 class="text-left">{{site.data.snippets.editor[page.lang]}}</h3>
         <ul>
         {% for editor in page.editors %}
@@ -73,7 +73,7 @@ layout: base
         </ul>
       </div>
 
-      <div class="mr-5">
+      <div class="mr-auto">
         <h3 class="text-left">{{site.data.snippets.reviewers[page.lang]}}</h3>
           <ul>
           {% for reviewer in page.reviewers %}
@@ -83,7 +83,7 @@ layout: base
       </div>
 
       {% if page.translator %}
-      <div class="mr-5">
+      <div class="mr-auto">
         <h3 class="text-left">{{site.data.snippets.translator[page.lang]}}</h3>
         <ul>
         {% for translator in page.translator %}
@@ -94,7 +94,7 @@ layout: base
       {% endif %}
 
       {% if page.translation-editor %}
-      <div class="mr-5">
+      <div class="mr-auto">
         <h3 class="text-left">{{site.data.snippets.translation-editors[page.lang]}}</h3>
         <ul>
         {% for translation-editor in page.translation-editor %}
@@ -105,7 +105,7 @@ layout: base
       {% endif %}
 
       {% if page.translation-reviewer %}
-      <div class="mr-5">
+      <div>
         <h3 class="text-left">{{site.data.snippets.translation-reviewers[page.lang]}}</h3>
         <ul>
         {% for editor in page.translation-reviewer %}

--- a/css/style.css
+++ b/css/style.css
@@ -216,7 +216,6 @@ Lesson Headers
 
   header li, header .metarow {
     font: .9rem/1.1rem 'Roboto Condensed';
-    margin: 0;
   }
 
   header .metarow {


### PR DESCRIPTION
This closes #1106 by using bootstrap's flexbox utilities instead of relying on a complicated series of if/else tags to place lesson metadata based on whether the lesson was an original, or a translation (and thus had a lot of additional contributor names to attach to it)

The only remaining bit of if/else logic comes for original lessons, giving a more defined space to the editor and reviewer metadata.