### PR TITLE
Minor change to the text of Introduction to stylometry with Python; fixes issue 1388

### DIFF
--- a/en/lessons/introduction-to-stylometry-with-python.md
+++ b/en/lessons/introduction-to-stylometry-with-python.md
@@ -56,7 +56,7 @@ This tutorial uses both datasets and software that you will have to download and
 
 ### The Dataset ###
 
-To work through this lesson, you will need to download and unzip the archive of the _Federalist Papers_ ([.zip](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/assets/introduction-to-stylometry-with-python/stylometry-federalist.zip)) containing the 85 documents that we will use for our analysis. The archive also contains the [original Project Gutenberg ebook](http://www.gutenberg.org/cache/epub/1404/pg1404.txt) version of the _Federalist Papers_ from which these 85 documents have been extracted. When you unzip the archive, it will create a [directory](https://en.wikipedia.org/wiki/Directory_(computing)) called `data`. This will be your [working directory](https://en.wikipedia.org/wiki/Working_directory) and all work should be saved here while completing the lesson.
+To work through this lesson, you will need to download and unzip the archive of the _Federalist Papers_ ([.zip](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/assets/introduction-to-stylometry-with-python/stylometry-federalist.zip)) containing the 85 documents that we will use for our analysis. The archive also contains the [original Project Gutenberg ebook](http://www.gutenberg.org/cache/epub/1404/pg1404.txt) version of the _Federalist Papers_ from which these 85 documents have been extracted. When you unzip the archive, it will create a [directory](https://en.wikipedia.org/wiki/Directory_(computing)) called `data` in your current [working directory](https://en.wikipedia.org/wiki/Working_directory). Make sure that you stay in this current working directory and that you save all work here while completing the lesson.
 
 ### The Software ###
 

--- a/fr/lecons/introduction-a-la-stylometrie-avec-python.md
+++ b/fr/lecons/introduction-a-la-stylometrie-avec-python.md
@@ -62,7 +62,7 @@ Ce tutoriel utilise un jeu de données et des logiciels que vous devrez téléch
 ### Le jeu de données
 
 Pour compléter les exercices de ce tutoriel, vous devrez télécharger et ouvrir l'archive des _Federalist Papers_ [.zip](https://github.com/programminghistorian/jekyll/tree/gh-pages/assets/introduction-to-stylometry-with-python) qui contient
-les 85 articles dont nous aurons besoin pour effectuer notre analyse. L'archive contient également le [livre électronique du Projet Gutenberg](http://www.gutenberg.org/cache/epub/1404/pg1404.txt) dont ces 85 documents ont été extraits. L'ouverture du fichier .zip créera un [répertoire](https://fr.wikipedia.org/wiki/R%C3%A9pertoire_(informatique)) nommé `data`. Ce sera votre répertoire de travail et tout le travail que vous réaliserez en suivant le tutoriel devrait y être sauvegardé.
+les 85 articles dont nous aurons besoin pour effectuer notre analyse. L'archive contient également le [livre électronique du Projet Gutenberg](http://www.gutenberg.org/cache/epub/1404/pg1404.txt) dont ces 85 documents ont été extraits. L'ouverture du fichier .zip créera un [répertoire](https://fr.wikipedia.org/wiki/R%C3%A9pertoire_(informatique)) nommé `data` dans votre répertoire de travail courant. Assurez-vous de rester dans ce répertoire de travail courant et d'y sauvegarder tout le travail que vous réaliserez en suivant le tutoriel.
 
 ### Le logiciel
 


### PR DESCRIPTION
This change clarifies which directory is the working directory while running the tutorial. French and English text updated. I do not believe that the tutorial has been translated into Spanish but I have requested a review from @programminghistorian/spanish-team anyway, just in case.