### PR TITLE
Revise text for retiring lessons

### DIFF
--- a/en/lesson-retirement-policy.md
+++ b/en/lesson-retirement-policy.md
@@ -26,7 +26,7 @@ Whether or not a new derivative is created, the following steps will be taken wi
 
 1. The lesson will be moved from `https://programminghistorian.org/lesson/LESSON-TITLE` TO `https://programminghistorian.org/lesson/retired/LESSON-TITLE`. A redirect will be established, so any links to the original URL will seamlessly point the user to the new URL.
 
-2. Once retired, the lesson will no longer appear in the directory of lessons, and it will be removed from the Twitter announcement stream.
+2. Once retired, the lesson will no longer appear in the directory of lessons, and it will be removed from the Twitter announcement stream. In order to remove it from the Twitter stream, editors should consult the Programming Historian Wiki.
 
 3. The following announcement will be added to the top of the retired lesson: 
     <div class="alert alert-warning">{{ site.data.snippets.retired-definition[page.lang] | markdownify }}

--- a/es/politica-retirada-lecciones.md
+++ b/es/politica-retirada-lecciones.md
@@ -19,11 +19,11 @@ En los casos en que los miembros del equipo editorial, o miembros de la comunida
 
 Con independencia de que se cree o no un nuevo derivado, si el tutorial ya ha sido publicado, llevaremos a cabo los siguientes pasos:
 
-- La lección será trasladada de https://programminghistorian.org/es/lecciones/TITULO-LECCION a https://programminghistorian.org/es/lecciones/retirada/TITULO-LECCION. Se establecerá una redirección, por lo que cualquier enlace a la URL original indicará al usuario la nueva URL.
+1. La lección será trasladada de https://programminghistorian.org/es/lecciones/TITULO-LECCION a https://programminghistorian.org/es/lecciones/retirada/TITULO-LECCION. Se establecerá una redirección, por lo que cualquier enlace a la URL original indicará al usuario la nueva URL.
 
-- Una vez retirada, la lección dejará de aparecer en el directorio de lecciones y se eliminará del flujo de anuncios de Twitter.
+2. Una vez retirada, la lección dejará de aparecer en el directorio de lecciones y se eliminará del flujo de anuncios de Twitter. Los editores deberán consultar las instrucciones para retirar la lección del flujo de Twitter que encuentran en la Wiki de *Programming Historian*. 
 
-- El siguiente anuncio será añadido a la parte superior de la lección retirada:
+3. El siguiente anuncio será añadido a la parte superior de la lección retirada:
 
     <div class="alert alert-warning">{{ site.data.snippets.retired-definition[page.lang] | markdownify }}
 

--- a/es/politica-retirada-lecciones.md
+++ b/es/politica-retirada-lecciones.md
@@ -21,7 +21,7 @@ Con independencia de que se cree o no un nuevo derivado, si el tutorial ya ha si
 
 1. La lección será trasladada de https://programminghistorian.org/es/lecciones/TITULO-LECCION a https://programminghistorian.org/es/lecciones/retirada/TITULO-LECCION. Se establecerá una redirección, por lo que cualquier enlace a la URL original indicará al usuario la nueva URL.
 
-2. Una vez retirada, la lección dejará de aparecer en el directorio de lecciones y se eliminará del flujo de anuncios de Twitter. Los editores deberán consultar las instrucciones para retirar la lección del flujo de Twitter que encuentran en la Wiki de *Programming Historian*. 
+2. Una vez retirada, la lección dejará de aparecer en el directorio de lecciones y se eliminará del flujo de anuncios de Twitter. Los editores deberán consultar las instrucciones para retirar la lección del flujo de Twitter que se encuentran en la Wiki de *Programming Historian*. 
 
 3. El siguiente anuncio será añadido a la parte superior de la lección retirada:
 

--- a/fr/politique-retrait-lecons.md
+++ b/fr/politique-retrait-lecons.md
@@ -26,7 +26,7 @@ Qu'une leçon dérivée soit créée ou pas, voici les étapes à suivre pour re
 
 1. La leçon sera déplacée de `https://programminghistorian.org/fr/lecon/TITRE-DE-LA-LEÇON` à `https://programminghistorian.org/fr/lecons/retrait/TITRE-DE-LA-LEÇON`. Une redirection sera mise en place pour que des liens pointant à l'URL originelle renvoient l'utilisateur à la nouvelle URL.
 
-2. Une fois la leçon retirée, celle-ci n'apparaît plus dans le répertoire des leçons et elle est aussi enlevée de la liste de publications sur Twitter.
+2. Une fois la leçon retirée, celle-ci n'apparaît plus dans le répertoire des leçons et elle est aussi enlevée de la liste de publications sur Twitter. Les rédacteurs et les rédactrices du Programming Historian peuvent trouver toutes les instructions nécessaires sur le wiki pour enlever une leçon du bot Twitter. 
 
 3. L'avertissement suivant est ajouté en haut de la page de la leçon retirée:
     <div class="alert alert-warning">{{ site.data.snippets.retired-definition[page.lang] | markdownify }}


### PR DESCRIPTION
Closes #1674.

See also https://github.com/programminghistorian/jekyll/wiki/Retiring-a-Lesson-from-the-Twitter-Bot.

Tagging @programminghistorian/technical-team to make sure this makes sense. Once you approve, there is one sentence to the lesson retirement page that needs translating.
