### PR TITLE
add privacy policy

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -42,6 +42,16 @@ menu-about-research:
   fr:
     title: Recherche
     link: /fr/recherche
+menu-about-privacy:
+  en:
+    title: Privacy Policy
+    link: /en/privacy-policy
+  es:
+    title: Privacy Policy
+    link: /en/privacy-policy
+  fr:
+    title: Privacy Policy
+    link: /en/privacy-policy
 menu-contribute:
   en: Contribute
   es: Contribuciones

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -42,6 +42,8 @@ match the new entry you made in `_data/snippets.yml`
             role="menuitem">{{site.data.snippets.menu-about-team[page.lang].title}}</a>
           <a class="dropdown-item" href="{{site.baseurl}}{{site.data.snippets.menu-about-research[page.lang].link}}"
             role="menuitem">{{site.data.snippets.menu-about-research[page.lang].title}}</a>
+          <a class="dropdown-item" href="{{site.baseurl}}{{site.data.snippets.menu-about-privacy[page.lang].link}}"
+            role="menuitem">{{site.data.snippets.menu-about-privacy[page.lang].title}}</a>
           <a class="dropdown-item" href="{{ site.data.snippets.menu-translation-concordance[page.lang].link}}"
             role="menuitem">{{site.data.snippets.menu-translation-concordance[page.lang].title}}</a>
         </div>

--- a/en/privacy-policy.md
+++ b/en/privacy-policy.md
@@ -7,7 +7,7 @@ layout: blank
 
 ## Publishing Data
 
-As an open access publisher committed to openness, Programming Historian collects a number of pieces of information about authors, translators, editors, and reviewers. This information is publicly displayed in the following file: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>, and is also used to populate various pages of our website with relevant information (eg, an author's name and bio).
+As an open access publisher committed to openness, *Programming Historian* collects a number of pieces of information about authors, translators, editors, and reviewers. This information is publicly displayed in the following file: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>, and is also used to populate various pages of our website with relevant information (eg, an author's name and bio).
 
 Depending on one's role, the data collected may include:
 
@@ -28,7 +28,7 @@ If you wish to contact us to discuss any data we may have about you, you can ema
 
 ## Google Analytics Data
 
-The Programming Historian also collects web traffic data. We use this data to identify the needs of our visitors, to identify types of lessons that are in high demand in certain geographic regions, to promote the success of the project with potential funders, partners, and outside bodies through summary statistics, and to conduct and publish research about digital humanities and teaching and learning.
+The *Programming Historian* also collects web traffic data. We use this data to identify the needs of our visitors, to identify types of lessons that are in high demand in certain geographic regions, to promote the success of the project with potential funders, partners, and outside bodies through summary statistics, and to conduct and publish research about digital humanities and teaching and learning.
 
 None of the data collected by Google Analytics allows us to identify individuals.
 

--- a/en/privacy-policy.md
+++ b/en/privacy-policy.md
@@ -1,0 +1,59 @@
+---
+title: Privacy Policy
+layout: blank
+---
+
+# Privacy Policy
+
+## Publishing Data
+
+As an open access publisher committed to openness, Programming Historian collects a number of pieces of information about authors, translators, editors, and reviewers. This information is publicly displayed in the following file: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>, and is also used to populate various pages of our website with relevant information (eg, an author's name and bio).
+
+Depending on one's role, the data collected may include:
+
+- Name
+- Personal or Professional website address
+- Twitter handle
+- Github username
+- Year of joining the editorial board
+- Year of leaving the editorial board
+- Editorial board roles, if any
+- Institutional affiliation
+- A short biography, usually supplied by the author/editor
+- An ORCID
+
+In keeping with our open ethos, and to express our gratitude to authors, translators reviewers, and editors, we publicly acknowledge the names of all individuals who participate in one of these activities on the published lesson, and on our Project Team page (and its translations).
+
+If you wish to contact us to discuss any data we may have about you, you can email our managing editor. You have the right to withdraw your consent to our use of this data, however, it should be noted that Right to Erasure may not apply to authors of a submitted article as we have a legitimate interest in keeping your data to identify you as the author of a published and indexed text.
+
+## Google Analytics Data
+
+The Programming Historian also collects web traffic data. We use this data to identify the needs of our visitors, to identify types of lessons that are in high demand in certain geographic regions, to promote the success of the project with potential funders, partners, and outside bodies through summary statistics, and to conduct and publish research about digital humanities and teaching and learning.
+
+None of the data collected by Google Analytics allows us to identify individuals.
+
+Google Analytics sets a number of "cookies" on your computer when you visit the website. These may include:
+
+`_ga`, `_gat`
+
+You can block this using the "Do Not Track" settings in your browser
+
+`_utmv`
+
+This cookie is used by Google Analytics to determine the type of visitor that visits our website. The cookie determines the user's preferences based on which webpages they visit, so that we may use this data to understand which are the most popular webpages and why people visit the website.
+
+`__utmz`
+
+This cookie is used by Google Analytics to determine the type of referral used by each visitor to arrive at our website. The cookie determines if the user has come directly to our website or via a search engine, e-mail or e-mail campaign. We use this data to understand how our users arrive at our website.
+
+`__utma`
+
+This cookie is used to identify unique visitors to our website. The results are sent to our Google Analytics account, so that we can see how many unique visitors come to the site over a period of time.
+
+`__utmb`
+
+This cookie is used by Google Analytics to determine the visitor session times on our website. Each time you visit a new webpage on the website, the cookie is set to expire within 30 minutes. If it does not find an existing cookie, a new one is created.
+
+`__utmc`
+
+This cookie is used by Google Analytics in conjunction with __utmb to determine visitor sessions. Unlike __utmb, this cookie does not have an expiry date. It determines whether a new session should be created based on whether you have previously closed your browser, re-opened it and come back to the website.

--- a/en/privacy-policy.md
+++ b/en/privacy-policy.md
@@ -56,4 +56,4 @@ This cookie is used by Google Analytics to determine the visitor session times o
 
 `__utmc`
 
-This cookie is used by Google Analytics in conjunction with __utmb to determine visitor sessions. Unlike __utmb, this cookie does not have an expiry date. It determines whether a new session should be created based on whether you have previously closed your browser, re-opened it and come back to the website.
+This cookie is used by Google Analytics in conjunction with `__utmb` to determine visitor sessions. Unlike `__utmb`, this cookie does not have an expiry date. It determines whether a new session should be created based on whether you have previously closed your browser, re-opened it and come back to the website.


### PR DESCRIPTION
Closes #1321 

This PR is a preview of a privacy policy for _The Programming Historian_.

https://deploy-preview-1353--ph-dev.netlify.com/en/privacy-policy

During the 2019-06-26 meeting, we thought that because this would be a significant translation task, we may publish the english version first (since it is most pressing) and then open translation tasks to be completed by @programminghistorian/spanish-team  and @programminghistorian/french-team when they have the capacity. Please let us know if this is ok.