### PR TITLE
remove mdlincoln from editorial role

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -519,7 +519,6 @@
     fr: |
         Matthew Lincoln est développeur en humanités numériques à l'Université Carnegie Mellon et historien de l'art européen moderne.
   team_roles:
-   - editorial
    - technical-lead
    - board
 


### PR DESCRIPTION
@mdlincoln is stepping down from the English publication team. This will remove the role from the project team page.
