### PR TITLE
Issue 1367 - New English Author Guidelines (Stylesheet)

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -12,7 +12,7 @@ skip_validation: true
 <img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
 <h2 class="noclear">Step 1: <a href="#step-1-proposing-a-new-lesson">Proposing a New Lesson</a></h2>
 <h2 class="noclear">Step 2: <a href="#step-2-writing-a-new-lesson">Writing and Formatting a New Lesson</a></h2>
-<h2 class="noclear">Step 3: <a href="#step-3-submitting-a-new-lesson">Submitting a New Lesson</a></h2>
+<h2 class="noclear">Step 3: <a href="#step-3-submitting-a-new-lesson">Submitting a New Lesson</a></h2>  
 
 
 These guidelines have been developed to help you understand the process of creating a tutorial for the English version of *Programming Historian*. They include practical and philosophical details of the tutorial writing process, as well as an indication of the workflow and the peer review process. If at any time you are unclear, please email the managing editor, {% include managing-editor.html lang=page.lang %}.
@@ -163,7 +163,7 @@ The guideline is to use them sparingly in the running prose. Specific rules:
     *	**Religion**: Upper case for Anglican, Baptist, Buddhist, Catholic, Christian, Hindu, Methodist, Muslim, Protestant, Roman Catholic, Sikh, but lower for evangelicals, charismatics, atheists.
     *	**Holy Books (select)**:
         *	**Bible**: Capitalise if referring to Old or New Testament.
-        *	**Buddhist**: sutras (sermons) and abhidhamma (analysis and interpretation). For Tibetan Buddhismthere are also tantric texts and the Tibetan Book of the Dead.
+        *	**Buddhist**: sutras (sermons) and abhidhamma (analysis and interpretation). For Tibetan Buddhism there are also tantric texts and the Tibetan Book of the Dead.
         *	**Hindu**: the Śruti texts: Vedas, Samhitas, Brahmanas, Aranyakas, Upanishads; the Vedāngas, Hindu epics, Sutras, Shastras, philosophical texts, the Puranas, the Kāvya, the Bhasyas, many Nibandhas.
         *	**Judaism**: the Tanakh (Torah, Nevi'im, Ketuvim), Talmud (Mishnah, Gemara)
         *	**Qu'ran**: Capitalise. Texts include the Hadith, the Tawrat (Torah), Zabur (possibly Psalms), Injil (1.2 billion).

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -14,330 +14,336 @@ skip_validation: true
 <h2 class="noclear">Step 2: <a href="#writing-a-new-lesson">Writing and Formatting a New Lesson</a></h2>
 <h2 class="noclear">Step 3: <a href="#submitting-a-new-lesson">Submitting a New Lesson</a></h2>
 
-## Proposing a New Lesson
 
-If you have an idea for a new lesson, or have already written a tutorial that you think could be adapted for the *Programming Historian*, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and contact {% include managing-editor.html lang=page.lang %} to discuss your idea. Getting in touch at an early stage will help you frame your lesson--especially identifying a target audience and expected skill level--and to pair you with the most appropriate editor.
+These guidelines have been developed to help you understand the process of creating a tutorial for the English version of *Programming Historian*. They include practical and philosophical details of the tutorial writing process, as well as an indication of the workflow and the peer review process. If at any time you are unclear, please email the managing editor, {% include managing-editor.html lang=page.lang %}.
+
+## Step 1: Proposing a New Lesson
 
 <div class="alert alert-success">
-We welcome tutorials relevant for the humanities, pitched at any level of technical aptitude and experience that focus on one problem or process, can be sustainable in the long term, and are addressed to a global audience. The scope and length of the tutorial should be appropriate to the complexity of the task being taught. Tutorials should not exceed 8,000 words (including code) without the explicit permission of the editor, which will be granted only in exceptional circumstances. We expect that most lessons will be between 4,000 and 6,000 words. Longer lessons may need to be split into multiple tutorials.
+We welcome tutorials relevant to the humanities, pitched at any level of technical aptitude and experience, that focus on one problem or process, can be sustainable in the long term, and are addressed to a global audience. 
+
+The scope and length of the tutorial should be appropriate to the complexity of the task. Tutorials should not exceed 8,000 words (including code). Shorter lessons are welcome. Longer lessons may need to be split into multiple tutorials.
 </div>
 
-You can get a better sense of what we publish by looking through our [published lessons], reading our [reviewer guidelines] or browsing the [lessons currently in development](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons). We encourage lesson proposals on topics already covered or in development, provided that the new lesson makes its own unique contribution.
+If you have an idea for a new lesson, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and send it to {% include managing-editor.html lang=page.lang %}. 
 
-To aid in the sustainability of our lessons, authors should seek to submit lessons that are not overly dependent upon specific software or user interfaces. These lessons inevitably break or need substantial revision when a new version comes out. Teaching concepts rather than 'click on the _x_ button' helps make for sustainable tutorials.
+You can get a sense of what we publish by looking through our [published lessons]({{site.baseurl}}/en/lessons), reading our [reviewer guidelines]({{site.baseurl}}/en/reviewer-guidelines) or browsing [lessons in development](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons).
 
-Once your proposal is accepted, an editor will create a "Proposal" ticket in our [submissions repository](https://github.com/programminghistorian/ph-submissions/issues) with the lesson's working title and proposed learning outcomes. This ticket serves to mark the work in progress while you are writing your lesson. To avoid a backlog in the system, we ask that you submit your lesson within 90 days of the proposal being accepted.
+If your proposal is accepted, an editor will create a "Proposal" page on our [submissions website](https://github.com/programminghistorian/ph-submissions/issues) with the lesson's working title and proposed learning outcomes. This serves to mark the work in progress. To ensure timely publication, authors should submit their draft article within 90 days.
+
+During this 90 day period, your point of contact will be the managing editor or an editor delegated at the managing editor's perogative.
+
+--
+
+## Step 2: Writing and Formatting a New Lesson
+This style guide lays out a set of standards for authors to use when creating or translating English-language lessons for *Programming Historian*. By using it, you help us ensure content is consistent and accessible.
+
+It is presented in three sections which should be read before and after writing:
+
+* A. Style and Audience
+* B. Specific Style Guidelines
+* C. Formatting Guidelines
+
+## A. Style and Audience
+This first section is concerned with big-picture matters of style which will help you make decisions that meet the needs of our audience and editors. They include basic information on style and tone, open access and open source values, information on writing for a global audience, writing sustainably, and making smart choices about data used in lessons. Read this section when planning your lesson. Read it again before submitting to make sure your lesson meets these requirements.
+
+### Language and Style
+*	Tutorials should not exceed 8,000 words (including code).
+*	Keep your tone formal but accessible.
+*	Talk to your reader in the second person (you).
+*	Adopt a widely-used version of English (British, Canadian, Indian, South African etc).
+*	The piece of writing is a "tutorial" or a "lesson" and not an "article".
+
+### Open Source, Open Access
+*Programming Historian* is committed to open source values. All lessons must use open source programming languages and software whenever possible. This policy is meant to minimize costs for all parties, and to allow the greatest possible level of participation.
+
+Upon acceptance, you agree to publish your lesson under a Creative Commons "[CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en)" license.
+
+### Write for a Global Audience
+*Programming Historian* readers live all around the world. Authors can and should take steps to write their lesson accessibly for as many people as possible. Follow these global-facing guidelines:
+
+*	Write for someone who doesn't live in your country or share your beliefs.
+
+*	**Technical Terms:** should always be linked to [Wikipedia](https://www.wikipedia.org/) or a suitably reliable dictionary or sustainable website in the first instance. A technical term is any word that a person on the street may not know or understand.
+*	**Cultural References**: mentions of persons, organisations, or historical details should always come with contextual information. Assume no prior knowledge, even of widely known cultural references (eg, [the Beatles](https://en.wikipedia.org/wiki/The_Beatles)). Use generic terms rather than trademarks (tissue rather than Kleenex). Links to [Wikipedia](https://www.wikipedia.org/) should be used liberally. Be aware that historical events often have different names in different countries.
+*	**Idioms**: Avoid jokes, puns, plays on words, idiomatic expressions, sarcasm, emojis, jargon, terms unique to your dialect, or language that is more difficult than it needs to be.
+*	**Geography**: when referencing places, be specific. Does "south-west" mean Valencia? Canada? Africa? Always write out the full name of the area the first time you use it.
+*	**Multi-lingual**: when choosing methods or tools, make choices with multi-lingual readers in mind – especially for textual analysis methods, which may not support other character sets or may only provide intellectually robust results when used on English texts. Where possible, choose approaches that have multi-lingual documentation, or provide multi-lingual references for further reading. This will help our translators.
+*	**Racial and Ethnic Language**: use racial terminology carefully and with specificity. Historic terms no longer in use should be used only in their historical context and only when necessary. Use racial terms as adjectives and not nouns: white people rather than "whites", an Asian woman rather than "an Asian". Be aware that terms may be understood differently in different countries and what you have learned to be correct or sensitive may be culturally specific to your country (eg, not all people with African ancestry are "African Americans". Some of them are African, or black British, or Caribbean, etc). Likewise, readers in the UK will understand "Asian" (India, Pakistan, Bangladesh) differently than those in North America (eg China, Japan, Vietnam, Thailand).
+*	**Visual Representations**: choose primary sources, images, figures, and screen shots, considering how they will present themselves to a global audience.
+
+### Sustainable Writing
+*Programming Historian* publishes lessons for the long-term. Please follow these sustainability guidelines when writing:
+
+ *	**As General as Possible, but No More**: focus on methodologies and generalities, not software/interface specifics (eg avoid telling users to "click the X button", which may be different in future versions).
+ *	**Reduce Reliance on Unsustainable Elements**: use screenshots sparingly and with purpose. Interfaces change frequently and future readers may be confused. Chose external links with the future in mind. Does the site you are linking to change often? Will it exist in ten years?
+ *	**Specify Versions if they are Important**: be clear about any version-specific details readers will need to know in order to follow your lesson. Eg, do you need Python v.2, or will any version be fine?
+ *	**Point to Documentation**: direct readers to reliable documentation where possible. Provide general guidance on how to find the documentation if new versions are probable in future.
+ *	**Copies of Data**: all data used in lessons must be published with the lesson on *Programming Historian* servers along with your lesson. You must ensure you have the legal right to publish a copy of any data that you use. Data files should use open formats.
+
+Authors should consult our [lesson retirement policy]({{site.baseurl}}/en/lesson-retirement-policy) for information on how the editorial team manages lessons that have become out-of-date.
+
+## B. Specific Writing Guidelines
+This second section covers more specific matters of writing style, such as which words to use, or how we use punctuation, or what format to use for dates or numbers. Read this section before and after writing your draft.
+
+### Dates and Time
+ *	For centuries, use eighteenth century not 18th century. Avoid national-centric phrases such as "long eighteenth century" which have specific meaning to British eighteenth century specialists, but not to anyone else.
+ *	For decades, write the 1950s (not "the 1950s" or "the fifties").
+ *	Compress date sequences as follows; 1816-17, 1856-9, 1854-64.
+ *	For dates written in numeric form, use the format YYYY-MM-DD, which conforms to the standard ISO 8601:2004. This avoids ambiguity.
+ *	Use BCE/CE not BC/AD for dates (eg 325BCE).
+ *	1am, 6:30pm. Not 10 o’clock.
+
+### Numbers
+ *	Spell out from one to nine; integers above 10.
+ *	Use a consistent format if the boundary outlined above is crossed within a single sentence (five apples and one hundred oranges; 5 apples and 110 oranges).
+ *	Use commas (not periods/full stops) between groups of three digits in large numbers (32,904 not 32904). Exceptions: page numbers, addresses, in quotation, etc.
+ *	Use numerals for versions (version 5 or v.5) or actual values (eg, 5%, 7″, $6.00).
+ *	Always use the symbol % with numerals rather than the spelled-out word (percent), and make sure it is closed up to number: 0.05%.
+ *	Use [LaTeX formatting for mathematical formulae](https://davidhamann.de/2017/06/12/latex-cheat-sheet/).
+ *	For units of measure, use metric or imperial but be consistent.
+
+### Headings
+Headings should not contain inline code font or style formatting such as bold, italic, or code font.
+Headings should always immediately precede body text. Do not follow a heading with an admonition or another heading without some form of introductory or descriptive text.
+
+### Lists
+Typically, we use numbered lists and bulleted lists. List items are sentence-capped. List items should be treated as separate items and should not be strung together with punctuation or conjunctions. 
+
+NOT style:
+
+* Here is an item, and
+* here is another item; and
+* here is the final item.
+
+Style:
+
+* Here is an item
+* Here is another item
+* Here is the final item
+
+Or:
+
+1. Here is an item
+2. Here is another item
+3. Here is the final item
+
+### Punctuation
+ *	**Abbreviation**: spell out all words on first mention. European Union (EU) and then EU. Do not use full points / periods or spaces between initials: BBC, PhD, mph, 4am, etc.
+ *	**Ampersand**: generally speaking, do not use an ampersand in place of the word "and" unless referring to a company or publication that uses it: P&O, *Past & Present*.
+ *	**Apostrophe**: use the possessive 's after singular words or names that end in s – St James's, Jones's, mistress's; use it after plurals that do not end in s: children's, people’s, media's.
+ *	**Brackets / Parentheses**: it is better to use commas or dashes. Use round brackets to introduce explanatory material into a direct quote, eg: He said: "When finished it (the tunnel) will revolutionise travel" or "She said adiós (goodbye)". Place a full stop / period outside a closing bracket if the material inside is not a sentence (like this). (But an independent sentence takes the full stop before the closing bracket.) 
+ *	**Colon**: use to introduce lists, tabulations, texts, as in: 
+    *	The committee recommends: extending licensing hours to midnight; allowing children on licensed premises; relaxing planning controls on new public houses. 
+    *	Use after the name of a speaker for a whole quoted sentence: Mr James Sherwood, chairman of Sealink, said: "We have..." 
+    *	Lowercase the first letter after a colon: this is how we do it. 
+ *	**Comma**: serial comma (this, that, and the other).
+ *	**Dash**: a useful device to use instead of commas, but not more than one pair per sentence.
+ *	**Ellipsis**: three periods separated from the preceding and following words by a space ( ... ). Use to condense a direct quote (thus the quote "the people sitting in this meeting room deserve a better deal" becomes "the people ... deserve a better deal"). 
+ *	**Exclamation Mark**: use only at the end of a direct quote when it is clear that the remark is exclamatory, eg "I hate intolerance!"
+ *	**Full Stop / Period**: use frequently. Sentences should be short, crisp, straightforward. But do not put full stops between initials, after status title (Mx, Dr) or between abbreviations (EU). 
+ *	**Hyphen**: use to avoid ambiguity or to form a single idea from two or more words: 
+    *	Fractions: two-thirds.
+    *	Most words that begin with anti, non and neo.
+    *	A sum followed by the word worth - £10 million-worth of exports.
+    *	Some titles (director-general, secretary-general, but Attorney General, general secretary etc). The rule is to adopt the usage of the authority which created it 
+    *	Avoiding ambiguity (little-used car ... little used car).
+    *	Compass quarters (south-west, north-east). 
+ *	**Quotation Marks**: use straight (not curly) quotation marks for direct quotes. Use either single or double quotation marks but be consistent.
+
+### Capitalisation
+The guideline is to use them sparingly in the running prose. Specific rules: 
+
+*	**Title Case**: headings and book titles should use title case: "Preparing the Data for Analysis"; *The Pride and the Passion*, etc.
+*	**Always Capitalized**:
+    *	**Proper Names**: William J. Turkel – unless the person choses to spell their name otherwise (eg "bell hooks").
+    *	**Artistic, Cultural, Government Organizations, etc**: Museum of the Moving Image, Anne Frank House, Home Office, Agency for Global Media, United Nations.
+    *	**Holidays and Festivals**: Diwali, Hanukkah, Eid-Ul-Adha, Ramadan.
+*	**Sometimes or Partially Capitalized**:
+    *	**Places**: capitals for countries, regions, recognisable areas (eg, the Middle East, Senegal). Lower case for points of the compass, except where they are used as part of a place name (to reach the North Pole, head north). Further examples include: north-east Kenya, south Brazil, the west, western Canada, the far east, south-east Asia, Central America, Latin America.
+    *	**Historic Events**: first world war, second world war; Crimean/Boer/Vietnam/Gulf war; hundred years war.
+    *	**Religion**: Upper case for Anglican, Baptist, Buddhist, Catholic, Christian, Hindu, Methodist, Muslim, Protestant, Roman Catholic, Sikh, but lower for evangelicals, charismatics, atheists. 
+    *	**Holy Books (select)**:
+        *	**Bible**: Capitalise if referring to Old or New Testament.
+        *	**Buddhist**: sutras (sermons) and abhidhamma (analysis and interpretation). For Tibetan Buddhismthere are also tantric texts and the Tibetan Book of the Dead.
+        *	**Hindu**: the Śruti texts: Vedas, Samhitas, Brahmanas, Aranyakas, Upanishads; the Vedāngas, Hindu epics, Sutras, Shastras, philosophical texts, the Puranas, the Kāvya, the Bhasyas, many Nibandhas.
+        *	**Judaism**: the Tanakh (Torah, Nevi'im, Ketuvim), Talmud (Mishnah, Gemara)
+        *	**Qu'ran**: Capitalise. Texts include the Hadith, the Tawrat (Torah), Zabur (possibly Psalms), Injil (1.2 billion).
+        *	**Sikh**: Adi Granth (commonly called the Guru Granth Sahib), the Dasam Granth, the Varan Bhai Gurdas, the texts of Bhai Nand Lal.
+    *	**Jobs**: Capitalise the title when used with the name – President Macron but not as a description – Emmanuel Macron, president of France. The Pope and the Queen have capital letters.
+    *	**Organisations and Institutions**: the Government (cap in all references), the Cabinet (cap in all references), the Church of Ireland ("the church"), the Department of Education and Science ("the department"), Western University ("the university"), the Court of Appeal ("the appeal court" or "the court"). 
+    *	**Universities and Colleges**: Capitals for institution, lower case for departments ("Australian National University department of medieval history").
+    *	**Religious Institutions, Hospitals and Schools**: cap up the proper or place name, lower case the rest eg Nurture Hillandale rehabilitation hospital, Vernon county primary school, Ali Pasha’s mosque.
+*	**Always Lowercase**:
+    *	**Committees, Reports and Inquiries**: committee on climate change, trade and industry committee, royal commission on electoral reform 
+    *	**Agencies, Commissions, Public Bodies, Quangos**: benefits agency, crown prosecution service, customs and excise, parole board 
+    *	**Seasons**: spring, summer, autumn/fall, winter.
+    *	**Currencies**: euro, franc, mark, sterling, dong etc
+
+### References
+*	Links rather than endnotes may be appropriate in most cases.
+*	Ensure linked phrases are semantically meaningful. Do not link terms that are meaningful only to sighted users such as "click here".
+*	All traditionally published and academic literature should be end-noted rather than linked.
+*	If you are writing an "analysis" tutorial, you must refer to published scholarly literature.
+*	Endnote superscripts should be outside the final punctuation like this.² Not inside like this².
+*	Use the "Notes and Bibliography" system found in the [*The Chicago Manual of Style*, 17th Edition](https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html) for endnotes.
+*	On first mention of a published work, include author name (including first/given name). For example, "You can find more information in *The Elements of Typographic Style* by Robert Bringhurst," or "For more information, consult Robert Bringhurt’s *The Elements of Typographic Style*." On subsequent references, just use the book title. Author’s names can be shortened to surname only on subsequent use.
+*	Endnotes should not just contain a URL.
+This:
+
+    *	Grove, John. "Calhoun and Conservative Reform." *American Political Thought* 4, no. 2 (2015): 203–27. https://doi.org/10.1086/680389.
+
+ Not this
+
+    *	https://doi.org/10.1086/680389
 
 
-## Writing a New Lesson
-The *Programming Historian* is hosted at [GitHub](http://github.com), which is a free platform for maintaining files and their revision history. It's most often used to store files of programming code, but it's also a fabulous way to maintain an open-access resource like the *Programming Historian*. More specifically, our site uses [GitHub Pages] to take a bunch of plain text files and turn them into a spiffy website.
+### Challenging Words Explained
 
-This means that we we ask that authors adhere to the following lesson requirements, which are not merely stylistic, but in fact necessary for our publishing platform. While our technical requirements may be unfamiliar to you, **we are here to help you through the process and learn the technologies as you go.**
+ *	**Collective Nouns** (group, family, cabinet, etc) take singular or plural verb according to meaning: the family was shocked, the family were sitting down, scratching their heads. 
+ *	**Less or Fewer?** Less means less in quantity, (less money); fewer means smaller in number, (fewer coins).
+ *	**Over or More Than?** Over and under answer the question "how much?"; more than and fewer than answer the question "how many?": she is over 18, there were more than 20,000 at the game.
+ *	**That or Which?** that defines, which informs: this is the house that Jack built, but this house, which Jack built, is now falling down.
 
-Please note that as a volunteer-driven project, we are grateful for your attention to detail.
-
-
-### Use plain text
-Because our site is hosted using [GitHub Pages](https://pages.github.com), **your lesson must be written in plain text**, using a text editor of your choice. *Text editors are distinctly different from traditional word processing programs like MS Word.* We highly recommend using [Atom](https://atom.io/), which is available for Mac or Windows. Mac users might consider [TextWrangler] or TextEdit (which comes with Mac OS X). Windows users might consider [Notepad++].
-
-The specific editor you choose is not important, but you should begin writing your lesson in plain text to avoid frustrations later on. For instance, stylized quotation marks automatically inserted by MS Word create formatting problems that can be hard to debug.
-
+## C. Formatting Guidelines
+This final section covers matters of formatting for submission. Read this section before and after writing your draft. If you get any of these elements wrong, you will be able to correct them when we post a live preview of your lesson at the start of the peer review process.
 
 ### Write in Markdown
-**All new lessons must be written in Markdown.** Markdown is a simple mark-up language that is best written in a text editor (as explained above, do not use a word processor like MS Word or Open Office). [GitHub Pages] are powered by [Jekyll](http://jekyllrb.com/), which automatically converts the Markdown files into the HTML pages that you can find here on the website. Even this page is written in Markdown, as you can see by inspecting [the raw text on GitHub].
+All lessons must be written in [Markdown](https://en.wikipedia.org/wiki/Markdown). A template for writing your lessons has been provided.
 
-For a gentle introduction to GitHub Markdown (especially with *Programming Historian*, see [Getting Started with Markdown]({{site.baseurl}}/lessons/getting-started-with-markdown), or the concise reference [GitHub Guide to Markdown].
+* [Download the English Language Lesson template (.md)]({{site.baseurl}}/en/lesson-template.md).
 
+Markdown is a mark-up language that is best created with a text editor. MS Word and Open Office are NOT text editors and should be avoided. We recommend [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/) or [Notepad++](https://notepad-plus-plus.org/download).
+For a gentle introduction to Markdown formatting see [Getting Started with Markdown]({{site.baseurl}}/en/lessons/getting-started-with-markdown), or the concise reference [GitHub Guide to Markdown](https://guides.github.com/features/mastering-markdown/).
+
+Your lesson should be saved in .md format. Your lesson filename becomes part of the lesson URL. Therefore, it should be named according to the following rules:
+
+ *	A short, lowercase, descriptive name that gives a clear indication of the lesson contents (eg. getting-started-with-markdown.md).
+ *	Do not use spaces or underscores in the filename; use hyphens instead.
+ *	Use a keyword-rich filename that includes key technologies or methods (eg, Python or Sentiment Analysis).
+
+### Bold, Italics, and Underline
+To ensure consistency across lessons, adhere to the following text formatting guidelines:
+
+#### Bold
+ *	Bold is not used except in exceptional circumstances.
+ *	Bold is formatted using **\*\*double asterisks\*\***.
+
+#### Italics
+ *	Use italics for book titles, films, TV programmes, paintings, songs, albums, and websites.
+ *	Never use italics for business names (the *Facebook* website is owned by Facebook).
+ *	Do not use italics in headlines, even if referring to a book title.
+ *	Italics are formatted using *\*single asterisks\**.
+
+#### Underline
+ *	Underline is not used.
+
+
+### Alerts and Warnings
+If you want to include an aside or a warning to readers, you can set it apart from the main text:
+
+```
 <div class="alert alert-warning">
-  Before continuing, be sure you understand how to use Markdown syntax to use basic formatting like headers, bold, italics, links, paragraphs, and lists.
-</div>
-
-
-To make this easier, we have provided a template that we ask you to use for all lessons:
-
-```
-title: ["YOUR TITLE HERE"]
-collection: lessons
-layout: lesson
-slug: [LEAVE BLANK]
-date: [LEAVE BLANK]
-translation_date: [LEAVE BLANK]
-authors:
-- [FORENAME SURNAME 1]
-- [FORENAME SURNAME 2, etc]
-reviewers:
-- [LEAVE BLANK]
-editors:
-- [LEAVE BLANK]
-translator:
-- [FORENAME SURNAME 1]
-translation-editor:
-- [LEAVE BLANK]
-translation-reviewer:
-- [LEAVE BLANK]
-original: [LEAVE BLANK]
-review-ticket: [LEAVE BLANK]
-difficulty: [LEAVE BLANK]
-activity: [LEAVE BLANK]
-topics: [LEAVE BLANK]
-abstract: [LEAVE BLANK]
----
-
-# Contents
-
-{% include toc.html %}
-
-# First level heading
-
-[CONTENT HERE. Please write formally, sustainably, and for a global audience.]
-
-## Second level heading - with some examples of formatting
-
-### Font Formatting:
-*italic text*
-**bold text**
-`reserved words or file names` (eg "for loop", or "myData.csv")
-
-### Links:
-[a link to *Programming Historian*](http://programminghistorian.org)
-
-### Images:
-{% include figure.html filename="IMAGE-FILENAME" caption="Caption to image" %} - see https://programminghistorian.org/en/author-guidelines for more guidance on images.
-
-### A Sample Unordered List
-
-* Fruits
-  * Apples
-  * Oranges
-  * Grapes
-* Dairy
-  * Milk
-  * Cheese
-
-### A Sample Ordered List
-
-1. Finish tutorial
-2. Go to grocery store
-3. Prepare lunch
-
-###A Sample Table:
-
-| Heading 1 | Heading 2 | Heading 3 |
-| --------- | --------- | --------- |
-| Row 1, column 1 | Row 1, column 2 | Row 1, column 3|
-| Row 2, column 1 | Row 2, column 2 | Row 2, column 3|
-| Row 3, column 1 | Row 3, column 2 | Row 3, column 3|
-
-### An End Note:
-
-This is some text.[^1]
-This is some more text.[^2]
-
-
-
-# Endnotes
-[^1] Properly formatted citation using Chicago Manual of Style
-[^2] Properly formatted citation using Chicago Manual of Style
-```
-
-### Choose a searchable name
-Name your new lesson file following these guidelines:
-
--   Make the filename all lowercase, and short but descriptive. This filename will
-    eventually become the [slug] for the lesson's URL when published. For example, the lesson titled "Getting Started with Markdown" has a slug of `getting-started-with-markdown` and a URL of `https://programminghistorian.org/en/lessons/getting-started-with-markdown`. Please see existing lessons for more concrete examples.
--   Your slug will be referenced later in these directions as LESSON-SLUG.
--    Think about how potential readers might search for something like your lesson. A keyword-rich slug is a good way to get search-engine traffic.
--   Do not put spaces or underscores in the filename; use hyphens instead.
--   The filename extension should be `.md` (markdown).
-
-### Endnote format
-
-Authors are asked to use the [Chicago Manual of Style](https://en.wikipedia.org/wiki/The_Chicago_Manual_of_Style) for endnote formatting.
-
-### Use informative section headings
-We strive to make our lessons easy to follow by using section headings consistently throughout our lessons. As you compose your lesson, section headings will help you visualize how well you've structured your lesson. Avoid long sections of text with no headings; these become very difficult to follow.
-
-**Please do not make your own headings** with **bold** or *italic* text; use an appropriate heading level (which we can style consistently across our lessons). Unless your lesson is incredibly short, you'll probably need at least 3 levels.
-
-Although there are a few ways to create section headings with Markdown, we ask that you use the `#` notation in your headings. Top-level section headings are indicated with a \#; second-level with \#\#, and so on.
-
-### Alerts
-If you want to point out something that isn't essential for following the lesson but think is important enough to mention (or applies only to certain readers), you can set it apart from the main lesson text by using our [alert styling](https://v4-alpha.getbootstrap.com/components/alerts/) (borrowed from Bootstrap).
-
-For this, you need to use HTML, such as
-
-``` html
-<div class="alert alert-warning">
-  Be sure that you follow directions carefully!
+ Be sure that you follow directions carefully!
 </div>
 ```
 
-And will render on the website as:
+### Figures and Images
+Images can help readers understand your lesson steps, but should not be used for decoration. If you wish to use images in your lesson, label them sequentially LESSON-NAME1.jpg, LESSON-NAME2.jpg, etc. Refer to them in the text as "Figure 1", "Figure 2", and so on. All figures must come with a concise figure caption and endnotes where appropriate. You must have the legal right to post any images.
 
-<div class="alert alert-warning">
-  Be sure that you follow directions carefully!
-</div>
+Use web-friendly file formats such as .png or .jpg and reduce large images to a maximum of 840px on the longest side. This is important for readers in countries with slower internet speeds.
 
-### Special style rules
-Like any other journal, *Programming Historian* also has a house style that we expect authors to follow to maintain consistency across our lessons. Unlike other journals, however, breaking these style rules can mean that your lessons will not be properly generated into a web page and therefore will remain invisible.
+Images should be saved in a folder with the same name as your lesson .md file. The editor assigned to your lesson can assist you in uploading your images when you submit. 
 
-### Figures
-No matter how short or simple, all lessons benefit from images, particularly screen shots (or partial screen shots) that illustrate what the reader should see as they move through the tutorial. Not only do they make tutorials more "skimmable," figures help show the reader they are doing the right thing. And of course images can save a considerable amount of description in your text.
+To insert an image in your text, use the following format:
 
-
-#### Create a folder
-First, create a folder in which you will store all of your image files  The folder name should be the same as the `LESSON-SLUG` that you have chosen for your lesson file name. The editor assigned to your lesson can assist you in uploading your images to the `ph-submissions` repository when you submit your lesson.
-
-
-#### Use intelligible filenames
-There are two ways you can name your files. One option is to use consistent, semantically meaningful filenames that clearly indicate what the image is about. Alternatively, you can  name them sequentially using the same hyphenated lesson slug
-(or an abbreviated version if the slug is rather long), followed by
-numbers to indicate which figure it is. (For example,
-`counting-frequencies-1.png`, `counting-frequencies-2.png`, and so on.)
-
-#### Use standard formats and sizes
-Make sure the images are in web-friendly formats such as PNG or JPEG and sized appropriately (both in terms of pixels and bytes).
-
-#### Including images
-Wherever you want to insert an image, use the following line of code in the body of your lesson:
-
-{% raw %}
-``` markdown
-{% include figure.html filename="IMAGE-FILENAME" caption="Caption to image" %}
 ```
-{% endraw %}
-
-You'll need to modify `IMAGE-FILENAME` and `Caption to image` according to your lesson and image. Note that you may use Markdown within caption text, for instance to mark text as bold or italic.
-
-When the Markdown is rendered by our system, this line will automatically produce HTML that looks like this:
-
-``` html
-<figure>
-    <a href="/images/LESSON-SLUG/IMAGE-FILENAME">
-       <img src="/images/LESSON-SLUG/IMAGE-FILENAME" alt="Caption to image">
-    </a>
-<figcaption>
-    Caption to image
-</figcaption>
-</figure>
+{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION" %}
 ```
 
-<div class="alert alert-warning">
-  Note that when figure tags are added this way, the image will not show up in the preview on GitHub or in other Markdown preview programs.
-</div>
+Images may not appear in previews of your lesson, but your editor will ensure they render properly when the lesson is published.
+
+### Code Examples
+Lines of code should be formatted to distinguish them clearly from prose:
+
+ *	Lines of code should be maximum 80 characters
+ *	Multi-line code blocks should be enclosed in three \`\`\`back-ticks\`\`\`. 
+ *	Inline code (rarely used) can be enclosed in single \`backticks\`.
 
 
-### Code Blocks
-If you want to include code in a lesson, or to show the output of a
-program, use what's called a [fenced code block]. On a new line, use three backticks
-(`` ` ``) to open a code block, followed by the language of your code
-(eg, `python` or `html`). Then paste in your code, and when finished,
-close the code block with three more backticks. The code will then be
-offset in the finished version and will look like this:
-
-``` python
-print 'hello world'
+``` 
+They will look like this 
 ```
+` and this ` respectively.
 
-### Write Sustainably
-PH strives to publish lessons that will be of use to our readers for the foreseeable future. Authors should consult our [lesson retirement policy]({{site.baseurl}}/lesson-retirement-policy), which describes how the _Programming Historian_ editorial team manages lessons that have become out-of-date. To aid in creating sustainable lessons, we ask that you keep certain writing guidelines in mind as you create your lesson:
+--
+Follow best practice in writing your code:
 
-- Instead of focusing on software specifics, keep your lesson more geared towards methodologies and tool generalities.
-- If your lesson can leverage existing software documentation, consider directing your readers to this documentation rather than repeating it in the lesson. Instead of linking directly to a software company's resources (which often change), you can provide general guidance on how to find the documentation.
-- Limit the use of software version-specific images, unless required to follow the lesson.
-- Check any external links to ensure they are live and up-to-date.
-- Data sources for lessons should be hosted with the _Programming Historian_.
+*	**Variable and Function Names**: variable names should be nouns (eg "counter") and function names should be verbs (eg "createFile"). Choose names that are concise and meaningful. You may use [snake_case](https://en.wikipedia.org/wiki/Snake_case) or [camelCase](https://en.wikipedia.org/wiki/Camel_case), but be consistent.
+*	**User Commands**: when writing about text you want the reader to replace with their own information, use FULL CAPS and enclose by ` backticks ` (eg, \`USERNAME HERE\`).
+*	**Filenames**: filenames that you ask your reader to create or use should be enclosed in `backticks` when mentioned in the text and should include their file extension. Choose names that are concise and meaningful. You may use [snake_case](https://en.wikipedia.org/wiki/Snake_case) or [camelCase](https://en.wikipedia.org/wiki/Camel_case), but be consistent (eg, `data.txt`, `cleanData.py` etc).
+*	**Reserved Words**: words that are part of a programming language should always be formatted as `code` using `back-ticks` in the running prose. A list of reserved words in common programming languages include:
+   
+#### JavaScript:
 
+`abstract`, `arguments`, `await`, `Boolean`, `break`, `byte`, `case`, `catch`, `char`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `double`, `else`, `enum`, `eval`, `export`, `extends`, `false`, `final`, `finally`, `float`, `for`, `function`, `goto`, `if`, `implements`, `import`, `in`, `instanceof`, `int`, `interface`, `let`, `long`, `native`, `new`, `null`, `package`, `private`, `protected`, `public`, `return`, `short`, `static`, `super`, `switch`, `synchronized`, `this`, `throw`, `throws`, `transient`, `true`, `try`, `typeof`, `var`, `void`, `volatile`, `while`, `with`, `yield`.
 
-### Write For a Global Audience
+#### Python 2:
+`and`, `as`, `assert`, `break`, `class`, `continue`, `def`, `del`, `elif`, `else`, `except`, `exec`, `finally`, `for`, `from`, `global`, `if`, `import`, `in`, `is`, `lambda`, `not`, `or`, `pass`, `print`, `raise`, `return`, `try`, `while`, `with`, `yield`.
 
-Programming Historian readers live all around the world, and operate in a range of cultural contexts. To help reach that global audience, we have been publishing in more than one language since 2017, and aim to translate all tutorials. **While we recognise that not all methods or tools are fully internationally accessible**, authors can and should take steps to write their lesson in a way that is accessible to as many people as possible. **Please consider the following when writing your tutorial**:
+#### Python 3:
+`and`, `as`, `assert`, `break`, `class`, `continue`, `def`, `del`, `elif`, `else`, `except`, `False`, `finally`, `for`, `from`, `global`, `if`, `import`, `in`, `is`, `lambda`, `nonlocal`, `None`, `not`, `or`, `pass`, `raise`, `return`, `True`, `try`, `while`, `with`, `yield`.
 
-- When choosing your methods or tools, try to make choices with multi-lingual readers in mind. This is particularly important when working on textual analysis methods, or where users may reasonably want to have support for different character sets (eg, accented characters, non-Latin, etc).
-- When choosing primary sources, images, producing figures, or taking screen shots, consider how they will present themselves to a global audience.
-- When writing, avoid jokes, cultural references, puns, plays on words, idiomatic expressions, sarcasm, emojis, or language that is more difficult than it needs to be. Mentions of persons, organisations, or historical details should always come with contextual information. It may help to assume your reader does not live in your country or speak your language.
-- In code examples or metadata, use internationally recognised standard formats for dates and times ([ISO 8601:2004](https://www.iso.org/standard/40874.html)). In free text, be aware of cultural differences related to the representation of dates and times which might cause confusion.
-- Where possible, choose methods and tools that have multi-lingual documentation. If this is not practical, it would be great if you could add some multi-lingual references at the end of your tutorial.
+#### R:
+`break`, `else`, `for`, `FALSE`, `function`, `if`, `in`, `Inf`, `NA`, `NA_character_`, `NA_complex_`, `NA_integer_`, `NA_real_`, `NaN`, `next`, `NULL`, `repeat`, `TRUE`, `while`.
 
-Contact your editor if you require guidance on any of these matters. Tutorials that are unable to meet these guidelines may not be translated, but are still welcome for consideration for monolingual publication.
+--
 
------
+## Step 3: Submitting a New Lesson
 
-## Submitting a New Lesson
-Once your lesson file has been prepared to the above specifications, you are ready to submit it!
+Double-check that your lesson file has been prepared to the above specifications. Once you are satisfied, we strongly recommend that you ask at least two people to try your tutorial and provide feedback. This will help you make improvements that mean our peer reviewers can focus on helping you produce the strongest possible lesson. 
 
-We have a [Programming Historian project page](https://github.com/programminghistorian) at GitHub, where we maintain two repositories (a repository is a place to store related files and folders--you can think of it as a kind of folder). One of these, called [jekyll](https://github.com/programminghistorian/jekyll), hosts the code for the live version of the site you see at <http://programminghistorian.org>. The other repository is called [ph-submissions].
+You are ready to submit the lesson for peer review. Submissions are made to our peer review site on [Github](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons).
 
-Our preferred way for authors to submit lessons is to add them directly to the [ph-submissions] repository (or repo, for short). Thanks to GitHub's features, you can do this using drag-and-drop uploading actions with which you are probably already familiar. As a new author, here are the steps:
-
-1. Create a [free account at GitHub](https://github.com/join). It takes about 30 seconds.
-2. Email your editor with your new GitHub username and your lesson filename/slug (be sure you've followed the naming guidelines above). The editor will then add you as a **collaborator** on the [ph-submissions] repo. Once you are added as a collaborator, you will be able to make direct changes to the [ph-submissions] repo, including adding, editing, removing, and renaming files. The editor will also create a folder with the same name as your lesson in the images folder. (If you have other data files that you link to in your tutorial, please ask your editor about them.)
-3. Once you've heard from your editor that you've been added as a collaborator, navigate to the [lessons folder](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons) of the [ph-submissions] repo. Then, drag and drop the markdown file of your lesson from your computer onto your browser window. (If you need help, see [GitHub's instructions](https://help.github.com/articles/adding-a-file-to-a-repository/)). Now click the green "Commit Changes" button; you don't need to change the default message.
-4. You probably have some images that go along with your lesson. Make sure all the image files are named appropriately according to the naming conventions specified above. Navigate to the [images folder](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/images) in the [ph-submissions] repo. Click on the folder with the same name as your lesson (which your editor should have created for you; if you don't see it, please contact your editor and wait for instructions). Once you are in the correct folder, drag and drop all of your images files onto the browser window, just like in step 3. You can't drag a folder of images; but you can drag multiple files at once.
-5. Preview your lesson! Wait a few minutes (usually less) for GitHub to convert your Markdown file into HTML and make it a live webpage. Then navigate to `http://programminghistorian.github.io/ph-submissions/lessons/` + `YOUR-LESSON-NAME` (but replace YOUR-LESSON-NAME with the name of your file).
-6. Let your editor know that you have uploaded your lesson files to the ph-submissions repo (they should get a notification about this, but we want to make sure nothing gets overlooked).
-
-<div class="alert alert-info">
-  If you are familiar with command-line git and GitHub already, you may also submit your lesson and images as a pull request to the `ph-submission` repo and merge it yourself after being added as a collaborator. <b>Please do not submit lessons by pull request to the main Jekyll repo</b> so we can provide live previews of lessons in progress.
-</div>
-
-## Lesson Submitted! Now What?
-To see what happens after you submit a lesson, feel free to browse our [editor guidelines](/editor-guidelines), which detail our editorial process. Highlights are below:
-
-The most immediately important step is that your editor will create an [issue](https://github.com/programminghistorian/ph-submissions/issues) for the new lesson on the [ph-submissions] repo, with a link to your lesson (that you previewed in step 5). The editor and at least two reviewers invited by the editor will post their comments to this issue.
-
-### Wait for Reviewer Feedback
-We aim to complete the review process within four weeks, but sometimes delays occur or people get busy and the process can take longer than we hoped.
-
-In keeping with the ideas of public scholarship and open peer review, we encourage discussions to stay on GitHub. However, we also want everyone to feel comfortable with the process. If you need to discuss something privately, please feel free to [email your editor directly](/project-team), or to contact one of our dedicated ombudsperson, [Amanda Visconti](/project-team).
+1. **Getting Access**: create a [free Github account](https://github.com/join). Email your Github username to your editor who will give you upload access to our submission site. Let the editor know the file name of your lesson and if you have any images or data files accompanying your tutorial.
+3. **Uploading your Lesson**: once your editor confirms you have been granted access to the site, upload your lesson to the [lessons folder](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons). If you need help, see [GitHub's instructions](https://help.github.com/articles/adding-a-file-to-a-repository/).
+4. **Uploading Images**: if your lesson includes images, make sure all of the files are named according to the naming conventions specified above. Your editor will have created a folder for you to upload your images in the  [images directory](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/images). This folder should have the same name as your lesson filename. Upload your images to this folder. If you don't see it, please contact your editor and wait for instructions.
+5. **Uploading Data**: if your lesson includes data files, they should similarly be uploaded to a similarly named folder in the [assets directory](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/assets).
+6. **Email your editor** to let them know that you have uploaded your files.
 
 
-### Respond to Feedback
-Your editor and reviewers will most likely make some suggestions for improvements on the "issue" for your lesson. The editor should clarify which suggestions are essential to address, which are optional, and which can be set aside.
+## The Peer Review Process
 
-You can edit your files on GitHub, following [these instructions](https://help.github.com/articles/editing-files-in-your-repository/).
+Your editor will check that your files have been uploaded and formatted properly. At this stage you will be sent a preview link where any formatting errors will be evident and you can fix them.
 
-Your revisions should be completed within 4 weeks of receiving guidance from the editor on how to respond to the peer review. This is to ensure that lessons are published in a timely fashion and do not drag on unnecessarily. If you anticipate having trouble meeting the deadline, you should contact your editor to establish a more suitable due date.
+The peer review will be recorded on a Github "[ticket](https://github.com/programminghistorian/ph-submissions/issues)", which acts like an open message board discussion. Be aware that our peer review happens in public and remains publicly available as a permanent record of peer review. If you have concerns or would like to request a closed review, contact your assigned editor.
 
-If at any point you are unsure of your role or what to do next, feel free to email your editor or, better yet, to post a question to the issue (another editor might see it and can help you sooner than your own editor). You’ll understand that sometimes it will take us a few days to respond, but we hope the improvements to the finished lesson will be worth the wait.
+The peer review process normally happens in 3 stages:
 
+1) The editor assigned to your lesson will carefully read and try your lesson, providing a first round of feedback that you will be asked to respond to. The purpose of this first round of feedback is to ensure that your lesson addresses the needs of *Programming Historian* readers, and to make sure that the external peer reviewers receive a lesson that works. You will normally be given one month to respond to this first peer review.
 
-### Let your editor know you're done
-Once you have finished responding to feedback, let your editor know. If you haven't done so already, send your editor a 2-3 sentence bio statement that will appear at the end of your lesson, following the model of other lessons.
+2) The editor will then open the lesson for formal peer review. This will include at least two reviewers invited by the editor, and may also include comments from the wider community, who are welcome to contribute views. We generally try to ask reviewers to provide their comments within one month, but sometimes unforeseen circumstances mean this is not possible. The editor should make it clear to you that you should not respond to reviews until after both reviews have been published and the editor has summarised and provided clear instructions for moving forward. In some cases this may be a suggestion to substantially revise or rethink the lesson.  In other cases it will be a matter of making some changes. Depending on the peer review comments, and the nature of issues raised, you may need to revise the tutorial more than once, but the editor will endeavour to ensure that you are given a clear pathway towards publication. You always have the option of withdrawing from the review process if you so choose.
 
-Then, *Programming Historian*'s editorial team will quickly review your lesson and move it from the `ph-submissions` repository to the `jekyll` repository, and update our lessons directory.
+3) Once your editor and peer reviewers are happy with the piece, the editor will recommend publication to the Managing Editor, who will read the piece to ensure that it meets our Author's Guidelines and standards. In some cases there may be additional revisions or copy editing at this stage to bring the  piece in line with our publishing standards. If the Managing Editor is happy with the piece, it will be moved to the live site for publication. Your editor will inform you of any additional information required at this stage.
 
-Congratulations! You've published a lesson at *Programming Historian*!
+You may find it helpful to read our [editor guidelines](/editor-guidelines), which detail our editorial process. 
 
+If at any point you are unsure of your role or what to do next, post a question to the peer review issue. One of our editors will respond as soon as possible. We endeavour to respond to all queries within a few days.
 
-  [Lesson Pipeline wiki page]: https://github.com/programminghistorian/jekyll/wiki/Lesson-Pipeline
-  [reviewer guidelines]: /reviewer-guidelines.html
-  [published lessons]: /lessons
-  [TextWrangler]: http://www.barebones.com/products/textwrangler/
-  [Notepad++]: https://notepad-plus-plus.org/
-  [project team]: /project-team.html
-  [slug]: https://en.wikipedia.org/wiki/Semantic_URL#Slug
-  [YAML]: https://en.wikipedia.org/wiki/YAML
-  [GitHub Guide to Markdown]: https://guides.github.com/features/mastering-markdown/
-  [Markdown Basics]: https://help.github.com/articles/markdown-basics
-  [Github Flavored Markdown]: https://help.github.com/articles/github-flavored-markdown
-  [the raw text on GitHub]: https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/en/author-guidelines.md
-  [elements provided by HTML5]: http://html5doctor.com/the-figure-figcaption-elements/
-  [example of the preview with figures here]: https://github.com/programminghistorian/jekyll/commit/476f6d466d7dc4c36048954d2e1f309a597a4b87#diff-f61eee270fe5a122a0163ebf0e2f8725L28
-  [live version here]: /lessons/automated-downloading-with-wget#lesson-goals
-  [extended table syntax]: http://kramdown.gettalong.org/syntax.html#tables
-  [pandoc]: http://johnmacfarlane.net/pandoc/
-  [fenced code blocks]: https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks
-  [pull request]: https://help.github.com/articles/using-pull-requests/
-  [GitHub for Mac]: https://mac.github.com/
-  [GitHub for Windows]: https://windows.github.com/
-  [Create an account]: https://help.github.com/articles/signing-up-for-a-new-github-account/
-  [naming conventions described above]: #name-the-lesson-file
-  [pending pull requests on our repo]: https://github.com/programminghistorian/jekyll/pulls
-  [GitHub Guides]: https://guides.github.com/activities/forking/
-  [forking]: https://help.github.com/articles/fork-a-repo/
-  [independent tutorials]: https://gun.io/blog/how-to-github-fork-branch-and-pull-request/
-  [Git for Philosophers]: https://github.com/rzach/git4phi
-  [GitHub Pages]: https://pages.github.com
-  [ph-submissions]: https://github.com/programminghistorian/ph-submissions
+### Holding Us to Account
 
+Our team of volunteers works hard to provide a rigourous, collegial, and efficient peer review for authors. However, we recognize that there are times when we may fall short of expectations. We want authors to feel empowered to hold us to high standards. If, for whatever reason, you feel that you have been treated unfairly, that you are unhappy or confused by the process, that the review proess has been unnecessarily delayed, that a reviewer has been rude, that your editor has not been responsive enough, or have any other concern, please bring it to our attention so we can address it proactively.
+
+Raising a concern will NOT negatively affect the outcome of your peer review - even a peer review in progress.
+
+To raise a concern, please contact one of the following parties, chosing whomever you feel most comfortable approaching.
+
+* Your assigned editor
+* The managing editor
+* Our independent ombudsperson, [Amanda Visconti](/project-team)
+
+We hope you don't find yourself in a situation in which you are unhappy, but if you do, we thank you for helping us to improve.
+
+--
+
+This style guide was created with support from the School of Humanities, University of Hertfordshire.

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -250,9 +250,11 @@ Images should be saved in a folder with the same name as your lesson .md file. T
 
 To insert an image in your text, use the following format:
 
+{% raw %}
+``` markdown
+{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION" %}
 ```
-\{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION" %}
-```
+{% endraw %}
 
 Images may not appear in previews of your lesson, but your editor will ensure they render properly when the lesson is published.
 

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -10,9 +10,9 @@ skip_validation: true
 # Author Guidelines
 
 <img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
-<h2 class="noclear">Step 1: <a href="#proposing-a-new-lesson">Proposing a New Lesson</a></h2>
-<h2 class="noclear">Step 2: <a href="#writing-a-new-lesson">Writing and Formatting a New Lesson</a></h2>
-<h2 class="noclear">Step 3: <a href="#submitting-a-new-lesson">Submitting a New Lesson</a></h2>
+<h2 class="noclear">Step 1: <a href="#step-1-proposing-a-new-lesson">Proposing a New Lesson</a></h2>
+<h2 class="noclear">Step 2: <a href="#step-2-writing-a-new-lesson">Writing and Formatting a New Lesson</a></h2>
+<h2 class="noclear">Step 3: <a href="#step-3-submitting-a-new-lesson">Submitting a New Lesson</a></h2>
 
 
 These guidelines have been developed to help you understand the process of creating a tutorial for the English version of *Programming Historian*. They include practical and philosophical details of the tutorial writing process, as well as an indication of the workflow and the peer review process. If at any time you are unclear, please email the managing editor, {% include managing-editor.html lang=page.lang %}.
@@ -20,12 +20,12 @@ These guidelines have been developed to help you understand the process of creat
 ## Step 1: Proposing a New Lesson
 
 <div class="alert alert-success">
-We welcome tutorials relevant to the humanities, pitched at any level of technical aptitude and experience, that focus on one problem or process, can be sustainable in the long term, and are addressed to a global audience. 
+We welcome tutorials relevant to the humanities, pitched at any level of technical aptitude and experience, that focus on one problem or process, can be sustainable in the long term, and are addressed to a global audience.
 
 The scope and length of the tutorial should be appropriate to the complexity of the task. Tutorials should not exceed 8,000 words (including code). Shorter lessons are welcome. Longer lessons may need to be split into multiple tutorials.
 </div>
 
-If you have an idea for a new lesson, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and send it to {% include managing-editor.html lang=page.lang %}. 
+If you have an idea for a new lesson, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and send it to {% include managing-editor.html lang=page.lang %}.
 
 You can get a sense of what we publish by looking through our [published lessons]({{site.baseurl}}/en/lessons), reading our [reviewer guidelines]({{site.baseurl}}/en/reviewer-guidelines) or browsing [lessons in development](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons).
 
@@ -106,7 +106,7 @@ Headings should not contain inline code font or style formatting such as bold, i
 Headings should always immediately precede body text. Do not follow a heading with an admonition or another heading without some form of introductory or descriptive text.
 
 ### Lists
-Typically, we use numbered lists and bulleted lists. List items are sentence-capped. List items should be treated as separate items and should not be strung together with punctuation or conjunctions. 
+Typically, we use numbered lists and bulleted lists. List items are sentence-capped. List items should be treated as separate items and should not be strung together with punctuation or conjunctions.
 
 NOT style:
 
@@ -130,27 +130,27 @@ Or:
  *	**Abbreviation**: spell out all words on first mention. European Union (EU) and then EU. Do not use full points / periods or spaces between initials: BBC, PhD, mph, 4am, etc.
  *	**Ampersand**: generally speaking, do not use an ampersand in place of the word "and" unless referring to a company or publication that uses it: P&O, *Past & Present*.
  *	**Apostrophe**: use the possessive 's after singular words or names that end in s – St James's, Jones's, mistress's; use it after plurals that do not end in s: children's, people’s, media's.
- *	**Brackets / Parentheses**: it is better to use commas or dashes. Use round brackets to introduce explanatory material into a direct quote, eg: He said: "When finished it (the tunnel) will revolutionise travel" or "She said adiós (goodbye)". Place a full stop / period outside a closing bracket if the material inside is not a sentence (like this). (But an independent sentence takes the full stop before the closing bracket.) 
- *	**Colon**: use to introduce lists, tabulations, texts, as in: 
-    *	The committee recommends: extending licensing hours to midnight; allowing children on licensed premises; relaxing planning controls on new public houses. 
-    *	Use after the name of a speaker for a whole quoted sentence: Mr James Sherwood, chairman of Sealink, said: "We have..." 
-    *	Lowercase the first letter after a colon: this is how we do it. 
+ *	**Brackets / Parentheses**: it is better to use commas or dashes. Use round brackets to introduce explanatory material into a direct quote, eg: He said: "When finished it (the tunnel) will revolutionise travel" or "She said adiós (goodbye)". Place a full stop / period outside a closing bracket if the material inside is not a sentence (like this). (But an independent sentence takes the full stop before the closing bracket.)
+ *	**Colon**: use to introduce lists, tabulations, texts, as in:
+    *	The committee recommends: extending licensing hours to midnight; allowing children on licensed premises; relaxing planning controls on new public houses.
+    *	Use after the name of a speaker for a whole quoted sentence: Mr James Sherwood, chairman of Sealink, said: "We have..."
+    *	Lowercase the first letter after a colon: this is how we do it.
  *	**Comma**: serial comma (this, that, and the other).
  *	**Dash**: a useful device to use instead of commas, but not more than one pair per sentence.
- *	**Ellipsis**: three periods separated from the preceding and following words by a space ( ... ). Use to condense a direct quote (thus the quote "the people sitting in this meeting room deserve a better deal" becomes "the people ... deserve a better deal"). 
+ *	**Ellipsis**: three periods separated from the preceding and following words by a space ( ... ). Use to condense a direct quote (thus the quote "the people sitting in this meeting room deserve a better deal" becomes "the people ... deserve a better deal").
  *	**Exclamation Mark**: use only at the end of a direct quote when it is clear that the remark is exclamatory, eg "I hate intolerance!"
- *	**Full Stop / Period**: use frequently. Sentences should be short, crisp, straightforward. But do not put full stops between initials, after status title (Mx, Dr) or between abbreviations (EU). 
- *	**Hyphen**: use to avoid ambiguity or to form a single idea from two or more words: 
+ *	**Full Stop / Period**: use frequently. Sentences should be short, crisp, straightforward. But do not put full stops between initials, after status title (Mx, Dr) or between abbreviations (EU).
+ *	**Hyphen**: use to avoid ambiguity or to form a single idea from two or more words:
     *	Fractions: two-thirds.
     *	Most words that begin with anti, non and neo.
     *	A sum followed by the word worth - £10 million-worth of exports.
-    *	Some titles (director-general, secretary-general, but Attorney General, general secretary etc). The rule is to adopt the usage of the authority which created it 
+    *	Some titles (director-general, secretary-general, but Attorney General, general secretary etc). The rule is to adopt the usage of the authority which created it
     *	Avoiding ambiguity (little-used car ... little used car).
-    *	Compass quarters (south-west, north-east). 
+    *	Compass quarters (south-west, north-east).
  *	**Quotation Marks**: use straight (not curly) quotation marks for direct quotes. Use either single or double quotation marks but be consistent.
 
 ### Capitalisation
-The guideline is to use them sparingly in the running prose. Specific rules: 
+The guideline is to use them sparingly in the running prose. Specific rules:
 
 *	**Title Case**: headings and book titles should use title case: "Preparing the Data for Analysis"; *The Pride and the Passion*, etc.
 *	**Always Capitalized**:
@@ -160,7 +160,7 @@ The guideline is to use them sparingly in the running prose. Specific rules:
 *	**Sometimes or Partially Capitalized**:
     *	**Places**: capitals for countries, regions, recognisable areas (eg, the Middle East, Senegal). Lower case for points of the compass, except where they are used as part of a place name (to reach the North Pole, head north). Further examples include: north-east Kenya, south Brazil, the west, western Canada, the far east, south-east Asia, Central America, Latin America.
     *	**Historic Events**: first world war, second world war; Crimean/Boer/Vietnam/Gulf war; hundred years war.
-    *	**Religion**: Upper case for Anglican, Baptist, Buddhist, Catholic, Christian, Hindu, Methodist, Muslim, Protestant, Roman Catholic, Sikh, but lower for evangelicals, charismatics, atheists. 
+    *	**Religion**: Upper case for Anglican, Baptist, Buddhist, Catholic, Christian, Hindu, Methodist, Muslim, Protestant, Roman Catholic, Sikh, but lower for evangelicals, charismatics, atheists.
     *	**Holy Books (select)**:
         *	**Bible**: Capitalise if referring to Old or New Testament.
         *	**Buddhist**: sutras (sermons) and abhidhamma (analysis and interpretation). For Tibetan Buddhismthere are also tantric texts and the Tibetan Book of the Dead.
@@ -169,12 +169,12 @@ The guideline is to use them sparingly in the running prose. Specific rules:
         *	**Qu'ran**: Capitalise. Texts include the Hadith, the Tawrat (Torah), Zabur (possibly Psalms), Injil (1.2 billion).
         *	**Sikh**: Adi Granth (commonly called the Guru Granth Sahib), the Dasam Granth, the Varan Bhai Gurdas, the texts of Bhai Nand Lal.
     *	**Jobs**: Capitalise the title when used with the name – President Macron but not as a description – Emmanuel Macron, president of France. The Pope and the Queen have capital letters.
-    *	**Organisations and Institutions**: the Government (cap in all references), the Cabinet (cap in all references), the Church of Ireland ("the church"), the Department of Education and Science ("the department"), Western University ("the university"), the Court of Appeal ("the appeal court" or "the court"). 
+    *	**Organisations and Institutions**: the Government (cap in all references), the Cabinet (cap in all references), the Church of Ireland ("the church"), the Department of Education and Science ("the department"), Western University ("the university"), the Court of Appeal ("the appeal court" or "the court").
     *	**Universities and Colleges**: Capitals for institution, lower case for departments ("Australian National University department of medieval history").
     *	**Religious Institutions, Hospitals and Schools**: cap up the proper or place name, lower case the rest eg Nurture Hillandale rehabilitation hospital, Vernon county primary school, Ali Pasha’s mosque.
 *	**Always Lowercase**:
-    *	**Committees, Reports and Inquiries**: committee on climate change, trade and industry committee, royal commission on electoral reform 
-    *	**Agencies, Commissions, Public Bodies, Quangos**: benefits agency, crown prosecution service, customs and excise, parole board 
+    *	**Committees, Reports and Inquiries**: committee on climate change, trade and industry committee, royal commission on electoral reform
+    *	**Agencies, Commissions, Public Bodies, Quangos**: benefits agency, crown prosecution service, customs and excise, parole board
     *	**Seasons**: spring, summer, autumn/fall, winter.
     *	**Currencies**: euro, franc, mark, sterling, dong etc
 
@@ -193,7 +193,7 @@ The guideline is to use them sparingly in the running prose. Specific rules:
 
 ### Challenging Words Explained
 
- *	**Collective Nouns** (group, family, cabinet, etc) take singular or plural verb according to meaning: the family was shocked, the family were sitting down, scratching their heads. 
+ *	**Collective Nouns** (group, family, cabinet, etc) take singular or plural verb according to meaning: the family was shocked, the family were sitting down, scratching their heads.
  *	**Less or Fewer?** Less means less in quantity, (less money); fewer means smaller in number, (fewer coins).
  *	**Over or More Than?** Over and under answer the question "how much?"; more than and fewer than answer the question "how many?": she is over 18, there were more than 20,000 at the game.
  *	**That or Which?** that defines, which informs: this is the house that Jack built, but this house, which Jack built, is now falling down.
@@ -246,7 +246,7 @@ Images can help readers understand your lesson steps, but should not be used for
 
 Use web-friendly file formats such as .png or .jpg and reduce large images to a maximum of 840px on the longest side. This is important for readers in countries with slower internet speeds.
 
-Images should be saved in a folder with the same name as your lesson .md file. The editor assigned to your lesson can assist you in uploading your images when you submit. 
+Images should be saved in a folder with the same name as your lesson .md file. The editor assigned to your lesson can assist you in uploading your images when you submit.
 
 To insert an image in your text, use the following format:
 
@@ -260,12 +260,12 @@ Images may not appear in previews of your lesson, but your editor will ensure th
 Lines of code should be formatted to distinguish them clearly from prose:
 
  *	Lines of code should be maximum 80 characters
- *	Multi-line code blocks should be enclosed in three \`\`\`back-ticks\`\`\`. 
+ *	Multi-line code blocks should be enclosed in three \`\`\`back-ticks\`\`\`.
  *	Inline code (rarely used) can be enclosed in single \`backticks\`.
 
 
-``` 
-They will look like this 
+```
+They will look like this
 ```
 ` and this ` respectively.
 
@@ -276,7 +276,7 @@ Follow best practice in writing your code:
 *	**User Commands**: when writing about text you want the reader to replace with their own information, use FULL CAPS and enclose by ` backticks ` (eg, \`USERNAME HERE\`).
 *	**Filenames**: filenames that you ask your reader to create or use should be enclosed in `backticks` when mentioned in the text and should include their file extension. Choose names that are concise and meaningful. You may use [snake_case](https://en.wikipedia.org/wiki/Snake_case) or [camelCase](https://en.wikipedia.org/wiki/Camel_case), but be consistent (eg, `data.txt`, `cleanData.py` etc).
 *	**Reserved Words**: words that are part of a programming language should always be formatted as `code` using `back-ticks` in the running prose. A list of reserved words in common programming languages include:
-   
+
 #### JavaScript:
 
 `abstract`, `arguments`, `await`, `Boolean`, `break`, `byte`, `case`, `catch`, `char`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `double`, `else`, `enum`, `eval`, `export`, `extends`, `false`, `final`, `finally`, `float`, `for`, `function`, `goto`, `if`, `implements`, `import`, `in`, `instanceof`, `int`, `interface`, `let`, `long`, `native`, `new`, `null`, `package`, `private`, `protected`, `public`, `return`, `short`, `static`, `super`, `switch`, `synchronized`, `this`, `throw`, `throws`, `transient`, `true`, `try`, `typeof`, `var`, `void`, `volatile`, `while`, `with`, `yield`.
@@ -293,7 +293,7 @@ Follow best practice in writing your code:
 
 ## Step 3: Submitting a New Lesson
 
-Double-check that your lesson file has been prepared to the above specifications. Once you are satisfied, we strongly recommend that you ask at least two people to try your tutorial and provide feedback. This will help you make improvements that mean our peer reviewers can focus on helping you produce the strongest possible lesson. 
+Double-check that your lesson file has been prepared to the above specifications. Once you are satisfied, we strongly recommend that you ask at least two people to try your tutorial and provide feedback. This will help you make improvements that mean our peer reviewers can focus on helping you produce the strongest possible lesson.
 
 You are ready to submit the lesson for peer review. Submissions are made to our peer review site on [Github](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons).
 
@@ -318,7 +318,7 @@ The peer review process normally happens in 3 stages:
 
 3) Once your editor and peer reviewers are happy with the piece, the editor will recommend publication to the Managing Editor, who will read the piece to ensure that it meets our Author's Guidelines and standards. In some cases there may be additional revisions or copy editing at this stage to bring the  piece in line with our publishing standards. If the Managing Editor is happy with the piece, it will be moved to the live site for publication. Your editor will inform you of any additional information required at this stage.
 
-You may find it helpful to read our [editor guidelines](/editor-guidelines), which detail our editorial process. 
+You may find it helpful to read our [editor guidelines](/editor-guidelines), which detail our editorial process.
 
 If at any point you are unsure of your role or what to do next, post a question to the peer review issue. One of our editors will respond as soon as possible. We endeavour to respond to all queries within a few days.
 

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -33,8 +33,6 @@ If your proposal is accepted, an editor will create a "Proposal" page on our [su
 
 During this 90 day period, your point of contact will be the managing editor or an editor delegated at the managing editor's perogative.
 
---
-
 ## Step 2: Writing and Formatting a New Lesson
 This style guide lays out a set of standards for authors to use when creating or translating English-language lessons for *Programming Historian*. By using it, you help us ensure content is consistent and accessible.
 
@@ -189,13 +187,8 @@ The guideline is to use them sparingly in the running prose. Specific rules:
 *	Use the "Notes and Bibliography" system found in the [*The Chicago Manual of Style*, 17th Edition](https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html) for endnotes.
 *	On first mention of a published work, include author name (including first/given name). For example, "You can find more information in *The Elements of Typographic Style* by Robert Bringhurst," or "For more information, consult Robert Bringhurt’s *The Elements of Typographic Style*." On subsequent references, just use the book title. Author’s names can be shortened to surname only on subsequent use.
 *	Endnotes should not just contain a URL.
-This:
-
-    *	Grove, John. "Calhoun and Conservative Reform." *American Political Thought* 4, no. 2 (2015): 203–27. https://doi.org/10.1086/680389.
-
- Not this
-
-    *	https://doi.org/10.1086/680389
+    *	(Correct): Grove, John. "Calhoun and Conservative Reform." *American Political Thought* 4, no. 2 (2015): 203–27. https://doi.org/10.1086/680389.
+    *	(Incorrect): https://doi.org/10.1086/680389
 
 
 ### Challenging Words Explained
@@ -258,7 +251,7 @@ Images should be saved in a folder with the same name as your lesson .md file. T
 To insert an image in your text, use the following format:
 
 ```
-{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION" %}
+\{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION" %}
 ```
 
 Images may not appear in previews of your lesson, but your editor will ensure they render properly when the lesson is published.
@@ -297,7 +290,6 @@ Follow best practice in writing your code:
 #### R:
 `break`, `else`, `for`, `FALSE`, `function`, `if`, `in`, `Inf`, `NA`, `NA_character_`, `NA_complex_`, `NA_integer_`, `NA_real_`, `NaN`, `next`, `NULL`, `repeat`, `TRUE`, `while`.
 
---
 
 ## Step 3: Submitting a New Lesson
 
@@ -344,6 +336,6 @@ To raise a concern, please contact one of the following parties, chosing whomeve
 
 We hope you don't find yourself in a situation in which you are unhappy, but if you do, we thank you for helping us to improve.
 
---
+---
 
 This style guide was created with support from the School of Humanities, University of Hertfordshire.

--- a/en/lesson-template.md
+++ b/en/lesson-template.md
@@ -17,31 +17,32 @@ This file can be used as a template for writing your lesson. It includes informa
 
 **Delete everything above this line when ready to submit your lesson**.
 
-title: ["YOUR TITLE HERE"]
+title: YOUR TITLE HERE
 collection: lessons
 layout: lesson
-slug: [LEAVE BLANK]
-date: [LEAVE BLANK]
-translation_date: [LEAVE BLANK]
+slug: LEAVE BLANK
+date: LEAVE BLANK
+translation_date: LEAVE BLANK
 authors:
-- [FORENAME SURNAME 1]
-- [FORENAME SURNAME 2, etc]
+- FORENAME SURNAME 1
+- FORENAME SURNAME 2, etc
 reviewers:
-- [LEAVE BLANK]
+- LEAVE BLANK
 editors:
-- [LEAVE BLANK]
+- LEAVE BLANK
 translator:
-- [FORENAME SURNAME 1]
+- FORENAME SURNAME 1
+- FORENAME SURNAME 2, etc
 translation-editor:
-- [LEAVE BLANK]
+- LEAVE BLANK
 translation-reviewer:
-- [LEAVE BLANK]
-original: [LEAVE BLANK]
-review-ticket: [LEAVE BLANK]
-difficulty: [LEAVE BLANK]
-activity: [LEAVE BLANK]
-topics: [LEAVE BLANK]
-abstract: [LEAVE BLANK]
+- LEAVE BLANK
+original: LEAVE BLANK
+review-ticket: LEAVE BLANK
+difficulty: LEAVE BLANK
+activity: LEAVE BLANK
+topics: LEAVE BLANK
+abstract: LEAVE BLANK
 ---
 
 # A Table of Contents

--- a/en/lesson-template.md
+++ b/en/lesson-template.md
@@ -1,0 +1,130 @@
+# Programming Historian English Language Lesson Template
+
+This file can be used as a template for writing your lesson. It includes information and guidelines on formatting which supplement but do not replace the author's guidelines (https://programminghistorian.org/en/author-guidelines)
+
+## Some Important Reminders:
+
+*	Tutorials should not exceed 8,000 words (including code).
+*	Keep your tone formal but accessible.
+*	Talk to your reader in the second person (you).
+*	Adopt a widely-used version of English (British, Canadian, Indian, South African etc).
+*	The piece of writing is a "tutorial" or a "lesson" and not an "article".
+*  Adopt open source principles
+*  Write for a global audience
+*  Write sustainably
+
+# Lesson Metadata
+
+**Delete everything above this line when ready to submit your lesson**.
+
+title: ["YOUR TITLE HERE"]
+collection: lessons
+layout: lesson
+slug: [LEAVE BLANK]
+date: [LEAVE BLANK]
+translation_date: [LEAVE BLANK]
+authors:
+- [FORENAME SURNAME 1]
+- [FORENAME SURNAME 2, etc]
+reviewers:
+- [LEAVE BLANK]
+editors:
+- [LEAVE BLANK]
+translator:
+- [FORENAME SURNAME 1]
+translation-editor:
+- [LEAVE BLANK]
+translation-reviewer:
+- [LEAVE BLANK]
+original: [LEAVE BLANK]
+review-ticket: [LEAVE BLANK]
+difficulty: [LEAVE BLANK]
+activity: [LEAVE BLANK]
+topics: [LEAVE BLANK]
+abstract: [LEAVE BLANK]
+---
+
+# A Table of Contents
+
+Include the following short code to automatically generate a table of contents for your lesson (mandatory).
+
+{% include toc.html %}
+
+--
+
+## Some Markdown Formatting Examples:
+
+# First Level Heading
+## Second Level Heading
+### Third Level Heading
+#### Fourth Level Heading
+
+
+### Font Formatting
+**bold text**
+*italic text*
+`reserved words` (eg "for loop", or "myData.csv")
+
+### Links
+
+Create [a link to *Programming Historian*](http://programminghistorian.org) using the format in this sentence. Ensure linked phrases are semantically meaningful. Do not link terms that are meaningful only to sighted users such as "click here".
+
+### Inserting Images:
+
+Copy this short-code to insert an image. Replace words in all caps with your image information (eg, Figure1.jpg). Captions should include sequential image numbering (eg "Figure 1: ..."). 
+
+{% include figure.html filename="IMAGE-FILENAME" caption="CAPTION TO IMAGE" %}
+
+### Alerts and Warnings
+
+If you want to include an aside or a warning to readers, you can set it apart from the main text:
+
+<div class="alert alert-warning">
+ Be sure that you follow directions carefully!
+</div>
+
+It will appear in a coloured box and can be useful for drawing attention to particular warnings.
+
+### A Sample Unordered List
+
+* Here is an item
+* Here is another item
+* Here is the final item
+
+### A Sample Ordered List
+
+1. Here is an item
+2. Here is another item
+3. Here is the final item
+
+###A Sample Table
+
+| Heading 1 | Heading 2 | Heading 3 |
+| --------- | --------- | --------- |
+| Row 1, column 1 | Row 1, column 2 | Row 1, column 3|
+| Row 2, column 1 | Row 2, column 2 | Row 2, column 3|
+| Row 3, column 1 | Row 3, column 2 | Row 3, column 3|
+Table 1: This table contains...
+
+### Referencing
+
+*	Links rather than endnotes may be appropriate in most cases.
+*	Ensure linked phrases are semantically meaningful. Do not link terms that are meaningful only to sighted users such as "click here".
+*	All traditionally published and academic literature should be end-noted rather than linked.
+*	If you are writing an "analysis" tutorial, you must refer to published scholarly literature.
+*	Endnote superscripts should be outside the final punctuation like this.[^1] Not inside like this[^1].
+*	Use the "Notes and Bibliography" system found in the [The Chicago Manual of Style, 17th Edition](https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html) for endnotes.
+
+#### An End Note:
+
+This is some text.[^1]
+This is some more text.[^2]
+
+##### Endnotes
+[^1] Properly formatted citation using Chicago Manual of Style
+[^2] Properly formatted citation using Chicago Manual of Style
+
+
+# Further Questions?
+
+Your assigned editor or the managing editor would be happy to answer any questions you may have.


### PR DESCRIPTION
closes #1367.
closes #1382.

This pull request updates the English language "Author-Guidelines.md" to include the new stylesheet discussed in various issues: #959 #1194 #1209 #1367 and which members of the team have already had a chance to comment upon.

I have integrated the new style guidelines into our existing page, after having condensed and organised the new information into 3 categories: 

* A. Style and Audience (philosophical information)
* B. Specific Style Guidelines (grammar and writing guidelines)
* C. Formatting Guidelines (markdown specific things)

The steps on pitching and submitting a lesson remain but have been condensed.

I don't believe any important information has been lost through this process, and I hope the new styleguide makes it easier for authors and editors to follow, as I've tried to organize the information more logically.

I have also pulled the Lesson Template out into a separate file to avoid some of the rendering issues raised in #1382. I've reorganized this slightly to put it in line with the author guidelines. The template is linked within the guidelines.