### PR TITLE
Update Jmparr roles

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -706,7 +706,6 @@
     fr: |
         Jessica Parr est maîtresse de conférences au Simmons College à Boston et spécialiste du monde atlantique à l'époque moderne.
   team_roles:
-   - editorial
    - board
    - global-lead
 


### PR DESCRIPTION
After discussion, @JMParr has decided to focus on the Global Team moving forward. She will finish her current editorial tasks. This updates her "roles" on the Project Team page.