### PR TITLE
Sponsor banners

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,4 +64,7 @@ defaults:
     values:
       category: posts
 
+# Flags to enable/disable "Support PH" alerts on lessons, and on sitewide banner above the navigation bar
+lesson_donation_alerts: true
+
 # For local work: bundle exec jekyll serve --watch --baseurl '/proghistdev' or wherever else your local site is located

--- a/_config.yml
+++ b/_config.yml
@@ -66,5 +66,6 @@ defaults:
 
 # Flags to enable/disable "Support PH" alerts on lessons, and on sitewide banner above the navigation bar
 lesson_donation_alerts: true
+sitewide_donation_banner: true
 
 # For local work: bundle exec jekyll serve --watch --baseurl '/proghistdev' or wherever else your local site is located

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -390,7 +390,7 @@ donation-alert:
   fr: |
     ## Vous pouvez faire une donation
 
-    Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et contribuer au libre partage des savoirs.
+    Les tutoriels de qualité en accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et contribuer au libre partage des savoirs.
 
 donation-banner:
     en: |

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -388,9 +388,9 @@ donation-alert:
 
     More text here as well
   es: |
-    ## Donate today!
+    ## ¡Haz una donación!
 
-    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+    Producir buenos tutoriales de acceso abierto cuesta dinero. Únete al creciente número de personas que [apoya a _The Programming Historian_](https://www.patreon.com/theprogramminghistorian) para que podamos continuar compartiendo conocimientos de forma gratuita.
 
     ---
 
@@ -408,7 +408,7 @@ donation-banner:
     en: |
       <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
     es: |
-      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">¡Dona ahora a <i>The Programming Historian</i>!</a></h2>
     fr: |
       <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Vous pouvez faire une donation au <i>Programming Historian</i></a></h2>
 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -398,8 +398,7 @@ donation-alert:
   fr: |
     ## Donate today!
 
-    Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et
-contribuer au libre partage des savoirs.
+    Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et contribuer au libre partage des savoirs.
 
     ---
 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -382,7 +382,7 @@ donation-alert:
   en: |
     ## Donate today!
 
-    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+    Great Open Access tutorials cost money to produce. Join the growing number of people [supporting _The Programming Historian_](https://www.patreon.com/theprogramminghistorian) so we can continue to share knowledge free of charge.
 
     ---
 
@@ -398,7 +398,8 @@ donation-alert:
   fr: |
     ## Donate today!
 
-    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+    Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et
+contribuer au libre partage des savoirs.
 
     ---
 
@@ -410,7 +411,7 @@ donation-banner:
     es: |
       <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
     fr: |
-      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Vous pouvez faire une donation au <i>Programming Historian</i></a></h2>
 
 # Included in the lesson.html layout when a lesson has been marked as retired, and is not to be displayed on the main directory.
 retired:
@@ -427,7 +428,7 @@ retired-definition:
   es: |
     Los editores de The Programming Historian hacen todo lo posible para mantener las lecciones a medida que surgen inevitablemente problemas menores. Sin embargo, desde la publicación, los cambios en las tecnologías subyacentes o los principios utilizados en esta lección han sido sustanciales, hasta el punto de que los editores han decidido no actualizarla más. Es posible que la lección siga siendo una herramienta de aprendizaje útil y una instantánea de las técnicas de la historia digital cuando se publicó, pero no podemos garantizar que todos los elementos sigan funcionando como estaba previsto.
   fr: |
-    Les rédacteurs et rédactrices du Programming Historian font tout leur possible pour pour maintenir les leçons en ligne car de petits problèmes peuvent survenir. Toutefois, depuis sa parution, soit les technologies soit les principes mobilisés par cette leçon ont subi de tels changements qu'il a été décidé de ne plus le mettre à jour. Cette leçon peut encore s'avérer un outil d'apprentissage utile ou encore offrir un aperçu des techniques utilisées en histoire numérique au moment de sa publication, néanmoins nous ne sommes pas en mesure de garantir que dans son ensemble elle reste aussi efficace que prévu.
+    Les rédacteurs et rédactrices du Programming Historian font tout leur possible pour maintenir les leçons en ligne car de petits problèmes peuvent survenir. Toutefois, depuis sa parution, soit les technologies soit les principes mobilisés par cette leçon ont subi de tels changements qu'il a été décidé de ne plus le mettre à jour. Cette leçon peut encore s'avérer un outil d'apprentissage utile ou encore offrir un aperçu des techniques utilisées en histoire numérique au moment de sa publication, néanmoins nous ne sommes pas en mesure de garantir que dans son ensemble elle reste aussi efficace que prévu.
 
 retirement-reason:
   en: Why was this lesson retired?

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -406,11 +406,11 @@ donation-alert:
 
 donation-banner:
     en: |
-      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+      <h2><a href="https://www.patreon.com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
     es: |
-      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">¡Dona ahora a <i>The Programming Historian</i>!</a></h2>
+      <h2><a href="https://www.patreon.com/theprogramminghistorian" class="alert-link">¡Dona ahora a <i>The Programming Historian</i>!</a></h2>
     fr: |
-      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Vous pouvez faire une donation au <i>Programming Historian</i></a></h2>
+      <h2><a href="https://www.patreon.com/theprogramminghistorian" class="alert-link">Vous pouvez faire une donation au <i>Programming Historian</i></a></h2>
 
 # Included in the lesson.html layout when a lesson has been marked as retired, and is not to be displayed on the main directory.
 retired:

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -396,7 +396,7 @@ donation-alert:
 
     More text here as well
   fr: |
-    ## Donate today!
+    ## Vous pouvez faire une donation
 
     Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et contribuer au libre partage des savoirs.
 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -383,26 +383,14 @@ donation-alert:
     ## Donate today!
 
     Great Open Access tutorials cost money to produce. Join the growing number of people [supporting _The Programming Historian_](https://www.patreon.com/theprogramminghistorian) so we can continue to share knowledge free of charge.
-
-    ---
-
-    More text here as well
   es: |
     ## ¡Haz una donación!
 
     Producir buenos tutoriales de acceso abierto cuesta dinero. Únete al creciente número de personas que [apoya a _The Programming Historian_](https://www.patreon.com/theprogramminghistorian) para que podamos continuar compartiendo conocimientos de forma gratuita.
-
-    ---
-
-    More text here as well
   fr: |
     ## Vous pouvez faire une donation
 
     Les tutoriels de qualité à accès libre ont un coût de production. Vous pouvez [rejoindre celles et ceux qui soutiennent le _Programming Historian_](https://www.patreon.com/theprogramminghistorian) et contribuer au libre partage des savoirs.
-
-    ---
-
-    More text here as well
 
 donation-banner:
     en: |

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -93,7 +93,7 @@ menu-lesson-requests:
   es:
     title: Solicitud de lecciones
     link: /es/solicitud-lecciones
-  fr: 
+  fr:
     title: Appel à contributions
     link: /fr/appel-contributions
 menu-contribute-feedback:
@@ -130,7 +130,7 @@ menu-contribute-translate:
   en:
     title: Translator Guidelines
     link: /en/translator-guidelines
-  fr: 
+  fr:
     title: Consignes aux traducteurs
     link: /fr/consignes-traducteurs
 menu-contribute-edit:
@@ -213,7 +213,7 @@ issn:
 footer:
   license:
     en: |
-      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license. 
+      _The Programming Historian_ (ISSN: 2397-2068) is released under a [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en) license.
     es: |
       _The Programming Historian en español_ (ISSN: 2517-5769) se publica con una licencia [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.es).
     fr: |
@@ -222,7 +222,7 @@ footer:
     en: |
       This project is administered by ProgHist Limited, Company Number [12192946](https://beta.companieshouse.gov.uk/company/12192946).
     es: |
-      Este proyecto es administrado por ProgHist Limited, con número de compañía [12192946](https://beta.companieshouse.gov.uk/company/12192946). 
+      Este proyecto es administrado por ProgHist Limited, con número de compañía [12192946](https://beta.companieshouse.gov.uk/company/12192946).
     fr: |
         Ce projet est administré par ProgHist Limited, no d'immatriculation [12192946](https://beta.companieshouse.gov.uk/company/12192946).
 
@@ -242,10 +242,10 @@ footer:
     en: Make a suggestion
     es: Envíanos tus comentarios
     fr: Faire une suggestion
-  rss-feed: 
+  rss-feed:
     en: RSS feed subscriptions
-    es: Suscripción a RSS 
-    fr: S'abonner au flux RSS   
+    es: Suscripción a RSS
+    fr: S'abonner au flux RSS
 
 # lesson-index
 reset-button:
@@ -378,6 +378,31 @@ donate:
   en: Support PH
   es: Apoyar PH
   fr: Soutenir PH
+donation-alert:
+  en: |
+    ## Donate today!
+
+    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+
+    ---
+
+    More text here as well
+  es: |
+    ## Donate today!
+
+    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+
+    ---
+
+    More text here as well
+  fr: |
+    ## Donate today!
+
+    Please support the future of digial publishing by [donating to _The Programming Historian_](https://www.patreon.com/theprogramminghistorian)
+
+    ---
+
+    More text here as well
 
 # Included in the lesson.html layout when a lesson has been marked as retired, and is not to be displayed on the main directory.
 retired:

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -404,6 +404,14 @@ donation-alert:
 
     More text here as well
 
+donation-banner:
+    en: |
+      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+    es: |
+      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+    fr: |
+      <h2><a href="https://www.patreon/com/theprogramminghistorian" class="alert-link">Donate to <i>The Programming Historian</i> today!</a></h2>
+
 # Included in the lesson.html layout when a lesson has been marked as retired, and is not to be displayed on the main directory.
 retired:
   en: This lesson has been retired

--- a/_includes/sitewide_donation_banner.html
+++ b/_includes/sitewide_donation_banner.html
@@ -1,0 +1,7 @@
+{% comment %}
+Banner to appear at the top of every site page soliciting donations.
+{% endcomment %}
+
+<div class="alert alert-success sitewide-alert text-center">
+  {{ site.data.snippets.donation-banner[page.lang] | markdownify }}
+</div>

--- a/_includes/support-alert.html
+++ b/_includes/support-alert.html
@@ -1,1 +1,5 @@
+{% comment %}
+These call-to-action alert boxes will be displayed on lessons. To toggle the display, edit the lesson_donation_alerts
+value in the _config.yml file
+{% endcomment %}
 <div class="alert alert-success">{{ site.data.snippets.donation-alert[page.lang] | markdownify }}</div>

--- a/_includes/support-alert.html
+++ b/_includes/support-alert.html
@@ -1,0 +1,1 @@
+<div class="alert alert-success">{{ site.data.snippets.donation-alert[page.lang] | markdownify }}</div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -43,11 +43,3 @@ This template, therefore, is most useful on pages requiring full-window bleeds: 
   </body>
 
 </html>
-
-<style lang="css">
-  .sitewide-alert {
-    position: relative;
-    margin-bottom: 0;
-  }
-
-</style>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,7 +1,8 @@
 {% comment %}
-  This template assembles principal page components (standard HTML header, menu bar, main content, and footer) WITHOUT the standard wrapper div (called "container", which sets the standard page width) as found in the "blank" template.
+This template assembles principal page components (standard HTML header, menu bar, main content, and footer) WITHOUT the
+standard wrapper div (called "container", which sets the standard page width) as found in the "blank" template.
 
-  This template, therefore, is most useful on pages requiring full-window bleeds: the index page and lessons pages.
+This template, therefore, is most useful on pages requiring full-window bleeds: the index page and lessons pages.
 {% endcomment %}
 
 <!-- Calculate the lesson slug for use across this page -->
@@ -12,9 +13,14 @@
   {% include header.html %}
 
   <body>
+    {% if site.sitewide_donation_banner %}
+    <div class="alert alert-success sitewide-alert text-center">
+      {{ site.data.snippets.donation-banner[page.lang] | markdownify }}
+    </div>
+    {% endif %}
     <main class="hide-screen">
       {% include menu.html %}
-        {{content}}
+      {{content}}
       {% include footer.html %}
     </main>
     <div class="hide-print">
@@ -29,8 +35,8 @@
         <tbody>
           <tr>
             <th>
-                {{content}}
-                {% include footer.html %}
+              {{content}}
+              {% include footer.html %}
             </th>
           </tr>
         </tbody>
@@ -39,3 +45,11 @@
   </body>
 
 </html>
+
+<style lang="css">
+  .sitewide-alert {
+    position: relative;
+    margin-bottom: 0;
+  }
+
+</style>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,9 +14,7 @@ This template, therefore, is most useful on pages requiring full-window bleeds: 
 
   <body>
     {% if site.sitewide_donation_banner %}
-    <div class="alert alert-success sitewide-alert text-center">
-      {{ site.data.snippets.donation-banner[page.lang] | markdownify }}
-    </div>
+    {% include sitewide_donation_banner.html %}
     {% endif %}
     <main class="hide-screen">
       {% include menu.html %}

--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -1,7 +1,9 @@
 {% comment %}
-  This template assembles principal page components (standard HTML header, menu bar, page content, and footer). The page content is held in a wrapper div (called "container"), which sets the standard page width.
+This template assembles principal page components (standard HTML header, menu bar, page content, and footer). The page
+content is held in a wrapper div (called "container"), which sets the standard page width.
 
-  This is the standard template used by ALL site pages EXCEPT the home page and lessons pages (which have full-window bleeds and therefore cannot have all page content wrapped in the "container" div; they use the base template).
+This is the standard template used by ALL site pages EXCEPT the home page and lessons pages (which have full-window
+bleeds and therefore cannot have all page content wrapped in the "container" div; they use the base template).
 {% endcomment %}
 
 <!DOCTYPE html>
@@ -10,12 +12,14 @@
   {% include header.html %}
 
   <body>
-
+    {% if site.sitewide_donation_banner %}
+    {% include sitewide_donation_banner.html %}
+    {% endif %}
     {% include menu.html %}
 
     <div class="container">
       <article>
-  	     {{content}}
+        {{content}}
       </article>
     </div>
 

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -56,7 +56,9 @@ All lesson metadata and alerts should follow the convention of pulling appropria
                     4.0</a></p>
               </div>
               <div class="donate mr-5">
-                <p><a href="https://programminghistorian.org{{ site.data.snippets.menu-contribute-support-donate[page.lang].link}}"><i class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
+                <p><a
+                    href="https://programminghistorian.org{{ site.data.snippets.menu-contribute-support-donate[page.lang].link}}"><i
+                      class="fas fa-credit-card"></i> {{ site.data.snippets.donate[page.lang] }}</a></p>
               </div>
             </div>
           </div>
@@ -176,6 +178,10 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
 <div class="container">
 
+  {% if site.lesson_donation_alerts %}
+  {% include support-alert.html %}
+  {% endif %}
+
   {% for candidate in translation_candidates %}
   <!-- Banner pointing to translations of this lesson when they exist -->
   <div class="alert alert-warning">
@@ -260,6 +266,11 @@ All lesson metadata and alerts should follow the convention of pulling appropria
       </p>
     </div>
   </div>
+
+  {% if site.lesson_donation_alerts %}
+  {% include support-alert.html %}
+  {% endif %}
+
 </div>
 </div>
 

--- a/css/style.css
+++ b/css/style.css
@@ -133,6 +133,11 @@ Home Page
     background-color: {{ site.data.snippets.background_color.fr }};
   }
 
+  .sitewide-alert {
+    position: relative;
+    margin-bottom: 0;
+  }
+
 /* =============================================================================
 Lesson Headers
 ========================================================================== */
@@ -845,7 +850,7 @@ Footer
   tr, img { page-break-inside: avoid; }
   img { max-width: 100% !important; }
   @page { margin: 0.5cm; }
-  
+
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
   .hide-screen {


### PR DESCRIPTION
Closes #1563

In this example, I've put "alert" boxes at both the top and bottom of lesson pages so we can see if we like one or both. I have also mocked up example formatting for the alert boxes in lessons, so we could accommodate longer or shorter texts, call-out headers, etc.

See an example lesson here: https://deploy-preview-1585--ph-preview.netlify.com/

todo:

- [x] move the `.sitewide-alert` scoped css to the main CSS file once finalized
- [x] move sitewide banner to an include? it only shows up once in the layouts so does not necessarily warrant being an include, but doing so would follow the same pattern as the support-alert.html box
- [x] finalize text for both alerts
- [x] ES translation for both texts
- [x] FR translation for both texts