### PR TITLE
Add Institutional Partner Programme text

### DIFF
--- a/en/support-us.md
+++ b/en/support-us.md
@@ -44,7 +44,7 @@ By joining the Institutional Partner Programme you will receive the following be
 - The right to use Programming Historian Library Partner Programme membership in marketing activities.
 - For library partners: a list of articles published by all Programming Historian journals (on request).
 
-Partnership rates for 2020 are set at £1,000 GBP ($1,300 USD / €1,100 EUR) and £150 ($195 USD / €165 EUR) for partners in [ODA eligible countries](http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/daclist.htm). Rates are due annually from the date of first payment. Rates are published in January each year.
+Partnership rates for 2020 are set at £1,000 GBP (approximately $1,300 USD / €1,100 EUR) and £150 (approximately $195 USD / €165 EUR) for partners in [ODA eligible countries](http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/daclist.htm). Rates are due annually from the date of first payment. Rates are published in January each year.
 
 To become a Institutional Partner, please email James Baker at <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> with "Institutional Partners Programme" in the subject line. Your email should include the following information:
 

--- a/en/support-us.md
+++ b/en/support-us.md
@@ -44,7 +44,7 @@ By joining the Institutional Partner Programme you will receive the following be
 - The right to use Programming Historian Library Partner Programme membership in marketing activities.
 - For library partners: a list of articles published by all Programming Historian journals (on request).
 
-Partnership rates for 2020 are set at £1,000 GBP (approximately $1,300 USD / €1,100 EUR) and £150 (approximately $195 USD / €165 EUR) for partners in [ODA eligible countries](http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/daclist.htm). Rates are due annually from the date of first payment. Rates are published in January each year.
+Partnership rates for 2020 are set at £1,000 GBP (approximately $1,300 USD / €1,180 EUR) and £150 (approximately $195 USD / €175 EUR) for partners in [ODA eligible countries](http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/daclist.htm). Rates are due annually from the date of first payment. Rates are published in January each year.
 
 To become a Institutional Partner, please email James Baker at <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> with "Institutional Partners Programme" in the subject line. Your email should include the following information:
 

--- a/en/support-us.md
+++ b/en/support-us.md
@@ -48,8 +48,6 @@ Partnership rates for 2020 are set at Â£1,000 GBP (approximately $1,300 USD / â‚
 
 To become a Institutional Partner, please email James Baker at <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> with "Institutional Partners Programme" in the subject line. Your email should include the following information:
 
-Send Email</a>
-
 - Your Name.
 - Your Institution.
 - Your Preferred Method of Payment (bank transfer, cheque, invoice, Paypal).

--- a/en/support-us.md
+++ b/en/support-us.md
@@ -38,7 +38,7 @@ The Programming Historian Institutional Partner Programme enables your library, 
 
 By joining the Institutional Partner Programme you will receive the following benefits:
 
-- An invitation to our [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) Annual General Meeting as an Advisory Member (one individual per Library Partner).
+- An invitation to our [ProgHist Ltd](https://beta.companieshouse.gov.uk/company/12192946) Annual General Meeting as an Advisory Member (one individual per Library Partner).
 - An annual breakdown of ProgHist Ltd expenditure.
 - Acknowledgement of your contribution on our 'Supporters' page.
 - The right to use Programming Historian Library Partner Programme membership in marketing activities.

--- a/en/support-us.md
+++ b/en/support-us.md
@@ -32,6 +32,37 @@ Individual donors to the _Programming Historian_ are vital to growing, improving
 - Ongoing donations by becoming a supporter of the _Programming Historian_ via [Patreon](https://www.patreon.com/theprogramminghistorian). 
 - One-time donations can be made to the _Programming Historian_ via [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7BGHUZRVS4LYL&source=url), bank transfer (Lloyds Bank account number 55263268, sort code 30-96-26), or cheque (made payable to 'ProgHist Ltd' and posted to 'Dr James Baker, Arts A135, University of Sussex, United Kingdom, BN1 9RH'). For donations via bank transfer and cheque, we'd be grateful if you could write to us at <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> to let us know who you are and why you've chosen to support our work.
 
+## Institutional Partner Programme
+
+The Programming Historian Institutional Partner Programme enables your library, university, or research centre to support the growth, development, and sustainability of our award winning open access publishing platform.
+
+By joining the Institutional Partner Programme you will receive the following benefits:
+
+- An invitation to our [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) Annual General Meeting as an Advisory Member (one individual per Library Partner).
+- An annual breakdown of ProgHist Ltd expenditure.
+- Acknowledgement of your contribution on our 'Supporters' page.
+- The right to use Programming Historian Library Partner Programme membership in marketing activities.
+- For library partners: a list of articles published by all Programming Historian journals (on request).
+
+Partnership rates for 2020 are set at £1,000 GBP ($1,300 USD / €1,100 EUR) and £150 ($195 USD / €165 EUR) for partners in [ODA eligible countries](http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/daclist.htm). Rates are due annually from the date of first payment. Rates are published in January each year.
+
+To become a Institutional Partner, please email James Baker at <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> with "Institutional Partners Programme" in the subject line. Your email should include the following information:
+
+Send Email</a>
+
+- Your Name.
+- Your Institution.
+- Your Preferred Method of Payment (bank transfer, cheque, invoice, Paypal).
+- Your Preferred Currency (if this is not listed, please ask).
+
+Note that upon email with the subject line "Institutional Partners Programme" you agree to the following conditions:
+
+1. You are authorized to commit to expenditure of the institution whose name you use.
+2. Once a method of payment is agreed and funds requested you will enter a legally binding agreement for the amounts specified.
+3. The Programming Historian Editorial Board reserves the right to reject funds from any organization or individual for any reason.
+4. The Programming Historian is an international volunteer-driven project whose financial activities are administered by ProgHist Limited, a Not for Profit Company Limited by Guarantee that is registered in England, Company Number 12192946.
+5. The purpose of the Programming Historian is to advance the education of the public in the humanities in particular in the use of digital tools and techniques and to promote research for the public benefit in all aspects of that subject and to publish the useful results.
+
 ## Sponsor Us
 
 If you represent an organisation or group who are interested in sponsoring The Programming Historian, please contact [James Baker](https://github.com/drjwbaker) to discuss. Sponsorship can be financial, in-kind, or a combination of both. Sponsorship length and value are negotiable.

--- a/es/apoyanos.md
+++ b/es/apoyanos.md
@@ -37,7 +37,7 @@ El Programa de Instituciones Asociadas de The Programming Historian permite a tu
 
 Al unirte al Programa de Instituciones Asociadas recibirás los siguientes beneficios:
 
-- Invitación a la reunión anual de [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) como Miembro Asesor (una persona por institución asociada).
+- Invitación a la reunión anual de [ProgHist Ltd](https://beta.companieshouse.gov.uk/company/12192946) como Miembro Asesor (una persona por institución asociada).
 - Acceso al detalle de los gastos anuales de ProgHist Ltd.
 - Reconocimiento de tu contribución en nuestra página de Patrocinadores.
 - Derecho a usar la membrecía a este programa en las actividades de promoción de tu institución.

--- a/es/apoyanos.md
+++ b/es/apoyanos.md
@@ -23,13 +23,43 @@ El proyecto agradece el siguiente apoyo:
 - Fondos para un taller de escritura en Bogotá, Colombia, financiados por la [Academia Británica](https://www.thebritishacademy.ac.uk) [2018]
 - Fondos iniciales y soporte de administración de la Red en Historia y Medio Ambiente de Canadá ([NiCHE](http://niche-canada.org/)) [2011-2013]
 
-- Nuestros primeros suscriptores de *Patreon* Rachel Murphy (nivel 'Suscriptor'), Miriam Posner (nivel 'Patrocinador') y Tim Hitchcock (nivel 'Mecenas'). En particular, agradecemos la contribución de los siguientes suscriptores de Patreon de nivel 'Mecenas': Tim Hitchcock, Shawn Graham, Jeff Blackadar. 
+- Nuestros primeros suscriptores de *Patreon* Rachel Murphy (nivel 'Suscriptor'), Miriam Posner (nivel 'Patrocinador') y Tim Hitchcock (nivel 'Mecenas'). En particular, agradecemos la contribución de los siguientes suscriptores de Patreon de nivel 'Mecenas': Tim Hitchcock, Shawn Graham, Jeff Blackadar.
 
 ## Donaciones
 Los patrocinadores individuales del _Programming Historian en Español_ son vitales para aumentar, mejorar y mantener nuestro trabajo. Aceptamos donativos únicos y recurrentes.  
 
 - Donaciones recurrentes a _Programming Historian en Español_ a través de [Patreon](https://www.patreon.com/theprogramminghistorian)
 - Donaciones únicas a _Programming Historian en Español_ por [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7BGHUZRVS4LYL&source=url), transferencia bancaria (número de cuenta de Lloyds Bank 55263268, código bancario 30-96-26) o con un cheque a nombre de "ProgHist Ltd" enviado a la dirección: 'Dr James Baker, Arts A135, University of Sussex, United Kingdom, BN1 9RH'. En caso de donativos por transferencia bancaria o cheque, solicitamos que envíes un correo <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> para que nos cuentes sobre ti y por qué decidiste apoyar nuestro trabajo.
+
+## Programa de Instituciones Asociadas
+
+El Programa de Instituciones Asociadas de The Programming Historian permite a tu biblioteca, universidad o centro de investigación apoyar el crecimiento, desarrollo y sustentabilidad de nuestra premiada plataforma de publicación abierta.
+
+Al unirte al Programa de Instituciones Asociadas recibirás los siguientes beneficios:
+
+- Invitación a la reunión anual de [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) como Miembro Asesor (una persona por institución asociada).
+- Acceso al detalle de los gastos anuales de ProgHist Ltd.
+- Reconocimiento de tu contribución en nuestra página de Patrocinadores.
+- Derecho a usar la membrecía a este programa en las actividades de promoción de tu institución.
+- Para bibliotecas socias: lista de todos los artículos publicados por las distintas ediciones de The Programming Historian (previa solicitud).
+
+El costo de asociación para 2020 corresponde a £1000 libras esterlinas (aproximadamente $1300 dólares / €1180 euros). Las instituciones de [países elegibles para Ayuda Oficial al Desarrollo (AOD)](https://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/DAC_List_ODA_Recipients2018to2020_flows_En.pdf) pueden asociarse por £150 libras esterlinas (aproximadamente $195 dólares / €175 euros). Estos costos son anuales y su período de vigencia se inicia con la fecha del primer pago. En el mes de enero se publica la actualización de los costos para cada año.
+
+Para convertirte en una institución asociada debes enviar un correo electrónico a James Baker a <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> con el asunto "Programa de Instituciones Asociadas". El correo debe incluir la siguiente información:
+
+- Nombre.
+- Institución a la que perteneces.
+- Método de pago preferido (transferencia bancaria, cheque, factura, PayPal).
+- Moneda preferida (en caso de que no esté en la lista, por favor consultar).
+
+Ten en cuenta que al enviar el correo electrónico con el asunto "Programa de Instituciones Asociadas" estás aceptando las siguientes condiciones:
+
+1. Estás autorizado a comprometer gastos de la institución a la que representas.
+2. Una vez que se acuerde el método de pago y se soliciten los fondos, serás parte de un acuerdo legalmente vinculante por los montos especificados.
+3. El Consejo Editorial de The Programming Historian se reserva el derecho de rechazar fondos de cualquier organización o individuo por las razones que estime conveniente.
+4. The Programming Historian es un proyecto internacional impulsado por voluntarios cuyas actividades son administradas por ProgHist Limitada, una compañía sin fines de lucro que se encuentra registrada en Inglaterra con el número 12192946.
+5. El propósito de The Programming Historian es hacer avanzar la educación del público en las Humanidades, en particular en el uso de de herramientas y técnicas digitales, promover investigación para el bien público en este ámbito y publicar resultados significativos.
+
 
 ## Patrocinio
 Si representas a una organización o grupo que esté interesado en patrocinar a *The Programming Historian en Español*, por favor ponte en contacto con [James Baker](https://github.com/drjwbaker) (en inglés). El patrocinio puede ser financiero, en especie, o una combinación de ambos. La duración y el valor del patronicio son negociables.
@@ -44,4 +74,3 @@ Todo patrocinio está sujeto al acuerdo del [Consejo Editorial](/es/equipo-de-pr
 
 ## Administración de donaciones y patrocinios
 [James Baker](https://github.com/drjwbaker) administra las donaciones y los patrocinios en nombre del [Consejo Editorial de *The Programming Historian*](/es/equipo-de-proyecto).
-

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -44,7 +44,7 @@ En participant à notre programme de partenariat institutionnel vous bénéficie
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
 - Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).
 
-Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 100 euros (1 600 dollars canadiens / 1 200 francs suisses) ou à 165 euros (250 dollars canadiens / 180 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement de l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes requises sont publiées annuellement en janvier.
+Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 180 euros (environs 1 720 dollars canadiens / 1 260 francs suisses) ou à 165 euros (environs 260 dollars canadiens / 190 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement de l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes requises sont publiées annuellement en janvier.
 
 Pour devenir partenaire institutionnel, merci de prendre contact avec James Baker à cette adresse électronique <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> en signalant comme sujet "Partenariat Institutionnel". Votre message doit inclure les informations suivantes:
 

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -34,7 +34,7 @@ Les donations à titre individuel au *Programming Historian* sont vitales pour l
 
 ## Partenariat institutionnel
 
-Nouer un partenariat institutionnel avec *The Programming Historian* permet à votre bibliothèque, université ou centre de recherche d'apporter son soutien au développement et la pérennité d'une plateforme de publication en libre accès qui a déjà reçu de nombreuses recompenses. 
+Nouer un partenariat institutionnel avec *The Programming Historian* permet à votre bibliothèque, université ou centre de recherche d'apporter son soutien au développement et à la pérennité d'une plateforme de publication en libre accès qui a déjà reçu de nombreuses récompenses. 
 
 En participant à notre programme de partenariat institutionnel vous bénéficiez des avantages suivants:
 
@@ -44,7 +44,7 @@ En participant à notre programme de partenariat institutionnel vous bénéficie
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
 - Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).
 
-Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 100 euros (1 600 dollars canadiens / 1 200 francs suisses) ou à 165 euros (250 dollars canadiens / 180 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement par l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes sont publiées annuellement en janvier.
+Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 100 euros (1 600 dollars canadiens / 1 200 francs suisses) ou à 165 euros (250 dollars canadiens / 180 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement de l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes requises sont publiées annuellement en janvier.
 
 Pour devenir partenaire institutionnel, merci de prendre contact avec James Baker à cette adresse électronique <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> en signalant comme sujet "Partenariat Institutionnel". Votre message doit inclure les informations suivantes:
 

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -38,7 +38,7 @@ Nouer un partenariat institutionnel avec *The Programming Historian* permet à v
 
 En participant à notre programme de partenariat institutionnel vous bénéficiez des avantages suivants:
 
-- Participation à l'assemblée générale annuelle de [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) en tant que membre consultatif (un individu par institution partenaire).
+- Participation à l'assemblée générale annuelle de [ProgHist Ltd](https://beta.companieshouse.gov.uk/company/12192946) en tant que membre consultatif (un individu par institution partenaire).
 - La ventilation annuelle des dépenses de ProgHist Ltd.
 - Reconnaissance explicite de votre contribution dans <!-- la section [Nos soutiens](https://programminghistorian.org/fr/nous-soutenir#nos-soutiens) -->
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -44,7 +44,7 @@ En participant à notre programme de partenariat institutionnel vous bénéficie
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
 - Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).
 
-Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 180 euros (environs 1 720 dollars canadiens / 1 260 francs suisses) ou à 165 euros (environs 260 dollars canadiens / 190 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement de l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes requises sont publiées annuellement en janvier.
+Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 180 euros (environ 1 720 dollars canadiens / 1 260 francs suisses) ou à 165 euros (environ 260 dollars canadiens / 190 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement de l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes requises sont publiées annuellement en janvier.
 
 Pour devenir partenaire institutionnel, merci de prendre contact avec James Baker à cette adresse électronique <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> en signalant comme sujet "Partenariat Institutionnel". Votre message doit inclure les informations suivantes:
 

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -40,7 +40,7 @@ En participant à notre programme de partenariat institutionnel vous bénéficie
 
 - Participation à l'assemblée générale annuelle de [ProgHist Ltd](https://beta.companieshouse.gov.uk/company/12192946) en tant que membre consultatif (un individu par institution partenaire).
 - La ventilation annuelle des dépenses de ProgHist Ltd.
-- Reconnaissance explicite de votre contribution dans <!-- la section [Nos soutiens](https://programminghistorian.org/fr/nous-soutenir#nos-soutiens) -->
+- Reconnaissance explicite de votre contribution dans la section [Nos soutiens](/fr/nous-soutenir#nos-soutiens).
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
 - Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).
 

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -39,7 +39,7 @@ Nouer un partenariat institutionnel avec *The Programming Historian* permet à v
 En participant à notre programme de partenariat institutionnel vous bénéficiez des avantages suivants:
 
 - Participation à l'assemblée générale annuelle de [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) en tant que membre consultatif (un individu par institution partenaire).
-- An annual breakdown of ProgHist Ltd expenditure.
+- La ventilation annuelle des dépenses de ProgHist Ltd.
 - Reconnaissance explicite de votre contribution dans <!-- la section [Nos soutiens](https://programminghistorian.org/fr/nous-soutenir#nos-soutiens) -->
 - Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
 - Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -32,6 +32,35 @@ Les donations à titre individuel au *Programming Historian* sont vitales pour l
 - Les donations régulières se font en devenant parrain ou marraine du *Programming Historian* via [Patreon](https://www.patreon.com/theprogramminghistorian). 
 - Les donations ponctuelles peuvent se faire à destination du *Programming Historian* via [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7BGHUZRVS4LYL&source=url), par virement bancaire (Lloyds Bank, numéro de compte 55263268, code bancaire 30-96-26), où par chèque (à l'ordre de 'ProgHist Ltd' et envoyé par la poste à: Dr James Baker, Arts A135, University of Sussex, United Kingdom, BN1 9RH). Pour les donations par virement bancaire et par chèque, nous vous saurions gré de nous écrire à l'adresse électronique suivante <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> pour nous faire savoir qui vous êtes et pour quelle raison vous avez décidé de soutenir notre travail. 
 
+## Partenariat institutionnel
+
+Nouer un partenariat institutionnel avec *The Programming Historian* permet à votre bibliothèque, université ou centre de recherche d'apporter son soutien au développement et la pérennité d'une plateforme de publication en libre accès qui a déjà reçu de nombreuses recompenses. 
+
+En participant à notre programme de partenariat institutionnel vous bénéficiez des avantages suivants:
+
+- Participation à l'assemblée générale annuelle de [ProgHist Ltd](https://github.com/programminghistorian/jekyll/wiki/ProgHist-Ltd) en tant que membre consultatif (un individu par institution partenaire).
+- An annual breakdown of ProgHist Ltd expenditure.
+- Reconnaissance explicite de votre contribution dans <!-- la section [Nos soutiens](https://programminghistorian.org/fr/nous-soutenir#nos-soutiens) -->
+- Le droit de valoriser ce partenariat dans les activités de promotion de votre institution.
+- Pour les bibliothèques partenaires: une liste d'articles publiés par toutes les versions du Programming Historian (sur demande).
+
+Les montants pour nouer un partenariat sont fixés, pour l'année 2020, à 1 100 euros (1 600 dollars canadiens / 1 200 francs suisses) ou à 165 euros (250 dollars canadiens / 180 francs suisses) pour des partenaires en provenance de [pays éligibles à l'aide publique au développement par l'OCDE](http://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/listecad.htm). Les partenariats sont annuels, renouvelables et comptent à partir de la date du premier règlement. Les sommes sont publiées annuellement en janvier.
+
+Pour devenir partenaire institutionnel, merci de prendre contact avec James Baker à cette adresse électronique <a href="mailto:programminghistorian@gmail.com">programminghistorian@gmail.com</a> en signalant comme sujet "Partenariat Institutionnel". Votre message doit inclure les informations suivantes:
+
+- Votre nom.
+- Votre institution.
+- Le moyen de paiement de votre choix (virement bancaire, chèque, Paypal, paiement sur facture).
+- La monnaie de votre choix (si absente de la liste, merci de demander).
+
+En envoyant un message intitulé "Partenariat institutionnel", merci de noter que vous consentez aux conditions suivantes:
+
+1. Vous avez eu l'autorisation de votre institution, au nom de laquelle vous nous contactez. 
+2. Une fois que vous vous déclarez d'accord sur une méthode de règlement et en recevez la demande, vous vous engagez à fournir la somme consentie.
+3. Le comité éditorial du Programming Historian maintient le droit de rejeter le financement de quelque organisation ou individu que ce soit pour quelque raison que ce soit.
+4. Le Programming Historian est un projet international mené par des bénévoles dont les activités financières sont administrées par ProgHist Limited, une société à but non lucratif immatriculée en Angleterre sous le numéro 12192946.
+5. L'objectif du Programming Historian est de faire connaître l'application des technologies numériques aux humanités auprès d'un plus large public, de promouvoir la recherche pour le bien commun de la société dans ce domaine, et de publier les résultats significatifs. 
+
 ## Nous parrainer
 
 Si vous représentez un organisme ou groupe intéressé à sponsoriser le Programming Historian, merci de prendre contact avec  [James Baker](https://github.com/drjwbaker) pour en discuter avec lui. Ce type de soutien peut être soit financier soit en nature ou encore les deux à la fois, d'une durée et de valeur négociables.


### PR DESCRIPTION
Add Institutional Partner Programme text.

Closes https://github.com/programminghistorian/jekyll/issues/1625

Requires EN and FR translation of new "Institutional Partner Programme" section of support-us.md: pinging @programminghistorian/french-team @programminghistorian/spanish-team 

@acrymble: what are your thoughts on dropping the sponsorship route and replacing it with this? Or should we have both? (it doesn't hurt I guess)