### PR TITLE
remove python warning

### DIFF
--- a/en/lessons/extracting-keywords.md
+++ b/en/lessons/extracting-keywords.md
@@ -7,6 +7,7 @@ authors:
 reviewers:
 - Guy McClellan
 - Amanda Morton
+- Frederik Elwert
 editors:
 - Fred Gibbs
 difficulty: 2
@@ -15,7 +16,7 @@ exclude_from_check:
 activity: acquiring
 topics: [data-manipulation]
 abstract: "This lesson will teach you how to use Python to extract a set of keywords very quickly and systematically from a set of texts."
-python_warning: true
+python_warning: false
 redirect_from: /lessons/extracting-keywords
 ---
 


### PR DESCRIPTION
removes python2  warning from top of lesson that's been updated to python3
adds new reviewer to reflect assistance repairing lesson