### PR TITLE
Added privacy policy in Spanish

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -48,7 +48,7 @@ menu-about-privacy:
     link: /en/privacy-policy
   es:
     title: Política de privacidad
-    link: es/politica-de-privacidad
+    link: /es/politica-de-privacidad
   fr:
     title: Privacy Policy
     link: /en/privacy-policy

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -48,7 +48,7 @@ menu-about-privacy:
     link: /en/privacy-policy
   es:
     title: Política de privacidad
-    link: /es/politica-de-privacidad
+    link: es/politica-de-privacidad
   fr:
     title: Privacy Policy
     link: /en/privacy-policy

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -47,8 +47,8 @@ menu-about-privacy:
     title: Privacy Policy
     link: /en/privacy-policy
   es:
-    title: Privacy Policy
-    link: /en/privacy-policy
+    title: Política de privacidad
+    link: /es/politica-de-privacidad
   fr:
     title: Privacy Policy
     link: /en/privacy-policy

--- a/es/politica-de-privacidad.md
+++ b/es/politica-de-privacidad.md
@@ -1,0 +1,62 @@
+```
+---
+title: Política de privacidad
+layout: blank
+---
+```
+
+# Política de privacidad
+
+## Datos de publicación
+
+Como publicación en acceso abierto comprometida con la transparencia, *Programming Historian* recopila cierta información sobre los autores, traductores, editores y revisores. Esta información se muestra de manera pública en el siguiente archivo:  https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml y también se utiliza para completar varias páginas de nuestro sitio web con información relevante (por ejemplo, el nombre de una autora y su biografía).
+
+Dependiendo del papel de cada cual, los datos recopilados pueden incluir: 
+
+- Nombre
+- Información de sitio web personal o profesional
+- Nombre de usuario/a de Twitter
+- Nombre de usuario/a de Github
+- Año de incorporación al equipo editorial
+- Año de baja del equipo editorial
+- Papel en el equipo editorial, si procede
+- Afiliación institucional
+- Una biografía breve, normalmente proporcionada por los autores o los editores
+- Un ORCID
+
+De acuerdo con nuestro espíritu abierto y para expresar nuestra gratitud a autores, traductores, revisores y editores reconocemos públicamente todos los nombres de los participantes en alguna de estas actividades en las lecciones publicadas y en nuestra página del Equipo del Proyecto (y sus traducciones). 
+
+Si deseas ponerte en contacto para hablar sobre algún dato que podamos tener sobre ti, puedes enviar un email al jefe o la jefa de redacción. Tienes derecho a retirar tu permiso para usar tus datos, sin embargo,  el Derecho a Borrado puede no aplicar a autores de artículos enviados ya que estamos interesados en mantener tus datos para identificarte como autor de un texto publicado e indexado. 
+
+## Datos de Google Analytics
+
+*Programming Historian* también recoge datos de tráfico web. Utilizamos estos datos para identificar las necesidades de nuestros/as usuarios/as, para identificar el tipo de lecciones que presentan gran demanda en ciertas regiones geográficas, para promover el éxito del proyecto con proveedores de fondos, colaboradores y entidades externas mediante resúmenes estadísticos, y para realizar y publicar investigación sobre las humanidades digitales, la enseñanza y el aprendizaje. 
+
+Ninguno de los datos recogidos por Google Analytics nos permite identificar a individuos concretos. 
+
+Google Analytics establece una serie de "cookies" en tu ordenador cuando visitas nuestra página web. Estas pueden incluir: 
+
+`_ga`, `_gat`
+
+Puedes bloquear esto usando la configuración de "No monitorizar" en tu navegador.
+
+`_utmv`
+
+Google Analytics utiliza esta cookie para determinar el tipo de usuario que visita nuestro sitio web. La cookie determina las preferencias de los usuarios basándose en las páginas web que visitan y utilizar así dichos datos para entender qué páginas son las más populares y por qué la gente las visita.
+
+`__utmz`
+
+Google Analytics utiliza esta cookie para determinar el tipo de referencia usada por cada usuario para llegar a nuestra página web. La cookie determina si el/la visitante viene directamente a nuestra web o mediante un buscador, un email o una campaña de emails. Utilizamos estos datos para entender cómo llegan a nuestra página nuestras visitas. 
+
+`__utma`
+
+Esta cookie se utiliza para identificar visitantes únicos en nuestra página web. Los resultados se envían a nuestra cuenta de Google Analytics para que podamos ver cuántas visitas únicas recibimos a lo largo del tiempo.
+
+`__utmb`
+
+Google Analytics utiliza esta cookie para determinar el tiempo de sesión del usuario en nuestra web. Cada vez que visitas una nueva página en nuestro sitio web, la cookie se configura para expirar en los siguientes 30 minutos. Si no encuentra una cookie existente, crea una nueva. 
+
+`__utmc`
+
+Google Analytics utiliza esta cookie junto con `__utmb` para determinar las sesiones de visita. A diferencia de  `__utmb`, esta cookie no expira. Determina la creación de una sesión nueva basándose en si has cerrado el navegador anteriormente, si lo has re-abierto y regresado a nuestra página web. 
+

--- a/es/politica-de-privacidad.md
+++ b/es/politica-de-privacidad.md
@@ -1,15 +1,14 @@
-```
 ---
 title: Política de privacidad
+original: privacy-policy
 layout: blank
 ---
-```
 
 # Política de privacidad
 
 ## Datos de publicación
 
-Como publicación en acceso abierto comprometida con la transparencia, *Programming Historian* recopila cierta información sobre los autores, traductores, editores y revisores. Esta información se muestra de manera pública en el siguiente archivo:  https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml y también se utiliza para completar varias páginas de nuestro sitio web con información relevante (por ejemplo, el nombre de una autora y su biografía).
+Como publicación en acceso abierto comprometida con la transparencia, *Programming Historian* recopila cierta información sobre los autores, traductores, editores y revisores. Esta información se muestra de manera pública en el siguiente archivo:  <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml> y también se utiliza para completar varias páginas de nuestro sitio web con información relevante (por ejemplo, el nombre de una autora y su biografía).
 
 Dependiendo del papel de cada cual, los datos recopilados pueden incluir: 
 


### PR DESCRIPTION
Follows Issue #1360 , a translation of the privacy policy already published in English. Needs review from a Spanish team member to merge. 
