### PR TITLE
French translation of the  Privacy Policy page; closes Issue 1359

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -50,8 +50,8 @@ menu-about-privacy:
     title: Política de privacidad
     link: /es/politica-de-privacidad
   fr:
-    title: Privacy Policy
-    link: /en/privacy-policy
+    title: Politique sur la vie privée
+    link: /fr/politique-vie-privee
 menu-contribute:
   en: Contribute
   es: Contribuciones

--- a/fr/politique-vie-privee.md
+++ b/fr/politique-vie-privee.md
@@ -7,9 +7,9 @@ layout: blank
 
 ## Publication de données
 
-En tant qu'éditeur en libre accès qui souscrit aux principes d'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteurs, traducteurs, rédacteurs et évaluateurs. Cette information est affichée publiquement dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elle sert aussi à insérer des informations pertinentes (par exemple, le nom et la biographie d'un.e auteur.e) dans diverses autres pages du site.
+En tant qu'éditeur qui souscrit aux principes du libre accès et de l'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteurs, traducteurs, rédacteurs et évaluateurs. Ces informations sont publiées dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elles servent aussi à bonifier plusieurs autres pages du site en y insérerant des données pertinentes (par exemple, le nom et la biographie d'un.e auteur.e).
 
-Selon les rôles, l'information recueillie peut inclure:
+Selon les rôles joués par chaque individu au sein du projet, l'information recueillie peut inclure:
 
 - Le nom
 - L'adresse d'un site web personnel ou professionnel
@@ -19,36 +19,36 @@ Selon les rôles, l'information recueillie peut inclure:
 - L'année de départ du Comité éditorial
 - Les rôles au sein du Comité éditorial, s'il y a lieu
 - L'affiliation institutionnelle
-- Une courte biographie, habituellement fournie par l'auteur ou le rédacteur
+- Une courte biographie, habituellement fournie par l'auteur ou par le rédacteur
 - Un identificateur ORCID
 
-En accord avec notre code d'éthique favorisant l'ouverture et afin d'exprimer notre gratitude envers les auteurs, traducteurs, rédacteurs et évaluateurs, nous publions les noms de toutes les personnes qui contribuent dans l'un ou l'autre de ces rôles sur la page de chaque leçon publiée et sur la page Équipe du projet (et ses traductions).
+En vertu de notre code d'éthique qui favorise l'ouverture et afin d'exprimer notre gratitude envers les auteurs, traducteurs, rédacteurs et évaluateurs, nous publions les noms de toutes les personnes qui ont contribué au développement d'une leçon publiée, dans l'un ou l'autre de ces rôles, sur la page de cette leçon et sur la page Équipe du projet (et ses traductions).
 
-Si vous désirez nous contacter pour discuter des données que nous détenons à votre sujet, vous pouvez écrire à notre rédactrice en chef. Vous avez le droit de retirer la permission en vertu de laquelle nous utilisons ces données. Notez cependant que le Droit à l'oubli pourrait ne pas s'appliquer aux auteurs d'un article publié puisque nous avons un intérêt légitime à conserver vos données afin de vous identifier comme auteur d'un article publié et indexé.
+Si vous désirez nous contacter pour discuter des données que nous détenons à votre sujet, vous pouvez écrire à notre rédactrice en chef. Vous avez le droit de retirer la permission en vertu de laquelle nous utilisons ces données. Notez cependant que le Droit à l'oubli pourrait ne pas s'appliquer aux auteur.e.s d'un article publié puisque nous avons un intérêt légitime à conserver vos données afin de vous identifier comme auteur.e d'un article publié et indexé.
 
 ## Données Google Analytics
 
-Le *Programming Historian* récolte également des données au sujet du trafic sur le web. Nous utilisons ces données pour identifier les besoins de nos visiteurs, pour savoir quels types de leçons sont les plus demandés dans certaines régions géographiques, pour promouvoir le succès de notre projet auprès de partenaires, de bailleurs de fonds et d'agences externes à l'aide de statistiques sommaires, et pour réaliser et publier des recherches concernant les humanités numériques, l'enseignement et l'apprentissage.
+Le *Programming Historian* récolte également des données au sujet du trafic sur notre site web. Nous utilisons ces données pour identifier les besoins de nos visiteurs, pour savoir quels types de leçons sont les plus demandés dans certaines régions géographiques, pour promouvoir notre projet auprès de partenaires potentiels, de bailleurs de fonds et d'agences externes à l'aide de statistiques sommaires, et pour réaliser et publier des recherches concernant les humanités numériques, l'enseignement et l'apprentissage.
 
 Aucune des données recueillies par Google Analytics ne nous permet d'identifier des individus.
 
-Google Analytics installe un certain nombre de "cookies" sur votre ordinateur lorsque vous visitez notre site. Ils peuvent inclure:
+Google Analytics installe un certain nombre de "cookies" sur votre ordinateur lorsque vous visitez notre site. Ceux-ci peuvent inclure:
 
 `_ga`, `_gat`
 
-Vous pouvez bloquer ceci en utilisant les paramètres "Ne pas traquer" de votre fureteur. 
+Vous pouvez bloquer ces cookies en utilisant les paramètres "Ne pas traquer" de votre fureteur. 
 
 `_utmv`
 
-Google Analytics utilise ce cookie pour déterminer les types de visiteurs qui consultent notre site. Ce cookie détermine les préférences de l'usager en fonction des pages visitées, afin que nous puissions utiliser cette information pour savoir quelles pages sont les plus populaires et pourquoi les lecteurs visitent notre site.
+Google Analytics utilise ce cookie pour déterminer quels types de visiteurs consultent notre site. Ce cookie détermine les préférences des usagers en fonction des pages qu'ils visitent, afin que nous puissions identifier nos pages les plus populaires et savoir ce qui intéresse nos lecteurs.
 
 `__utmz`
 
-Google Analytics utilise ce cookie pour déterminer la méthode de référence utilisée par chaque visiteur qui entre sur notre site. Le cookie détermine si l'usager atteint notre site directement ou par l'intermédiaire d'un moteur de recherche, d'un courriel ou d'une campagne de courriels. Nous utilisons cette information pour comprendre comment nos utilisateurs atteignent notre site. 
+Google Analytics utilise ce cookie pour déterminer comment nos visiteurs parviennent à notre site. Le cookie détermine si un usager entre sur le site directement ou par l'intermédiaire d'un moteur de recherche, d'un courriel ou d'une campagne de courriels. Nous utilisons cette information pour comprendre comment nos utilisateurs atteignent notre site. 
 
 `__utma`
 
-Ce cookie sert à identifier les visiteurs uniques de notre site. Les résultats sont transmis à notre compte Google Analytics pour que nous puissions savoir combien de visiteurs différents visitent notre site au cours d'une période spécifique.
+Ce cookie sert à identifier les visiteurs uniques de notre site. Les résultats sont transmis à notre compte Google Analytics pour que nous puissions dénombrer les individus qui visitent notre site au cours d'une période spécifique.
 
 `__utmb`
 

--- a/fr/politique-vie-privee.md
+++ b/fr/politique-vie-privee.md
@@ -1,0 +1,59 @@
+---
+title: Politique sur la vie privée
+layout: blank
+---
+
+# Politique sur la vie privée
+
+## Publication de données
+
+En tant qu'éditeur en libre accès qui souscrit aux principes d'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteurs, traducteurs, rédacteurs et évaluateurs. Cette information est affichée publiquement dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elle sert aussi à insérer des informations pertinentes (par exemple, le nom et la biographie d'un.e auteur.e) dans diverses autres pages du site.
+
+Selon les rôles, l'information recueillie peut inclure:
+
+- Le nom
+- L'adresse d'un site web personnel ou professionnel
+- Le nom d'usager sur Twitter
+- Le nom d'usager sur Github
+- L'année d'entrée au Comité éditorial
+- L'année de départ du Comité éditorial
+- Les rôles au sein du Comité éditorial, s'il y a lieu
+- L'affiliation institutionnelle
+- Une courte biographie, habituellement fournie par l'auteur ou le rédacteur
+- Un identificateur ORCID
+
+In keeping with our open ethos, and to express our gratitude to authors, translators reviewers, and editors, we publicly acknowledge the names of all individuals who participate in one of these activities on the published lesson, and on our Project Team page (and its translations).
+
+If you wish to contact us to discuss any data we may have about you, you can email our managing editor. You have the right to withdraw your consent to our use of this data, however, it should be noted that Right to Erasure may not apply to authors of a submitted article as we have a legitimate interest in keeping your data to identify you as the author of a published and indexed text.
+
+## Google Analytics Data
+
+The *Programming Historian* also collects web traffic data. We use this data to identify the needs of our visitors, to identify types of lessons that are in high demand in certain geographic regions, to promote the success of the project with potential funders, partners, and outside bodies through summary statistics, and to conduct and publish research about digital humanities and teaching and learning.
+
+None of the data collected by Google Analytics allows us to identify individuals.
+
+Google Analytics sets a number of "cookies" on your computer when you visit the website. These may include:
+
+`_ga`, `_gat`
+
+You can block this using the "Do Not Track" settings in your browser
+
+`_utmv`
+
+This cookie is used by Google Analytics to determine the type of visitor that visits our website. The cookie determines the user's preferences based on which webpages they visit, so that we may use this data to understand which are the most popular webpages and why people visit the website.
+
+`__utmz`
+
+This cookie is used by Google Analytics to determine the type of referral used by each visitor to arrive at our website. The cookie determines if the user has come directly to our website or via a search engine, e-mail or e-mail campaign. We use this data to understand how our users arrive at our website.
+
+`__utma`
+
+This cookie is used to identify unique visitors to our website. The results are sent to our Google Analytics account, so that we can see how many unique visitors come to the site over a period of time.
+
+`__utmb`
+
+This cookie is used by Google Analytics to determine the visitor session times on our website. Each time you visit a new webpage on the website, the cookie is set to expire within 30 minutes. If it does not find an existing cookie, a new one is created.
+
+`__utmc`
+
+This cookie is used by Google Analytics in conjunction with `__utmb` to determine visitor sessions. Unlike `__utmb`, this cookie does not have an expiry date. It determines whether a new session should be created based on whether you have previously closed your browser, re-opened it and come back to the website.

--- a/fr/politique-vie-privee.md
+++ b/fr/politique-vie-privee.md
@@ -7,7 +7,7 @@ layout: blank
 
 ## Publication de données
 
-En tant qu'éditeur qui souscrit aux principes du libre accès et de l'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteurs, traducteurs, rédacteurs et évaluateurs. Ces informations sont publiées dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elles servent aussi à bonifier plusieurs autres pages du site en y insérerant des données pertinentes (par exemple, le nom et la biographie d'un.e auteur.e).
+En tant qu'éditeur qui souscrit aux principes du libre accès et de l'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteur(e)s, traducteurs et traductrices, rédacteurs et rédactrices, et évaluateurs et évaluatrices. Ces informations sont publiées dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elles servent aussi à bonifier plusieurs autres pages du site en y insérerant des données pertinentes (par exemple, le nom et la biographie d'un(e) auteur(e)).
 
 Selon les rôles joués par chaque individu au sein du projet, l'information recueillie peut inclure:
 
@@ -19,12 +19,12 @@ Selon les rôles joués par chaque individu au sein du projet, l'information rec
 - L'année de départ du Comité éditorial
 - Les rôles au sein du Comité éditorial, s'il y a lieu
 - L'affiliation institutionnelle
-- Une courte biographie, habituellement fournie par l'auteur ou par le rédacteur
-- Un identificateur ORCID
+- Une courte biographie, habituellement fournie par l'auteur(e) ou par la personne responsable du suivi éditorial
+- Un identifiant ORCID
 
-En vertu de notre code d'éthique qui favorise l'ouverture et afin d'exprimer notre gratitude envers les auteurs, traducteurs, rédacteurs et évaluateurs, nous publions les noms de toutes les personnes qui ont contribué au développement d'une leçon publiée, dans l'un ou l'autre de ces rôles, sur la page de cette leçon et sur la page Équipe du projet (et ses traductions).
+En vertu de notre code d'éthique qui favorise l'ouverture et afin d'exprimer notre gratitude envers les auteur(e)s, traducteurs et traductrices, rédacteurs et rédactrices, et évaluateurs et évaluatrices, nous publions les noms de toutes les personnes qui ont contribué au développement d'une leçon publiée, dans l'un ou l'autre de ces rôles, sur la page de cette leçon et sur la page Équipe du projet (et ses traductions).
 
-Si vous désirez nous contacter pour discuter des données que nous détenons à votre sujet, vous pouvez écrire à notre rédactrice en chef. Vous avez le droit de retirer la permission en vertu de laquelle nous utilisons ces données. Notez cependant que le Droit à l'oubli pourrait ne pas s'appliquer aux auteur.e.s d'un article publié puisque nous avons un intérêt légitime à conserver vos données afin de vous identifier comme auteur.e d'un article publié et indexé.
+Si vous désirez nous contacter pour discuter des données que nous détenons à votre sujet, vous pouvez écrire à notre rédacteur ou rédactrice en chef. Vous avez le droit de retirer la permission en vertu de laquelle nous utilisons ces données. Notez cependant que le Droit à l'oubli pourrait ne pas s'appliquer aux auteur(e)s d'un article publié puisque nous avons un intérêt légitime à conserver vos données afin de vous identifier comme auteur(e) d'un article publié et indexé.
 
 ## Données Google Analytics
 

--- a/fr/politique-vie-privee.md
+++ b/fr/politique-vie-privee.md
@@ -3,9 +3,9 @@ title: Politique sur la vie privée
 layout: blank
 ---
 
-# Politique sur la vie privée
+# Utilisation des données à caractère personnel
 
-## Publication de données
+## Publication des informations vous concernant
 
 En tant qu'éditeur qui souscrit aux principes du libre accès et de l'ouverture, le *Programming Historian* recueille un certain nombre d'informations au sujet de ses auteur(e)s, traducteurs et traductrices, rédacteurs et rédactrices, et évaluateurs et évaluatrices. Ces informations sont publiées dans le fichier suivant: <https://github.com/programminghistorian/jekyll/blob/gh-pages/_data/ph_authors.yml>. Elles servent aussi à bonifier plusieurs autres pages du site en y insérerant des données pertinentes (par exemple, le nom et la biographie d'un(e) auteur(e)).
 

--- a/fr/politique-vie-privee.md
+++ b/fr/politique-vie-privee.md
@@ -22,38 +22,38 @@ Selon les rôles, l'information recueillie peut inclure:
 - Une courte biographie, habituellement fournie par l'auteur ou le rédacteur
 - Un identificateur ORCID
 
-In keeping with our open ethos, and to express our gratitude to authors, translators reviewers, and editors, we publicly acknowledge the names of all individuals who participate in one of these activities on the published lesson, and on our Project Team page (and its translations).
+En accord avec notre code d'éthique favorisant l'ouverture et afin d'exprimer notre gratitude envers les auteurs, traducteurs, rédacteurs et évaluateurs, nous publions les noms de toutes les personnes qui contribuent dans l'un ou l'autre de ces rôles sur la page de chaque leçon publiée et sur la page Équipe du projet (et ses traductions).
 
-If you wish to contact us to discuss any data we may have about you, you can email our managing editor. You have the right to withdraw your consent to our use of this data, however, it should be noted that Right to Erasure may not apply to authors of a submitted article as we have a legitimate interest in keeping your data to identify you as the author of a published and indexed text.
+Si vous désirez nous contacter pour discuter des données que nous détenons à votre sujet, vous pouvez écrire à notre rédactrice en chef. Vous avez le droit de retirer la permission en vertu de laquelle nous utilisons ces données. Notez cependant que le Droit à l'oubli pourrait ne pas s'appliquer aux auteurs d'un article publié puisque nous avons un intérêt légitime à conserver vos données afin de vous identifier comme auteur d'un article publié et indexé.
 
-## Google Analytics Data
+## Données Google Analytics
 
-The *Programming Historian* also collects web traffic data. We use this data to identify the needs of our visitors, to identify types of lessons that are in high demand in certain geographic regions, to promote the success of the project with potential funders, partners, and outside bodies through summary statistics, and to conduct and publish research about digital humanities and teaching and learning.
+Le *Programming Historian* récolte également des données au sujet du trafic sur le web. Nous utilisons ces données pour identifier les besoins de nos visiteurs, pour savoir quels types de leçons sont les plus demandés dans certaines régions géographiques, pour promouvoir le succès de notre projet auprès de partenaires, de bailleurs de fonds et d'agences externes à l'aide de statistiques sommaires, et pour réaliser et publier des recherches concernant les humanités numériques, l'enseignement et l'apprentissage.
 
-None of the data collected by Google Analytics allows us to identify individuals.
+Aucune des données recueillies par Google Analytics ne nous permet d'identifier des individus.
 
-Google Analytics sets a number of "cookies" on your computer when you visit the website. These may include:
+Google Analytics installe un certain nombre de "cookies" sur votre ordinateur lorsque vous visitez notre site. Ils peuvent inclure:
 
 `_ga`, `_gat`
 
-You can block this using the "Do Not Track" settings in your browser
+Vous pouvez bloquer ceci en utilisant les paramètres "Ne pas traquer" de votre fureteur. 
 
 `_utmv`
 
-This cookie is used by Google Analytics to determine the type of visitor that visits our website. The cookie determines the user's preferences based on which webpages they visit, so that we may use this data to understand which are the most popular webpages and why people visit the website.
+Google Analytics utilise ce cookie pour déterminer les types de visiteurs qui consultent notre site. Ce cookie détermine les préférences de l'usager en fonction des pages visitées, afin que nous puissions utiliser cette information pour savoir quelles pages sont les plus populaires et pourquoi les lecteurs visitent notre site.
 
 `__utmz`
 
-This cookie is used by Google Analytics to determine the type of referral used by each visitor to arrive at our website. The cookie determines if the user has come directly to our website or via a search engine, e-mail or e-mail campaign. We use this data to understand how our users arrive at our website.
+Google Analytics utilise ce cookie pour déterminer la méthode de référence utilisée par chaque visiteur qui entre sur notre site. Le cookie détermine si l'usager atteint notre site directement ou par l'intermédiaire d'un moteur de recherche, d'un courriel ou d'une campagne de courriels. Nous utilisons cette information pour comprendre comment nos utilisateurs atteignent notre site. 
 
 `__utma`
 
-This cookie is used to identify unique visitors to our website. The results are sent to our Google Analytics account, so that we can see how many unique visitors come to the site over a period of time.
+Ce cookie sert à identifier les visiteurs uniques de notre site. Les résultats sont transmis à notre compte Google Analytics pour que nous puissions savoir combien de visiteurs différents visitent notre site au cours d'une période spécifique.
 
 `__utmb`
 
-This cookie is used by Google Analytics to determine the visitor session times on our website. Each time you visit a new webpage on the website, the cookie is set to expire within 30 minutes. If it does not find an existing cookie, a new one is created.
+Google Analytics utilise ce cookie pour calculer la durée des visites sur notre site. Chaque fois que vous visitez une nouvelle page sur le site, le cookie est programmé pour arriver à échéance après 30 minutes. Si aucun cookie n'existe au moment de la visite, un nouveau cookie est automatiquement créé.
 
 `__utmc`
 
-This cookie is used by Google Analytics in conjunction with `__utmb` to determine visitor sessions. Unlike `__utmb`, this cookie does not have an expiry date. It determines whether a new session should be created based on whether you have previously closed your browser, re-opened it and come back to the website.
+Google Analytics utilise ce cookie, en conjonction avec `__utmb`, pour mesurer la durée des visites. Contrairement à `__utmb`, ce cookie n'a pas de date de péremption. Il détermine si une nouvelle visite (ou 'session') doit être créée, en vérifiant si vous avez précédemment fermé votre fureteur et redémarré celui-ci avant de revenir sur le site. 


### PR DESCRIPTION
This creates file 'politique-vie-privee.md' in the main French subdirectory.

@programminghistorian/french-team : Please take a look at the text.

Tech team : Please change the main menu so that it points to this page instead of the English original, once Sofia or Martin has signed off on the text, as I do not know how to do it.

Thanks,
FDL