### PR TITLE
Issue1652 - consistent labelling of Project Roles

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -630,7 +630,6 @@
   team_roles:
    - editorial
    - board
-   - twitter-dev
    - communication
    - technical
    - instutitionally-supported

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1061,7 +1061,7 @@
   team_roles:
     - french
     - board
-    - managing-fr
+    - managing
     - technical
     - global
     - volunteer
@@ -1198,7 +1198,7 @@
   team_roles:
     - spanish
     - board
-    - managing-es
+    - managing
     - global
     - volunteer
     - proghist

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -556,7 +556,7 @@
         Sarah Melton est responsable des études numériques au Boston College.
   team_roles:
    - editorial
-   - managing-en
+   - managing
    - board
    - volunteer
 

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -280,7 +280,6 @@
         James Baker est maître de conférences en histoire numérique et en archivistique à l'Université du Sussex; il est spécialiste en histoire des interactions entre personnes et objets.
   team_roles:
    - proghist
-   - sponsorship
    - finance-manager
    - archive
    - board

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -42,11 +42,11 @@
     fr: |
         Adam Crymble est maître de conférences en histoire numérique.
   team_roles:
-   - board
+   - proghist
    - team-development-manager
    - global
+   - board
    - volunteer
-   - proghist
 
 - name: Caleb McDaniel
   team: false
@@ -116,6 +116,7 @@
         Maria José Afanador-Llach est maître de conférences en Humanités numériques et histoire à l'Université de los Andes, (Bogota, Colombie).
   team_roles:
    - spanish
+   - project-manager-at-large
    - board
 
 - name: Víctor Gayol
@@ -278,12 +279,13 @@
     fr: |
         James Baker est maître de conférences en histoire numérique et en archivistique à l'Université du Sussex; il est spécialiste en histoire des interactions entre personnes et objets.
   team_roles:
-   - board
-   - archive
+   - proghist
    - sponsorship
    - finance-manager
+   - archive
+   - board
    - institutionally-supported
-   - proghist
+
 
 - name: Amanda Morton
   team: false
@@ -526,10 +528,11 @@
     fr: |
         Matthew Lincoln est développeur en humanités numériques à l'Université Carnegie Mellon et historien de l'art européen moderne.
   team_roles:
+   - proghist
    - technical-lead
    - board
    - institutionally-supported
-   - proghist
+
 
 - name: Sarah Melton
   github: svmelton
@@ -555,8 +558,8 @@
     fr: |
         Sarah Melton est responsable des études numériques au Boston College.
   team_roles:
-   - editorial
    - managing
+   - editorial
    - board
    - volunteer
 
@@ -628,12 +631,12 @@
     fr: |
         Brandon Walsh est responsable des programmes des deuxième et troisième cycles au Scholar's Lab de l'Université de Virginie.
   team_roles:
+   - proghist
    - editorial
    - board
-   - communication
    - technical
    - instutitionally-supported
-   - proghist
+
 
 - name: Ted Dawson
   team: false
@@ -715,10 +718,10 @@
     fr: |
         Jessica Parr est maîtresse de conférences au Simmons College à Boston et spécialiste du monde atlantique à l'époque moderne.
   team_roles:
-   - board
-   - global-lead
-   - volunteer
    - proghist
+   - global-lead
+   - board
+   - volunteer
 
 - name: Taylor Arnold
   team: false
@@ -827,13 +830,11 @@
         Anna-Maria Sichani est spécialiste de l'histoire culturelle et de l'histoire de la littérature, mais aussi des humanités numériques. Elle est actuellement chercheuse en histoire des médias à l'Université du Sussex.
   team_roles:
    - editorial
-   - board
-   - ed-manager
-   - communication
-   - technical
-   - project-manager-at-large
-   - volunteer
    - proghist
+   - ed-manager
+   - technical
+   - board
+   - volunteer
 
 - name: Evan Peter Williamson
   team: false
@@ -956,11 +957,11 @@
         Jennifer Isasi est chercheuse postdoctorale du programme CLIR au LLILAS Benson en Études et collections latino-américaines, et docteure en études hispaniques.
   team_roles:
     - spanish
-    - board
-    - technical
-    - communication-manager
-    - institutionally-supported
     - proghist
+    - communication-manager
+    - technical
+    - board
+    - institutionally-supported
 
 - name: Jon MacKay
   team: false
@@ -1058,13 +1059,13 @@
         fr: |
             Institut de recherches historiques du Septentrion (IRHiS UMR 8529, CNRS/Université de Lille)
   team_roles:
-    - french
-    - board
     - managing
+    - french
+    - proghist
+    - board
     - technical
     - global
     - volunteer
-    - proghist
   bio:
         en: |
             Sofia Papastamkou is a historian and Research Engineer in Digital Humanities at the French National Center for Scientific Research (CNRS).
@@ -1157,6 +1158,7 @@
         Zoe LeBlanc est développeuse spécialiste des Humanités Numériques au Scholar's Lab de l'Université de Virginie..
   team_roles:
    - editorial
+   - proghist
    - board
    - technical
 
@@ -1195,12 +1197,13 @@
     fr: |
         Riva Quiroga est doctorante en linguistique à l'Université Catholique de Chili.
   team_roles:
-    - spanish
-    - board
     - managing
+    - spanish
+    - proghist
+    - board
     - global
     - volunteer
-    - proghist
+
 
 - name: Joshua G. Ortiz Baco
   twitter: jgob

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -5,6 +5,17 @@
 # definition: Brief description of that editorial team. If this is a derived label that uses the definition of another role, instead use...
 # source_role: The role type where the definition for this derived role can be found (e.g. pointing from an ES variant of a role to the original EN definition)
 
+
+# --- Publication Roles ---
+- type: managing
+  label:
+    en: Managing Editor
+    es: Jefe de redacción
+    fr: Rédacteur/rédactrice en chef
+  definition:
+    en: First point of contact for authors with lesson ideas
+    es: Primer contacto para autores con ideas de lecciones
+    fr: Premier contact pour les auteurs souhaitant proposer une lesson
 - type: editorial
   label:
     en: Editor (English)
@@ -32,15 +43,6 @@
     en: Responsible for editorial work resulting in the review and publication of French-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
     fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en français
-- type: managing
-  label:
-    en: Managing Editor
-    es: Jefe de redacción
-    fr: Rédacteur/rédactrice en chef
-  definition:
-    en: First point of contact for authors with lesson ideas
-    es: Primer contacto para autores con ideas de lecciones
-    fr: Premier contact pour les auteurs souhaitant proposer une lesson
 - type: ombuds
   label:
     en: Ombudsperson
@@ -50,6 +52,17 @@
     en: A person that authors and reviewers can turn to if they have queries or concerns about any part of the peer review and publication process
     es: Persona a la que los autores y revisores pueden recurrir si tienen preguntas o inquietudes sobre cualquier parte del proceso de revisión por pares y publicación
     fr: Personne que les auteur(e)s et évaluateur(trice)s peuvent consulter pour toute question liée à la procédure de l'évaluation par les pairs ou à la publication
+
+# --- Proghist Roles ---
+- type: proghist
+  label:
+     en: ProgHist Ltd
+     es: ProgHist Ltd
+     fr: ProgHist Ltd
+  definition:
+     en: This member holds a role in the not-for-profit company ProgHist Ltd, which supports the publications.
+     es: Este miembro funge un cargo en la compañía sin ánimo de lucro ProgHist Ltd, que gestiona las publicaciones.
+     fr: Ce(tte) membre occupe un rôle au sein de la compagnie sans but lucratif ProgHist Ltd, qui soutient les publications.
 - type: technical-lead
   label:
     en: Technical Lead
@@ -68,6 +81,15 @@
     en: Responsible for the technical features that bring the content and peer review to our community
     es: Responsable de las características técnicas respecto al contenido y la revisión por pares a nuestra comunidad
     fr: Responsable des aspects techniques rendant accessibles à notre communauté le contenu et l'évaluation par les pairs
+- type: communication-manager
+  label:
+    en: Communication Manager
+    es: Mánager de comunicación
+    fr: Responsable de la communication
+  definition:
+    en: Responsible for coordinating efforts of the communication team
+    es: Responsable de la coordinación del equipo de comunicación
+    fr: Responsable de la coordination de l'équipe de communication
 - type: archive
   label:
     en: Archivist
@@ -95,15 +117,6 @@
     en: Responsible for managing relationships with our sponsors
     es: Responsable de coordinar las relaciones con las y los patrocinadores
     fr: Personne chargée des relations avec les sponsors du projet
-- type: communication-manager
-  label:
-    en: Communication Manager
-    es: Mánager de comunicación
-    fr: Responsable de la communication
-  definition:
-    en: Responsible for coordinating efforts of the communication team
-    es: Responsable de la coordinación del equipo de comunicación
-    fr: Responsable de la coordination de l'équipe de communication
 - type: ed-manager
   label:
     en: Education Manager
@@ -149,6 +162,7 @@
     en: Keeping the team focused on achieving its goals in a timely manner
     es: Mantener al equipo enfocado en lograr sus objetivos de manera puntual
     fr: Garder l'équipe concentrée sur la réalisation de ses objectifs à l'intérieur des délais prévus
+
 # --- Derived roles ---
 - type: ombuds-es
   label:
@@ -180,6 +194,8 @@
     en: Managing new global initiatives, as well as trying to improve the cultural and linguistic diversity of the team, our lessons, and of participation in Digital Humanities more generally.
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
     fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.  
+
+# --- Status ---
 - type: volunteer
   label:
      en: Volunteer
@@ -198,12 +214,3 @@
      en: This member's time on the project is either directly or indirectly supported by their employer.
      es: El tiempo que este miembro dedica al proyecto está directa o indirectamente apoyado por su institución.
      fr: Le temps que ce membre consacre au projet est directement ou indirectement financé par son employeur.
-- type: proghist
-  label:
-     en: ProgHist Ltd
-     es: ProgHist Ltd
-     fr: ProgHist Ltd
-  definition:
-     en: This member holds a role in the not-for-profit company ProgHist Ltd, which supports the publications.
-     es: Este miembro funge un cargo en la compañía sin ánimo de lucro ProgHist Ltd, que gestiona las publicaciones.
-     fr: Ce(tte) membre occupe un rôle au sein de la compagnie sans but lucratif ProgHist Ltd, qui soutient les publications.

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -32,7 +32,7 @@
     en: Responsible for editorial work resulting in the review and publication of French-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
     fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en français
-- type: managing-en
+- type: managing
   label:
     en: Managing Editor
     es: Jefe de redacción

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -104,15 +104,6 @@
     en: Responsible for coordinating efforts of the communication team
     es: Responsable de la coordinación del equipo de comunicación
     fr: Responsable de la coordination de l'équipe de communication
-- type: twitter-dev
-  label:
-    en: Twitter Developer
-    es: Desarrollador de Twitter
-    fr: Développeur Twitter
-  definition:
-    en: Responsible for maintaining the Programming Historian Twitter bot
-    es: Responsable del mantenimiento del bot del Twitter de Programming Historian
-    fr: Responsable de la maintenance du bot Twitter du Programming Historian
 - type: ed-manager
   label:
     en: Education Manager

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -99,24 +99,6 @@
     en: Responsible for archiving the project
     es: Responsable del archivo del proyecto
     fr: Responsable de l'archive du projet
-- type: treasurer
-  label:
-    en: Treasurer
-    es: Tesorería
-    fr: Trésorier/trésorière
-  definition:
-    en: Responsible for project finances
-    es: Responsable de las finanzas del proyecto
-    fr: Personne chargée des finances du projet
-- type: sponsorship
-  label:
-    en: Sponsorship Coordinator
-    es: Coordinación de patrocinio
-    fr: Chargé(e) des donations
-  definition:
-    en: Responsible for managing relationships with our sponsors
-    es: Responsable de coordinar las relaciones con las y los patrocinadores
-    fr: Personne chargée des relations avec les sponsors du projet
 - type: ed-manager
   label:
     en: Education Manager

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -5,38 +5,29 @@
 # definition: Brief description of that editorial team. If this is a derived label that uses the definition of another role, instead use...
 # source_role: The role type where the definition for this derived role can be found (e.g. pointing from an ES variant of a role to the original EN definition)
 
-- type: board
-  label:
-    en: Editorial Board
-    es: Consejo editorial
-    fr: Comité éditorial
-  definition:
-    en: A fully-fledged member of the project team, involved in directing the project's future
-    es: Miembro de pleno derecho del equipo del proyecto, encargado de su dirección a futuro
-    fr: Membre à part entière de l'équipe, impliqué dans la direction du projet
 - type: editorial
   label:
-    en: Editorial Team (English)
-    es: Equipo editorial (Inglés)
-    fr: Équipe éditoriale (anglais)
+    en: Editor (English)
+    es: Editor(a) (Inglés)
+    fr: Rédacteur (anglais)
   definition:
     en: Responsible for editorial work resulting in the review and publication of English-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en inglés
     fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en anglais
 - type: spanish
   label:
-    en: Editorial Team (Spanish)
-    es: Equipo editorial (español)
-    fr: Équipe éditoriale (espagnol)
+    en: Editor (Spanish)
+    es: Editor(a) (español)
+    fr: Rédacteur (espagnol)
   definition:
     en: Responsible for editorial work resulting in the review and publication of Spanish-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en español
     fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en espagnol
 - type: french
   label:
-    en: Editorial Team (French)
-    es: Equipo editorial (francés)
-    fr: Équipe éditoriale (français)
+    en: Editor (French)
+    es: Editor(a) (francés)
+    fr: Rédacteur (français)
   definition:
     en: Responsible for editorial work resulting in the review and publication of French-language lessons
     es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
@@ -113,15 +104,6 @@
     en: Responsible for coordinating efforts of the communication team
     es: Responsable de la coordinación del equipo de comunicación
     fr: Responsable de la coordination de l'équipe de communication
-- type: communication
-  label:
-    en: Communication Team
-    es: Equipo de comunicación
-    fr: Équipe de communication
-  definition:
-    en: Responsible for managing and developing communication channels
-    es: Responsable del mantenimiento y creación de canales de comunicación
-    fr: Responsable de la gestion et du développement des canaux de communication
 - type: twitter-dev
   label:
     en: Twitter Developer
@@ -189,18 +171,6 @@
     es: Mediador (francés)
     fr: Médiateur/médiatrice (français)
   source_role: ombuds
-- type: managing-es
-  label:
-    en: Managing Editor (Spanish)
-    es: Jefe de redacción (español)
-    fr: Rédacteur/rédactrice en chef (espagnol)
-  source_role: managing-en
-- type: managing-fr
-  label:
-    en: Managing Editor (French)
-    es: Jefe de redacción (francés)
-    fr: Rédacteur/rédactrice en chef (français)
-  source_role: managing-en
 - type: global-lead
   label:
     en: Global Lead


### PR DESCRIPTION
Closes #1652 this is a pull request to reduce the number of tags we have on the project team page, and to make them more consistently focused on roles rather than teams (which are shown in a different way). This is NOT yet ready for review or merging. I just want to see it.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
