### PR TITLE
Revise yaml template to make more user friendly

### DIFF
--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -224,32 +224,32 @@ The following code should be added into the text of the lesson, usually before t
 ### 3) Add YAML metadata to the lesson file
 
 ```
-title: ["YOUR TITLE HERE"]
+title: "Your Title Here"
 collection: lessons
 layout: lesson
-slug: [e.g. introduction-to-sentiment-analysis]
-date: [YYYY-MM-DD]
-translation_date: [YYYY-MM-DD (translations only)]
+slug: e.g. introduction-to-sentiment-analysis
+date: YYYY-MM-DD
+translation_date: YYYY-MM-DD (translations only)
 authors:
-- [FORENAME SURNAME 1]
-- [FORENAME SURNAME 2, etc]
+- Forename Surname
+- Forename Surname etc
 reviewers:
-- [FORENAME SURNAME 1]
-- [FORENAME SURNAME 2, etc]
+- Forename Surname
+- Forename Surname etc
 editors:
-- [FORENAME SURNAME]
+- Forename Surname
 translator:
-- [FORENAME SURNAME (translations only)]
+- Forename Surname (translations only)
 translation-editor:
-- [FORNAME SURNAME (translations only)]
+- Forename Surname (translations only)
 translation-reviewer:
-- [FORNAME SURNAME (translations only)]
-original: [slug to original published lesson (translations only)]
-review-ticket: [e.g. https://github.com/programminghistorian/ph-submissions/issues/108]
-difficulty: [see guidance below]
-activity: [ONE OF: acquiring, transforming, analyzing, presenting, sustaining]
-topics: [see guidance below]
-abstract: [see guidance below]
+- Forename Surname (translations only)
+original: slug to original published lesson (translations only)
+review-ticket: e.g. https://github.com/programminghistorian/ph-submissions/issues/108
+difficulty: see guidance below
+activity: ONE OF: acquiring, transforming, analyzing, presenting, sustaining
+topics: see guidance below
+abstract: see guidance below
 
 ```
 

--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -248,7 +248,9 @@ original: slug to original published lesson (translations only)
 review-ticket: e.g. https://github.com/programminghistorian/ph-submissions/issues/108
 difficulty: see guidance below
 activity: ONE OF: acquiring, transforming, analyzing, presenting, sustaining
-topics: see guidance below
+topics: 
+ - topic one (see guidance below)
+ - topic two
 abstract: see guidance below
 
 ```

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -275,7 +275,9 @@ translation-reviewer:
 original: slug del original ((solo en traducción))
 difficulty: (ver abajo o mantener original en traducciones)
 activity: (ver abajo o mantener original en traducciones)
-topics: (ver abajo o mantener original en traducciones)
+topics: 
+ - tema uno
+ - tema dos (ver abajo o mantener original en traducciones)
 abstract: "(ver abajo o traducir el original)"
 ---
 ```

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -251,32 +251,32 @@ Observa el siguiente ejemplo para apreciar cómo debe verse el encabezado YAML d
 ```
 ---
 title: |
-	[Título de la lección]
+	Título de la lección
 collection: lessons
 layout: lesson
-slug: [e.g. introduccion-al-analisis-de-sentimientos]
-date: [Fecha original, YYYY-MM-DD]
-translation_date: [Fecha de traducción, YYYY-MM-DD]
+slug: e.g. introduccion-al-analisis-de-sentimientos
+date: (Fecha original) YYYY-MM-DD
+translation_date: (Fecha de traducción) YYYY-MM-DD
 authors:
-- [Nombre del autor 1]
-- [Nombre del autor 2, etc.]
+- Nombre del autor
+- Nombre del autor etc.
 editors:
-- [Nombre del editor original]
+- Nombre del editor original
 reviewers:
-- [Nombre del revisor original 1]
-- [Nombre del revisor original 2]
+- Nombre del revisor original
+- Nombre del revisor original
 translator:
-- [Nombre del traductor (solo en traducción)]
+- Nombre del traductor (solo en traducción)
 translation-editor:
-- [Nombre del editor de la traducción (solo en traducción)]
+- Nombre del editor de la traducción (solo en traducción)
 translation-reviewer:
-- [Nombre del revisor de la traducción 1 (solo en traducción)]
-- [Nombre del revisor de la traducción 2 (solo en traducción)]
-original: [slug del original ((solo en traducción))]
-difficulty: [(ver abajo o mantener original en traducciones)]
-activity: [(ver abajo o mantener original en traducciones)]
-topics: [(ver abajo o mantener original en traducciones)]
-abstract: "[(ver abajo o traducir el original)]"
+- Nombre del revisor de la traducción 1 (solo en traducción)
+- Nombre del revisor de la traducción 2 (solo en traducción)
+original: slug del original ((solo en traducción))
+difficulty: (ver abajo o mantener original en traducciones)
+activity: (ver abajo o mantener original en traducciones)
+topics: (ver abajo o mantener original en traducciones)
+abstract: "(ver abajo o traducir el original)"
 ---
 ```
 

--- a/fr/consignes-redacteurs.md
+++ b/fr/consignes-redacteurs.md
@@ -238,7 +238,9 @@ original: slug to original published lesson (champ spécifique aux traductions)
 review-ticket: e.g. https://github.com/programminghistorian/ph-submissions/issues/108
 difficulty: voir ci-dessous
 activity: UNIQUEMENT UN PARMI: acquiring, transforming, analyzing, presenting, sustaining
-topics: voir ci-dessous
+topics: 
+ - sujet un (voir ci-dessous)
+ - sujet deux
 abstract: voir ci-dessous
 
 ```

--- a/fr/consignes-redacteurs.md
+++ b/fr/consignes-redacteurs.md
@@ -214,32 +214,32 @@ Le code suivant doit être ajouté au texte de la leçon, habituellement avant l
 ### 3) Ajouter les métadonnées en YAML dans le fichier de la leçon
 
 ```
-title: ["VOTRE TITRE"]
+title: "Votre Titre"
 collection: lecons
 layout: lesson
-slug: [par ex. introduction-analyse-des-sentiments]
-date: [AAAA-MM-JJ]
-translation_date: [AAAA-MM-JJ (champ spécifique aux traductions)]
+slug: par ex. introduction-analyse-des-sentiments
+date: AAAA-MM-JJ
+translation_date: AAAA-MM-JJ (champ spécifique aux traductions)
 authors:
-- [PRÉNOM NOM 1]
-- [PRÉNOM NOM 2, etc]
+- Prénom Nom
+- Prénom Nom, etc
 reviewers:
-- [PRÉNOM NOM 1]
-- [PRÉNOM NOM 2, etc]
+- Prénom Nom
+- Prénom Nom, etc
 editors:
-- [PRÉNOM NOM]
+- Prénom Nom
 translator:
-- [PRÉNOM NOM (champ spécifique aux traductions)]
+- Prénom Nom (champ spécifique aux traductions)
 translation-editor:
-- [PRÉNOM NOM (champ spécifique aux traductions)]
+- Prénom Nom (champ spécifique aux traductions)
 translation-reviewer:
-- [PRÉNOM NOM (champ spécifique aux traductions)]
-original: [slug to original published lesson (champ spécifique aux traductions)]
-review-ticket: [e.g. https://github.com/programminghistorian/ph-submissions/issues/108]
-difficulty: [voir ci-dessous]
-activity: [UNIQUEMENT UN PARMI: acquiring, transforming, analyzing, presenting, sustaining]
-topics: [voir ci-dessous]
-abstract: [voir ci-dessous]
+- Prénom Nom (champ spécifique aux traductions)
+original: slug to original published lesson (champ spécifique aux traductions)
+review-ticket: e.g. https://github.com/programminghistorian/ph-submissions/issues/108
+difficulty: voir ci-dessous
+activity: UNIQUEMENT UN PARMI: acquiring, transforming, analyzing, presenting, sustaining
+topics: voir ci-dessous
+abstract: voir ci-dessous
 
 ```
 


### PR DESCRIPTION
Closes #1339 - removes [] from the YAML templates of all 3 languages. Also uses title case to prevent confusion for authors filling in the template. Should reduce the errors caused by [] in previewing the lesson.