### PR TITLE
Add Communication Team Roles

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -42,7 +42,6 @@
         Adam Crymble est maître de conférences en histoire numérique à l'Université du Hertfordshire.
   team_roles:
    - editorial
-   - community
    - board
 
 - name: Caleb McDaniel
@@ -589,7 +588,6 @@
         Brandon Walsh est responsable des programmes des deuxième et troisième cycles au Scholar's Lab de l'Université de Virginie.
   team_roles:
    - editorial
-   - community
    - board
    - twitter-dev
    - communication

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -591,6 +591,7 @@
    - editorial
    - community
    - board
+   - twitter-dev
 
 - name: Ted Dawson
   team: false
@@ -784,6 +785,7 @@
   team_roles:
    - editorial
    - board
+   - ed-manager
 
 - name: Evan Peter Williamson
   team: false

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -592,6 +592,7 @@
    - community
    - board
    - twitter-dev
+   - communication
 
 - name: Ted Dawson
   team: false
@@ -786,6 +787,7 @@
    - editorial
    - board
    - ed-manager
+   - communication
 
 - name: Evan Peter Williamson
   team: false
@@ -909,7 +911,7 @@
     - spanish
     - board
     - technical
-    - communication
+    - communication-manager
 
 - name: Jon MacKay
   team: false

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -103,12 +103,12 @@
   definition:
     en: Responsible for coordinating efforts of the communication team
     es: Responsable de la coordinación del equipo de comunicación
-    fr:
+    fr: Responsable de la coordination de l'équipe de communication
 - type: communication
   label:
     en: Communication Team
     es: Equipo de comunicación
-    fr:
+    fr: Équipe de communication
   definition:
     en: Responsible for managing and developing communication channels
     es: Responsable del mantenimiento y creación de canales de comunicación
@@ -117,29 +117,29 @@
   label:
     en: Twitter Developer
     es: Desarrollador de Twitter
-    fr:
+    fr: Développeur Twitter
   definition:
     en: Responsible for maintaining the Programming Historian Twitter bot
     es: Responsable del mantenimiento del bot del Twitter de Programming Historian
-    fr:
+    fr: Responsable de la maintenance du bot Twitter du Programming Historian
 - type: ed-manager
   label:
     en: Education Manager
     es: Mánager de educación 
-    fr:
+    fr: Responsable pédagogique
   definition:
     en: Responsible for the overall education aspect of the project
     es: Responsable del aspecto educativo general del proyecto 
-    fr:
+    fr: Responsable des aspects pédagogiques du projet
 - type: impact-manager
   label:
     en: Impact Manager
     es: Mánager de impacto 
-    fr:
+    fr: Responsable de la valorisation
   definition:
     en: Supports, coordinates, and enhances research impact and analytics
     es: Apoya, coordina y amplía la investigación y análisis del impacto del proyecto
-    fr:
+    fr: Accompagne, coordonne et appuie la valorisation et les travaux d'analyse du projet 
 # --- Derived roles ---
 - type: ombuds-es
   label:

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -98,16 +98,16 @@
 - type: communication-manager
   label:
     en: Communication Manager
-    es: Manger de comunicación
+    es: Mánager de comunicación
     fr: Responsable de la communication
   definition:
-    en: Responsible for coordinating efforts of the communications team
-    es:
+    en: Responsible for coordinating efforts of the communication team
+    es: Responsable de la coordinación del equipo de comunicación
     fr:
 - type: communication
   label:
     en: Communication Team
-    es:
+    es: Equipo de comunicación
     fr:
   definition:
     en: Responsible for managing and developing communication channels
@@ -116,29 +116,29 @@
 - type: twitter-dev
   label:
     en: Twitter Developer
-    es:
+    es: Desarrollador de Twitter
     fr:
   definition:
     en: Responsible for maintaining the Programming Historian Twitter bot
-    es:
+    es: Responsable del mantenimiento del bot del Twitter de Programming Historian
     fr:
 - type: ed-manager
   label:
     en: Education Manager
-    es:
+    es: Mánager de educación 
     fr:
   definition:
     en: Responsible for the overall education aspect of the project
-    es:
+    es: Responsable del aspecto educativo general del proyecto 
     fr:
 - type: impact-manager
   label:
     en: Impact Manager
-    es:
+    es: Mánager de impacto 
     fr:
   definition:
     en: Supports, coordinates, and enhances research impact and analytics
-    es:
+    es: Apoya, coordina y amplía la investigación y análisis del impacto del proyecto
     fr:
 # --- Derived roles ---
 - type: ombuds-es

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -41,15 +41,6 @@
     en: Responsible for editorial work resulting in the review and publication of French-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
     fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en français
-- type: community
-  label:
-    en: Community Engagement
-    es: Proyección hacia la comunidad
-    fr: Engagement communautaire
-  definition:
-    en: Responsible for project outreach and impact
-    es: Responsable de la proyección e impacto del proyecto
-    fr: Responsable de la diffusion et de l'impact du projet
 - type: managing-en
   label:
     en: Managing Editor

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -103,7 +103,7 @@
   definition:
     en: Responsible for managing relationships with our sponsors
     es: Responsable de coordinar las relaciones con las y los patrocinadores
-    fr: Personne chargée des relations avec les sponsors du projet 
+    fr: Personne chargée des relations avec les sponsors du projet
 - type: communication
   label:
     en: Communication Manager
@@ -112,7 +112,34 @@
   definition:
     en: Responsible for managing and developing communication channels
     es: Responsable del mantenimiento y creación de canales de comunicación
-    fr: Responsable de la gestion et du développement des canaux de communication    
+    fr: Responsable de la gestion et du développement des canaux de communication
+- type: twitter-dev
+  label:
+    en: Twitter Developer
+    es:
+    fr:
+  definition:
+    en: Responsible for maintaining the Programming Historian Twitter bot
+    es:
+    fr:
+- type: ed-manager
+  label:
+    en: Education Manager
+    es:
+    fr:
+  definition:
+    en: Responsible for the overall education aspect of the project
+    es:
+    fr:
+- type: impact-manager
+  label:
+    en: Impact Manager
+    es:
+    fr:
+  definition:
+    en: Supports, coordinates, and enhances research impact and analytics
+    es:
+    fr:
 # --- Derived roles ---
 - type: ombuds-es
   label:

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -104,11 +104,20 @@
     en: Responsible for managing relationships with our sponsors
     es: Responsable de coordinar las relaciones con las y los patrocinadores
     fr: Personne chargée des relations avec les sponsors du projet
-- type: communication
+- type: communication-manager
   label:
     en: Communication Manager
     es: Manger de comunicación
     fr: Responsable de la communication
+  definition:
+    en: Responsible for coordinating efforts of the communications team
+    es:
+    fr:
+- type: communication
+  label:
+    en: Communication Team
+    es:
+    fr:
   definition:
     en: Responsible for managing and developing communication channels
     es: Responsable del mantenimiento y creación de canales de comunicación


### PR DESCRIPTION
refs #1327.

@mdlincoln can you take a quick look and make sure I honored the YML setup you have going on? I also wasn't sure if we wanted an overarching label for the teams in addition to the roles themselves. This PR adds creates the roles discussed in #1327 and adds them to @amsichani @jenniferisasi and myself. But it does not also create an overarching "communications team" role. Let me know if we need that. 

Once @mdlincoln approves we can ping the Spanish and French teams to translate the few sentences here.