### PR TITLE
Properly retire lessons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,18 @@ defaults:
       retired: true
   -
     scope:
+      path: "es/lecciones/retirada"
+    values:
+      lesson: false
+      retired: true
+  -
+    scope:
+      path: "fr/lecons/retraite"
+    values:
+      lesson: false
+      retired: true
+  -
+    scope:
       path: "es/lecciones"
     values:
       lesson: true

--- a/fr/politique-retrait-lecons.md
+++ b/fr/politique-retrait-lecons.md
@@ -24,7 +24,7 @@ En accord avec notre licence [CC-BY](https://creativecommons.org/licenses/by/4.0
 
 Qu'une leçon dérivée soit créée ou pas, voici les étapes à suivre pour retirer une leçon :
 
-1. La leçon sera déplacée de `https://programminghistorian.org/fr/lecon/TITRE-DE-LA-LEÇON` à `https://programminghistorian.org/fr/lesson/retired/TITRE-DE-LA-LEÇON`. Une redirection sera mise en place pour que des liens pointant à l'URL originelle renvoient l'utilisateur à la nouvelle URL.
+1. La leçon sera déplacée de `https://programminghistorian.org/fr/lecon/TITRE-DE-LA-LEÇON` à `https://programminghistorian.org/fr/lecons/retraite/TITRE-DE-LA-LEÇON`. Une redirection sera mise en place pour que des liens pointant à l'URL originelle renvoient l'utilisateur à la nouvelle URL.
 
 2. Une fois la leçon retirée, celle-ci n'apparaît plus dans le répertoire des leçons et elle est aussi enlevée de la liste de publications sur Twitter.
 


### PR DESCRIPTION
This PR changes our site configuration so that retired spanish and french lessons will NOT be shown on the main lesson directory.

@programminghistorian/french-team @spapastamkou  I named the french folder `fr/lecons/retraite` - please let me know if there is a better name to use for it. Thank you.

closes #1638 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
