### PR TITLE
Add explainer re relationship between the Programming Historian and ProgHist Ltd

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -200,11 +200,16 @@ issn:
 footer:
   license:
     en: |
-      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license. _The Programming Historian_ is an international volunteer-driven project whose financial activities are administered by _[ProgHist Limited](https://beta.companieshouse.gov.uk/company/12192946)_, a Not for Profit Company Limited by Guarantee that is registered in England, Company Number 12192946.
+      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license. 
     es: |
       _The Programming Historian en español_ (ISSN: 2517-5769) se publica con una licencia [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.es).
     fr: |
       _The Programming Historian en français_ (ISSN: 2631-9462) est publié sous licence [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.fr).
+  financial:
+    en: |
+      This project is administered by ProgHist Limited, Company Number 12192946.
+    es: |
+    fr: |
 
   gh-hosted:
     en: Hosted on GitHub

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -200,7 +200,7 @@ issn:
 footer:
   license:
     en: |
-      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license.
+      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license. _The Programming Historian_ is an international volunteer-driven project whose financial activities are administered by _[ProgHist Limited](https://beta.companieshouse.gov.uk/company/12192946)_, a Not for Profit Company Limited by Guarantee that is registered in England, Company Number 12192946.
     es: |
       _The Programming Historian en español_ (ISSN: 2517-5769) se publica con una licencia [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.es).
     fr: |

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -210,6 +210,7 @@ footer:
       This project is administered by ProgHist Limited, Company Number 12192946.
     es: |
     fr: |
+        Ce projet est administré par ProgHist Limited, no d'immatriculation 12192946.
 
   gh-hosted:
     en: Hosted on GitHub

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -209,6 +209,7 @@ footer:
     en: |
       This project is administered by ProgHist Limited, Company Number 12192946.
     es: |
+      Este proyecto es administrado por ProgHist Limited, con número de compañía 12192946. 
     fr: |
         Ce projet est administré par ProgHist Limited, no d'immatriculation 12192946.
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
 
 
 <div class="d-flex flex-wrap justify-content-center footer-head">
-  {{ site.data.snippets.footer.license[page.lang] | markdownify }}
+  {{ site.data.snippets.footer.license[page.lang] | markdownify }}{{ site.data.snippets.footer.financial[page.lang] | markdownify }}
 </div>
 
 <div class="d-flex flex-wrap justify-content-around">

--- a/en/about.md
+++ b/en/about.md
@@ -30,9 +30,9 @@ The _Programming Historian_ team is committed to diversity, and we insist on a h
 
 ## Funding & Ownership
 
-For a list of our funders and supports, see the ['Support Us']({{site.baseurl}}/support-us) page
+The Programming Historian is an international volunteer-driven project whose financial activities are administered by ProgHist Limited, a Not for Profit Company Limited by Guarantee that is registered in England, Company Number 12192946. It is published by the _Editorial Board of the Programming Historian_. 
 
-The _Programming Historian_ is a volunteer-driven project. It is published by the _Editorial Board of the Programming Historian_.
+For a list of our funders and supports, see the ['Support Us']({{site.baseurl}}/support-us) page
 
 ## History of the Project
 

--- a/es/acerca-de.md
+++ b/es/acerca-de.md
@@ -29,9 +29,9 @@ _The Programming Historian en español_ (ISSN {{ site.data.snippets.issn[page.la
 En The Programming Historian estamos comprometidos con la diversidad y defendemos la necesidad de mantener un espacio de trabajo sin ningún tipo de acoso u hostigamiento basado en el género, identidad, orientación sexual, capacidades, físico, peso, etnia, edad, religión o nivel de conocimiento técnico de los participantes y colaboradores. Asimismo, nuestro compromiso con la diversidad se extiende a la composición del Consejo Editorial garantizando que los miembros de un mismo género o nacionalidad no alcanzan una ratio superior al 50% +1 del total. Con esto pretendemos que el proyecto se siga beneficiando de puntos de vista distintos. La medida está sujeta a revisiones futuras, por lo que aceptamos el envío de sugerencias de los miembros de la comunidad.
 
 ## Financiamiento y propiedad
-Para ver un listado de patrocinadores y ayudas, visita nuestra página '[Apóyanos](/es/apoyanos)'.
+Programming Historian es un proyecto internacional impulsado por voluntarios. Sus actividades financieras son administradas por ProgHist Limited, una organización sin fines de lucro limitada por garantía que está registrada en Inglaterra, con número de compañía 12192946. El proyecto es publicado por el consejo editorial de *Programming Historian*. 
 
-*The Programming Historian* es un proyecto impulsado por voluntarios y publicado por su Consejo Editorial.
+Para ver un listado de patrocinadores y ayudas, visita nuestra página '[Apóyanos](/es/apoyanos)'.
 
 ## Historia del proyecto
 

--- a/fr/apropos.md
+++ b/fr/apropos.md
@@ -30,8 +30,8 @@ Le _Programming Historian en français_ s'attache au principe de la diversité. 
 
 ## Financement & proprieté
 
+Le _Programming Historian_ est un projet international mené par des volontaires. Ses activités financières sont administrées par ProgHist Limited, une société à but non lucratif immatriculée en Angleterre sous le numéro 12192946. Le projet est publié par le conseil éditorial du _Programming Historian_.
 Une liste de nos donateurs et des soutiens reçus est consultable sur la page qui expose comment vous pouvez ['nous soutenir']({{site.baseurl}}/fr/nous-soutenir).
-Le _Programming Historian_ est un projet mené par des volontaires et publié par le conseil éditorial du _Programming Historian_.
 
 ## Histoire du projet
 


### PR DESCRIPTION
Per https://github.com/programminghistorian/jekyll/issues/1442 add text to describe relationship between the Programming Historian and ProgHist Ltd. Requires hacking `license` category, so may require refactoring. Also requires translation @programminghistorian/french-team @programminghistorian/spanish-team. Note, ProgHist Ltd will be operational from 1 October, so ideally this will be done before then.