### PR TITLE
Point to project team page for private contact on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is the main repository for the _Programming Historian_ (<http://programming
 
 For tutorials in submission, please see: [_Programming Historian Submissions_](https://github.com/programminghistorian/ph-submissions).
 
-If you have suggestions for the site or project, please click on the [Issues Tab](https://github.com/programminghistorian/jekyll/issues) above, and click [New Issue](https://github.com/programminghistorian/jekyll/issues/new) to describe your idea. Please note this will be public. If you would like to correspond with us privately, please contact [one of the current managing ediors listed on our Project Team Page](https://programminghistorian.org/en/project-team).
+If you have suggestions for the site or project, please click on the [Issues Tab](https://github.com/programminghistorian/jekyll/issues) above, and click [New Issue](https://github.com/programminghistorian/jekyll/issues/new) to describe your idea. Please note this will be public. If you would like to correspond with us privately, please contact [one of the current managing ediors listed on our Project Team page](https://programminghistorian.org/en/project-team).
 
 If you would like to contribute to the project, you can find detailed instructions for authors, reviewers, and editors on the [contributions page](http://programminghistorian.org/contribute) of the website.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is the main repository for the _Programming Historian_ (<http://programming
 
 For tutorials in submission, please see: [_Programming Historian Submissions_](https://github.com/programminghistorian/ph-submissions).
 
-If you have suggestions for the site or project, please click on the [Issues Tab](https://github.com/programminghistorian/jekyll/issues) above, and click [New Issue](https://github.com/programminghistorian/jekyll/issues/new) to describe your idea. Please note this will be public. If you would like to correspond with us privately, please contact [Anandi Silva Knuppel](mailto:anandi.silva.knuppel@emory.edu). 
+If you have suggestions for the site or project, please click on the [Issues Tab](https://github.com/programminghistorian/jekyll/issues) above, and click [New Issue](https://github.com/programminghistorian/jekyll/issues/new) to describe your idea. Please note this will be public. If you would like to correspond with us privately, please contact [one of the current managing ediors listed on our Project Team Page](https://programminghistorian.org/en/project-team).
 
 If you would like to contribute to the project, you can find detailed instructions for authors, reviewers, and editors on the [contributions page](http://programminghistorian.org/contribute) of the website.
 


### PR DESCRIPTION
I noticed that Anandi was still listed as the private contact on our repository README. I suggest we change that to a link to the Project Team page, which always lists the current managing editors at the top of the page.