### PR TITLE
use pipe syntax for yaml abstracts

### DIFF
--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -253,7 +253,8 @@ activity: ONE OF: acquiring, transforming, analyzing, presenting, sustaining
 topics:
  - topic one (see guidance below)
  - topic two
-abstract: see guidance below
+abstract: |
+  see guidance below
 
 ```
 

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -228,7 +228,7 @@ Si la lección fue escrita por un autor nuevo, el editor encargado necesitará u
 
 **Los espacios en blanco son importantes**, así que asegúrate de que la identación se ajusta a la de los otros casos y utiliza espacios en blanco en vez de tabuladores.
 
-Incluir el identificador `orcid` no es obligatorio, pero sí es recomendable si los autores se han registrado previamente en el [portal ORCID](https://orcid.org/). **Como editor, es importante tener la aprobación explícita del autor y asegurarse de que el identificador ORCID utilizado es el correcto**. 
+Incluir el identificador `orcid` no es obligatorio, pero sí es recomendable si los autores se han registrado previamente en el [portal ORCID](https://orcid.org/). **Como editor, es importante tener la aprobación explícita del autor y asegurarse de que el identificador ORCID utilizado es el correcto**.
 
 ### 2) Agrega una tabla de contenidos a la lección
 
@@ -275,10 +275,11 @@ translation-reviewer:
 original: slug del original ((solo en traducción))
 difficulty: (ver abajo o mantener original en traducciones)
 activity: (ver abajo o mantener original en traducciones)
-topics: 
+topics:
  - tema uno
  - tema dos (ver abajo o mantener original en traducciones)
-abstract: "(ver abajo o traducir el original)"
+abstract: |
+  ver abajo o traducir el original
 ---
 ```
 

--- a/fr/consignes-redacteurs.md
+++ b/fr/consignes-redacteurs.md
@@ -241,7 +241,8 @@ activity: UNIQUEMENT UN PARMI: acquiring, transforming, analyzing, presenting, s
 topics:
  - sujet un (voir ci-dessous)
  - sujet deux
-abstract: voir ci-dessous
+abstract: |
+  voir ci-dessous
 
 ```
 


### PR DESCRIPTION
A fair number of lessons pending on ph-submissions are having formatting and build errors because they use line breaks, quote marks, and more inside the abstracts. We can accommodate that kind of formatting in abstracts - it just means entering it slightly differently in the YAML, using the pipe-notation. I've added this across all editor guides.