### PR TITLE
Link to subsection of donate page

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -150,6 +150,16 @@ menu-contribute-support:
   fr:
     title: Nous soutenir
     link: /fr/nous-soutenir
+menu-contribute-support-donate:
+  en:
+    title: Support Us - Donate to Us
+    link: /en/support-us#donate-to-us
+  es:
+    title: Apóyanos - Donaciones
+    link: /es/apoyanos#donaciones
+  fr:
+    title: Nous soutenir - Donations
+    link: /fr/nous-soutenir#donations
 menu-lessons:
   en:
     title: Lessons

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -56,7 +56,7 @@ All lesson metadata and alerts should follow the convention of pulling appropria
                     4.0</a></p>
               </div>
               <div class="donate mr-5">
-                <p><a href="https://programminghistorian.org{{ site.data.snippets.menu-contribute-support[page.lang].link}}"><i class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
+                <p><a href="https://programminghistorian.org{{ site.data.snippets.menu-contribute-support-donate[page.lang].link}}"><i class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Add `menu-contribute-support-donate` to try to link to section of page (see https://github.com/programminghistorian/jekyll/pull/1520#issuecomment-550396549)