### PR TITLE
sort by translation date if it exists, otherwise use pub date

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -217,7 +217,7 @@ sort-by-date:
   en:
     sort by publication date
   es:
-    ordenar por fecha de traducción
+    ordenar por fecha de publicación
   fr:
     trier par date de publication
 sort-by-difficulty:

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -26,7 +26,7 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   <p class="abstract">{{ lesson.abstract | markdownify }}</p>
 
   {% comment %}
- Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is based on the later of publication date or translation date.
+ Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is based on translation date first, falling back to publication date.
 {% endcomment %}
   <span class="activity">{{ lesson.activity }}</span>
   <span class="topics">{{ lesson.topics | join: ' '}}</span>

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -26,11 +26,11 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   <p class="abstract">{{ lesson.abstract | markdownify }}</p>
 
   {% comment %}
- Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is publication date for english lesson, and translation date for spanish lessons.
+ Activity and topic are hidden via CSS as a hack to let JS sorting by activity and topic work. Note that the date sort is based on the later of publication date or translation date.
 {% endcomment %}
   <span class="activity">{{ lesson.activity }}</span>
   <span class="topics">{{ lesson.topics | join: ' '}}</span>
-  <span class="date">{% if lesson.lang == "es" %}{{ lesson.translation_date }}{% else %}{{ lesson.date }}{% endif %}</span>
+  <span class="date">{% if lesson.translation_date %}{{ lesson.translation_date }}{% else %}{{ lesson.date }}{% endif %}</span>
   <span class="difficulty">{{ lesson.difficulty }}</span>
 
 </div>

--- a/_plugins/validate_yaml.rb
+++ b/_plugins/validate_yaml.rb
@@ -138,6 +138,11 @@ module MyModule
               lesson_errors.push("'#{f}' is missing.")
             end
           end
+
+          # Check that translation date is later than publication date
+          unless p.data["translation_date"] > p.data["date"]
+            lesson_errors.push("translation_date is earlier than original publication date.")
+          end
         end
 
         # Check original lesson required fields


### PR DESCRIPTION
Closes #1251

This adjusts the code that creates the "sort date" when rendering a lesson page. IF a lesson has a translated date, that's the sorting date. If it is an original lesson without a translation date, then the sort date will be the publication date.

@programminghistorian/spanish-team needs to update the `sort-by-date` entry in `_snippets.yml`.