### PR TITLE
Add section for first IPP member

### DIFF
--- a/en/support-us.md
+++ b/en/support-us.md
@@ -25,6 +25,8 @@ The project is grateful for the following support:
 - Funding for a writing workshop in Bogota, Colombia, supported by the [British Academy](https://www.britac.ac.uk/) [2018].
 - Seed funding and project management support from the Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) [2011-2013].
 - Our founding [Patreon](https://www.patreon.com/theprogramminghistorian) subscribers Rachel Murphy ('Subscriber' tier), Miriam Posner ('Sponsor' tier), and Tim Hitchcock ('Patron' tier). We would particularly like to thank the following 'Patron' tier [Patreon](https://www.patreon.com/theprogramminghistorian) subscribers: Tim Hitchcock, Shawn Graham, Jeff Blackadar.
+- Our [Institutional Partner Programme](en/support-us#institutional-partner-programme) members:
+  - [KU Leuven Libraries](https://bib.kuleuven.be/) (2020-)
 
 ## Donate to Us
 
@@ -66,7 +68,7 @@ Note that upon email with the subject line "Institutional Partners Programme" yo
 
 If you represent an organisation or group who are interested in sponsoring The Programming Historian, please contact [James Baker](https://github.com/drjwbaker) to discuss. Sponsorship can be financial, in-kind, or a combination of both. Sponsorship length and value are negotiable.
 
-All sponsorship is subject to [agreement](https://github.com/programminghistorian/jekyll/wiki/Programming-Historian-Governance) by the [Editorial Board](https://programminghis) of The Programming Historian. In order to avoid perceived conflicts of interest, safeguard our peer review process, and ensure our academic integrity, the Editorial Board have agreed **not to accept** the following forms of sponsorship
+All sponsorship is subject to [agreement](https://github.com/programminghistorian/jekyll/wiki/Programming-Historian-Governance) by the Editorial Board of The Programming Historian. In order to avoid perceived conflicts of interest, safeguard our peer review process, and ensure our academic integrity, the Editorial Board have agreed **not to accept** the following forms of sponsorship
 
 - Headline Sponsorship. For example, 'The Programming Historian in association with..' or 'The Programming Historian powered by..'.
 - Individual or Selective Lesson Sponsorship. For example, your logo on a single lesson page or lessons pages about a single tool or set of approaches.

--- a/es/apoyanos.md
+++ b/es/apoyanos.md
@@ -23,8 +23,9 @@ El proyecto agradece el siguiente apoyo:
 - Financiación para establecer <em>Programming Historian</em> como una entidad legal proporcionada por la [Escuela de Historia, Historia del Arte y Filosofia, Universidad de Sussex](http://www.sussex.ac.uk/hahp/) [2019].
 - Fondos para un taller de escritura en Bogotá, Colombia, financiados por la [Academia Británica](https://www.thebritishacademy.ac.uk) [2018]
 - Fondos iniciales y soporte de administración de la Red en Historia y Medio Ambiente de Canadá ([NiCHE](http://niche-canada.org/)) [2011-2013]
-
 - Nuestros primeros suscriptores de *Patreon* Rachel Murphy (nivel 'Suscriptor'), Miriam Posner (nivel 'Patrocinador') y Tim Hitchcock (nivel 'Mecenas'). En particular, agradecemos la contribución de los siguientes suscriptores de Patreon de nivel 'Mecenas': Tim Hitchcock, Shawn Graham, Jeff Blackadar.
+- Los miembros de nuestro [Programa de Instituciones Asociadas](es/apoyanos#programa-de-instituciones-asociadas):
+  - [Bibliotecas de la Universidad Católica de Lovaina](https://bib.kuleuven.be/) (2020-)
 
 ## Donaciones
 Los patrocinadores individuales del _Programming Historian en Español_ son vitales para aumentar, mejorar y mantener nuestro trabajo. Aceptamos donativos únicos y recurrentes.  

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -26,7 +26,7 @@ Le projet est reconnaissant pour leur soutien à:
 - Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) pour le soutien de projet émergent et de gestion de projet [2011-2013].
 - Nos donateurs fondateurs [Patreon](https://www.patreon.com/theprogramminghistorian) Rachel Murphy (niveau "Abonné"), Miriam Posner (niveau "Parrain/Marraine") et Tim Hitchcock (niveau "Mécène"). Nous souhaitons remercier tout particulièrement les donateurs de niveau "Mécène" suivants: Tim Hitchcock, Shawn Graham, Jeff Blackadar.
 - Les membres de notre [programme de partenariat institutionnel](fr/nous-soutenir#partenariat-institutionnel):
- - Les bibliothèques de la [KU Leuven](https://bib.kuleuven.be/) (2020-)
+  - Les bibliothèques de la [KU Leuven](https://bib.kuleuven.be/) (2020-)
  
 ## Donations
 

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -25,7 +25,9 @@ Le projet est reconnaissant pour leur soutien à:
 - [British Academy](https://www.britac.ac.uk/) pour le financement d'un atelier d'écriture à Bogota en Colombie [2018].
 - Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) pour le soutien de projet émergent et de gestion de projet [2011-2013].
 - Nos donateurs fondateurs [Patreon](https://www.patreon.com/theprogramminghistorian) Rachel Murphy (niveau "Abonné"), Miriam Posner (niveau "Parrain/Marraine") et Tim Hitchcock (niveau "Mécène"). Nous souhaitons remercier tout particulièrement les donateurs de niveau "Mécène" suivants: Tim Hitchcock, Shawn Graham, Jeff Blackadar.
-
+- Les membres de notre [programme de partenariat institutionnel](fr/nous-soutenir#partenariat-institutionnel):
+ - Les bibliothèques de la [KU Leuven](https://bib.kuleuven.be/) (2020-)
+ 
 ## Donations
 
 Les donations à titre individuel au *Programming Historian* sont vitales pour le développement, l'amélioration et la pérennisation de notre travail. Celles-ci peuvent être ponctuelles ou régulières.


### PR DESCRIPTION
We have our first IPP member! So we need a brief section on the `support-us.md` page to reflect that. I've added the EN line:

> Our [Institutional Partner Programme](en/support-us#institutional-partner-programme) members:
>>  [KU Leuven Libraries](https://bib.kuleuven.be/) (2020-)

These needs FR/ES translation. Very small job!

@jenniferisasi When this is done and up on the site, can we tweet please. I suggest: a link to the IPP page, nice photo of the library / their logo, twitter hashtag, general big celebratory thank yous to our founding IPP member! https://github.com/programminghistorian/jekyll/issues/1658