### PR TITLE
direct link to patreon

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -56,7 +56,7 @@ All lesson metadata and alerts should follow the convention of pulling appropria
                     4.0</a></p>
               </div>
               <div class="donate mr-5">
-                <p><a href="https://programminghistorian.org{{ site.data.snippets.menu-contribute-support-donate[page.lang].link}}"><i class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
+                <p><a href="https://www.patreon.com/theprogramminghistorian"><i class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
I've changed the link in the 'support PH' at the top of each lesson to point directly to Patreon. From a UX standpoint we need to get people to actionable pages asap. 