### PR TITLE
Gh actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - uses actions/setup-ruby@v1
+    - uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.5.4
     - name: Build Programming Historian

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [check_run]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,6 @@ jobs:
     - uses: actions/setup-ruby@master
     - name: Build Programming Historian
       run:
+        gem install bundler:2.0.1
         bundle install
         sh _build/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,13 @@ jobs:
   build:
 
     runs-on: ubuntu-18.04
-    
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Run a multi-line script
-      run: |
+    - uses: actions/checkout@master
+    - uses actions/setup-ruby@v1
+      with:
+        ruby-version: 2.5.4
+    - name: Build Programming Historian
+      runs:
         bundle install
         sh _build/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run a multi-line script
+      run: |
+        bundle install
+        sh _build/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.5.4
+    - uses: actions/setup-ruby@master
     - name: Build Programming Historian
       run:
         bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request]
+on: [check_run]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,21 @@
-name: CI
+
+name: Ruby
 
 on: [push]
 
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-ruby@master
-    - name: Build Programming Historian
-      run:
-        gem install bundler:2.0.1
-        bundle install
-        sh _build/build.sh
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.5.4
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.5.x
+    - name: Build and test PH
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        _build/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
       with:
         ruby-version: 2.5.4
     - name: Build Programming Historian
-      runs:
+      run:
         bundle install
         sh _build/build.sh


### PR DESCRIPTION
An early experiment with GitHub actions for #1462 

- try breaking apart build and htmlproofer steps for better UX when looking for error
- any way to get red error text like we managed to do with Travis?
- upload packages and htmlproofer caches after build
- download previous packages & caches before next build