### PR TITLE
Issue 1330 -  Project Development Team setup

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -43,6 +43,7 @@
   team_roles:
    - editorial
    - board
+   - team-development-manager
 
 - name: Caleb McDaniel
   team: false
@@ -277,9 +278,9 @@
    - editorial
    - board
    - archive
-   - treasurer
    - sponsorship
    - technical
+   - finance-manager
 
 - name: Amanda Morton
   team: false
@@ -791,6 +792,7 @@
    - ed-manager
    - communication
    - technical
+   - project-manager-at-large
 
 - name: Evan Peter Williamson
   team: false

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -149,6 +149,33 @@
     en: Supports, coordinates, and enhances research impact and analytics
     es: Apoya, coordina y amplía la investigación y análisis del impacto del proyecto
     fr: Accompagne, coordonne et appuie la valorisation et les travaux d'analyse du projet 
+- type: finance-manager
+  label:
+    en: Finance Manager
+    es: Mánager de finanzas 
+    fr: Responsable des finances
+  definition:
+    en: Responsible for project finances and fundraising
+    es: Responsable de las finanzas del proyecto y la recaudación de fondos
+    fr: Responsable du financement du projet et de la collecte de fonds     
+- type: team-development-manager
+  label:
+    en: Team Development Manager
+    es: Mánager de desarrollo de equipo 
+    fr: Responsable du développement de l'équipe
+  definition:
+    en: Responsible for ensuring that everyone on the team is well supported
+    es: Responsable de asegurar que todos en el equipo estén bien apoyados
+    fr: Responsable de s'assurer que tous les membres de l'équipe sont bien soutenus 
+- type: project-manager-at-large
+  label:
+    en: Project Manager at Large
+    es: Mánager de proyectos en grande 
+    fr: Chef de projet en général
+  definition:
+    en: Keeping the team focused on achieving its goals in a timely manner
+    es: Mantener al equipo enfocado en lograr sus objetivos de manera oportuna
+    fr: Garder l'équipe concentrée sur la réalisation de ses objectifs en temps opportun
 # --- Derived roles ---
 - type: ombuds-es
   label:

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -165,17 +165,17 @@
     fr: Responsable du développement de l'équipe
   definition:
     en: Responsible for ensuring that everyone on the team is well supported
-    es: Responsable de asegurar que todos en el equipo estén bien apoyados
-    fr: Responsable de s'assurer que tous les membres de l'équipe sont bien soutenus 
+    es: Responsable de asegurar que todos en el equipo sean apoyados
+    fr: Responsable de s'assurer que tous les membres de l'équipe reçoivent le soutien nécessaire 
 - type: project-manager-at-large
   label:
     en: Project Manager at Large
-    es: Mánager de proyectos en grande 
-    fr: Chef de projet en général
+    es: Mánager de proyectos en general
+    fr: Chef de projet
   definition:
     en: Keeping the team focused on achieving its goals in a timely manner
-    es: Mantener al equipo enfocado en lograr sus objetivos de manera oportuna
-    fr: Garder l'équipe concentrée sur la réalisation de ses objectifs en temps opportun
+    es: Mantener al equipo enfocado en lograr sus objetivos de manera puntual
+    fr: Garder l'équipe concentrée sur la réalisation de ses objectifs à l'intérieur des délais prévus
 # --- Derived roles ---
 - type: ombuds-es
   label:


### PR DESCRIPTION
Closes #1330 - Project Development Team Setup.

I've added the new role descriptions to  the relevant files. To speed things up I've also attempted to add Spanish and French translations to the descriptions (using Google Translate). As  this may not be  sufficient, can someone who speaks those languages please either vet or request changes to the following  translations:

- type: finance-manager
  label:
    en: Finance Manager
    es: Mánager de finanzas 
    fr: Responsable des finances
  definition:
    en: Responsible for project finances and fundraising
    es: Responsable de las finanzas del proyecto y la recaudación de fondos
    fr: Responsable du financement du projet et de la collecte de fonds     
- type: team-development-manager
  label:
    en: Team Development Manager
    es: Mánager de desarrollo de equipo 
    fr: Responsable du développement de l'équipe
  definition:
    en: Responsible for ensuring that everyone on the team is well supported
    es: Responsable de asegurar que todos en el equipo estén bien apoyados
    fr: Responsable de s'assurer que tous les membres de l'équipe sont bien soutenus 
- type: project-manager-at-large
  label:
    en: Project Manager at Large
    es: Mánager de proyectos en grande 
    fr: Chef de projet en général
  definition:
    en: Keeping the team focused on achieving its goals in a timely manner
    es: Mantener al equipo enfocado en lograr sus objetivos de manera oportuna
fr: Garder l'équipe concentrée sur la réalisation de ses objectifs en temps opportun