### PR TITLE
Remove python2 warning

### DIFF
--- a/en/lessons/code-reuse-and-modularity.md
+++ b/en/lessons/code-reuse-and-modularity.md
@@ -22,7 +22,7 @@ debug."
 next: working-with-web-pages
 previous: working-with-text-files
 categories: [lessons, original-ph, python]
-python_warning: true
+python_warning: false
 redirect_from: /lessons/code-reuse-and-modularity
 ---
 

--- a/en/lessons/creating-and-viewing-html-files-with-python.md
+++ b/en/lessons/creating-and-viewing-html-files-with-python.md
@@ -18,7 +18,7 @@ abstract: "Here you will learn how to create HTML files with Python scripts, and
 how to use Python to automatically open an HTML file in Firefox."
 next: output-data-as-html-file
 previous: counting-frequencies
-python_warning: true
+python_warning: false
 redirect_from: /lessons/creating-and-viewing-html-files-with-python
 ---
 

--- a/en/lessons/manipulating-strings-in-python.md
+++ b/en/lessons/manipulating-strings-in-python.md
@@ -17,7 +17,7 @@ topics: [python]
 abstract: "This lesson is a brief introduction to string manipulation techniques in Python."
 next: from-html-to-list-of-words-1
 previous: working-with-web-pages
-python_warning: true
+python_warning: false
 redirect_from: /lessons/manipulating-strings-in-python
 ---
 

--- a/en/lessons/working-with-text-files.md
+++ b/en/lessons/working-with-text-files.md
@@ -17,7 +17,7 @@ topics: [python]
 abstract: "In this lesson you will learn how to manipulate text files using Python."
 next: code-reuse-and-modularity
 previous: viewing-html-files
-python_warning: true
+python_warning: false
 redirect_from: /lessons/working-with-text-files
 ---
 

--- a/es/lecciones/crear-y-ver-archivos-html-con-python.md
+++ b/es/lecciones/crear-y-ver-archivos-html-con-python.md
@@ -27,7 +27,7 @@ difficulty: 2
 activity: presenting
 topics: [python, website]
 abstract: "Aquí aprenderás cómo crear archivos HTML con scripts de Python, y cómo utilizar Python para abrir un archivo HTML en Firefox."
-python_warning: true
+python_warning: false
 ---
 
 {% include toc.html %}

--- a/es/lecciones/manipular-cadenas-de-caracteres-en-python.md
+++ b/es/lecciones/manipular-cadenas-de-caracteres-en-python.md
@@ -23,7 +23,7 @@ next: de-html-a-lista-de-palabras-1
 previous: trabajar-con-paginas-web
 original: manipulating-strings-in-python
 redirect_from: /es/lessons/manipulating-strings-in-python
-python_warning: true
+python_warning: false
 difficulty: 2
 activity: transforming
 topics: [python]

--- a/es/lecciones/trabajar-con-archivos-de-texto.md
+++ b/es/lecciones/trabajar-con-archivos-de-texto.md
@@ -23,7 +23,7 @@ next: reutilizacion-de-codigo-y-modularidad
 previous: ver-archivos-html
 original: working-with-text-files
 redirect_from: /es/lessons/working-with-text-files
-python_warning: true
+python_warning: false
 difficulty: 2
 activity: transforming
 topics: [python]


### PR DESCRIPTION
A number of our original python lessons had a Python 2 warning for readers at the top of the page. But not all of these pages had non-compliant code examples, and thus the warning isn't needed. This pull request just removes that warning from lessons that are already Python3 compliant.