### PR TITLE
Escape ampersand in gravity model lesson

### DIFF
--- a/_includes/feed-item.html
+++ b/_includes/feed-item.html
@@ -1,5 +1,5 @@
 <item>
-<title>{{ page.title }}</title>
+<title>{{ page.title | xml_escape }}</title>
 {% if page.abstract %}
   <description>{{ page.abstract | xml_escape }}</description>
 {% else %}

--- a/en/lessons/gravity-model.md
+++ b/en/lessons/gravity-model.md
@@ -1,5 +1,5 @@
 ---
-title: "Introduction to Gravity Models of Migration & Trade"
+title: "Introduction to Gravity Models of Migration &amp; Trade"
 collection: lessons
 layout: lesson
 slug: gravity-model

--- a/en/lessons/gravity-model.md
+++ b/en/lessons/gravity-model.md
@@ -1,5 +1,5 @@
 ---
-title: "Introduction to Gravity Models of Migration &amp; Trade"
+title: "Introduction to Gravity Models of Migration & Trade"
 collection: lessons
 layout: lesson
 slug: gravity-model


### PR DESCRIPTION
Closes #1412. The ampersand appears to be causing the RSS feed to not render in a valid manner. 