### PR TITLE
remove Editorial from Adam

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -43,7 +43,6 @@
     fr: |
         Adam Crymble est maître de conférences en histoire numérique à l'Université du Hertfordshire.
   team_roles:
-   - editorial
    - board
    - team-development-manager
    - global


### PR DESCRIPTION
Removing myself from the "editorial" team of the English publication, as I wont' be taking on editing this coming year. I'll instead be focusing on the development work and the new company we're setting up.