### PR TITLE
remove "initial" from "English version" on index

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -415,7 +415,7 @@ journal-title:
   es: The Programming Historian en español
   fr: The Programming Historian en français
 journal-subtitle: # ENGLISH ONLY FOR NOW, DO NOT TRANSLATE
-  en: The initial English version
+  en: English version
 title-open-quote:
   en: '"'
   es: '"'


### PR DESCRIPTION
I've removed "The Initial" from "The Initial English Version" on the front page. That makes it sound like the English publication is more important.