### PR TITLE
updating my email

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -740,7 +740,7 @@
 
 - name: Anandi Silva Knuppel
   github: alsalin
-  email: anandi.silva.knuppel@emory.edu
+  email: anandi.silva.knuppel@gmail.com
   twitter: anandilila
   url: "http://anandileela.com"
   team: true


### PR DESCRIPTION
emory email now inactive - using anandi.silva.knuppel@gmail.com for ME correspondence 