### PR TITLE
Split translation concordance into lessons vs. other pages sections 

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -2,6 +2,7 @@
 layout: blank
 title: The Programming Historian Blog
 redirect_from: /news.html
+skip_concordance: true
 ---
 
 <h1>PH Blog</h1>

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,5 @@
 ---
+skip_concordance: true
 ---
 
 @media screen {

--- a/feed.xml
+++ b/feed.xml
@@ -1,28 +1,31 @@
 ---
+skip_concordance: true
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0" 
+	xmlns:atom="http://www.w3.org/2005/Atom" 
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>{{ site.name | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
 		<link>{{ site.liveurl }}</link>
 		<atom:link href="{{ site.liveurl }}/feed.xml" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
-			<item>
-				<title>{{ post.title | xml_escape }}</title>
+		<item>
+			<title>{{ post.title | xml_escape }}</title>
 				{% if post.author.name %}
-					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
+			<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
 				{% endif %}
 				{% if post.excerpt %}
-					<description>{{ post.excerpt | xml_escape }}</description>
+			<description>{{ post.excerpt | xml_escape }}</description>
 				{% else %}
-					<description>{{ post.content | xml_escape }}</description>
+			<description>{{ post.content | xml_escape }}</description>
 				{% endif %}
-				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-				<link>{{ site.liveurl }}{{ post.url }}</link>
-				<guid isPermaLink="true">{{ site.liveurl }}{{ post.url }}</guid>
-			</item>
+			<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+			<link>{{ site.liveurl }}{{ post.url }}</link>
+			<guid isPermaLink="true">{{ site.liveurl }}{{ post.url }}</guid>
+		</item>
 		{% endfor %}
 
 				{% assign pages = site.pages | where:'layout','lesson'| where: 'lang', 'en' | sort:'date' | reverse %}
@@ -34,7 +37,7 @@
 				{% for page in pages limit:10 %}
 						{% include feed-item.html %}
 				{% endfor %}
-				
+
 				{% assign pages = site.pages | where:'layout','lesson'|  where:'lang','fr' | sort:'translation_date' | reverse %}
 				{% for page in pages limit:10 %}
 						{% include feed-item.html %}

--- a/js/lessonfilter.js
+++ b/js/lessonfilter.js
@@ -1,6 +1,3 @@
----
----
-
 function resetSort() {
   $('#current-sort').removeClass().addClass("sort-desc");
   $("#sort-by-date").removeClass().addClass("sort desc my-asc");
@@ -8,7 +5,7 @@ function resetSort() {
 }
 
 
-function applySortFromURI(uri,featureList) {
+function applySortFromURI(uri, featureList) {
 
   console.log("applying sort from URI");
 
@@ -60,7 +57,7 @@ function wireButtons() {
   console.log(uri.toString());
 
   var options = {
-    valueNames: [ 'date', 'title', 'difficulty', 'activity', 'topics' ]
+    valueNames: ['date', 'title', 'difficulty', 'activity', 'topics']
   };
 
   var featureList = new List('lesson-list', options);
@@ -68,42 +65,42 @@ function wireButtons() {
   var stateObj = { foo: "bar" };
 
   // When a filter button is clicked
-  $('.filter').children().click(function() {
-      // Set clicked button as current
-      $('.filter').children().removeClass("current");
-      $(this).addClass("current");
+  $('.filter').children().click(function () {
+    // Set clicked button as current
+    $('.filter').children().removeClass("current");
+    $(this).addClass("current");
 
-      // Update the results header
-      $('#results-value').text($(this).text() + " ");
-      $('#results-value').css('textTransform', 'uppercase');
+    // Update the results header
+    $('#results-value').text($(this).text() + " ");
+    $('#results-value').css('textTransform', 'uppercase');
 
-      applySortFromURI(uri,featureList);
+    applySortFromURI(uri, featureList);
   });
 
 
   // When the reset button is clicked
-  $('#filter-none').click(function() {
-      // Remove highlighting from filter buttons
-      $('.filter').children().removeClass("current");
+  $('#filter-none').click(function () {
+    // Remove highlighting from filter buttons
+    $('.filter').children().removeClass("current");
 
-      // Reset filter results header
-      $('#results-value').text($('#results-value').text());
+    // Reset filter results header
+    $('#results-value').text($('#results-value').text());
 
-      // Reset uri to remove query params
-      uri.search("");
-      history.pushState(stateObj, "", uri.toString());
+    // Reset uri to remove query params
+    uri.search("");
+    history.pushState(stateObj, "", uri.toString());
 
-      // Reset filtering and perform default sort
-      featureList.filter();
-      featureList.sort('date', { order: "desc" });
+    // Reset filtering and perform default sort
+    featureList.filter();
+    featureList.sort('date', { order: "desc" });
 
-      // Reset sort buttons to defaults
-      resetSort();
+    // Reset sort buttons to defaults
+    resetSort();
   });
 
 
   // When a sort button is clicked, update the results header to show current sorting status
-  $('.sort').click(function() {
+  $('.sort').click(function () {
 
     // Get sort type from button (date or difficulty)
     var sortType = $(this).attr("data-sort");
@@ -130,7 +127,7 @@ function wireButtons() {
     }
 
     // Set CSS class for results header (the arrow)
-    $('#current-sort').removeClass().addClass("sort-"+newSortOrder);
+    $('#current-sort').removeClass().addClass("sort-" + newSortOrder);
 
     // Manually sort to override default behavior of list.js, which does not support multiple sort buttons very well.
     // The problem is that when changing sort type, list.js automatically sorts asc on the first sort. This is not
@@ -145,11 +142,11 @@ function wireButtons() {
   });
 
   // Wire up each of the activity filter buttons.
-  $('.filter.activities').children().click(function() {
+  $('.filter.activities').children().click(function () {
 
     var type = $(this).attr("id").substr(7);
 
-    featureList.filter(function(item) {
+    featureList.filter(function (item) {
       if (item.values().activity == type) {
         return true;
       } else {
@@ -168,11 +165,11 @@ function wireButtons() {
 
 
   // Wire up each of the topic filter buttons.
-  $('.filter.topics').children().click(function() {
+  $('.filter.topics').children().click(function () {
 
     var type = $(this).attr("id").substr(7);
 
-    featureList.filter(function(item) {
+    featureList.filter(function (item) {
       var topicsArray = item.values().topics.split(/\s/);
       if (topicsArray.includes(type)) {
         return true;
@@ -211,6 +208,6 @@ function wireButtons() {
   }
   else {
     // Apply sorting criteria from the URI if no filter
-    applySortFromURI(uri,featureList);
+    applySortFromURI(uri, featureList);
   }
 };

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -3,9 +3,9 @@ layout: blank
 title: Translation Concordance
 ---
 
-An automatically-generated list of lessons translation relationships across our publications.
+An automatically-generated list of page translation relationships across our publications.
 
-{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'false'" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}
@@ -18,6 +18,27 @@ An automatically-generated list of lessons translation relationships across our 
   <tr>
     {% for l in site.data.snippets.language-list %}
     {% assign sp = page_versions | where: "lang", l | first %}
+    {% assign where_exp: "item", "item.layout == 'lesson' %}
+    <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
+    {% endfor %}
+  </tr>
+{% endfor %}
+</table>
+
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
+
+<table>
+  <tr>{% for l in site.data.snippets.language-list %}
+    <th>{{ l }}</th>{% endfor %}
+  </tr>
+  {% for p in original_pages %}
+  {% assign reverse_p = p.name | split: "." | first %}
+  {% assign translated_pages = site.pages | where: "original", reverse_p %}
+  {% assign page_versions =  p | concat: translated_pages %}
+  <tr>
+    {% for l in site.data.snippets.language-list %}
+    {% assign sp = page_versions | where: "lang", l | first %}
+    {% assign where_exp: "item", "item.layout != 'lesson' %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -24,7 +24,7 @@ An automatically-generated list of page translation relationships across our pub
 {% endfor %}
 </table>
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" | where_exp: "item", "item.layout != 'post'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,7 +5,7 @@ title: Translation Concordance
 
 An automatically-generated list of lessons translation relationships across our publications.
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
+{% assign original_pages = site.pages | where: "layout", "lesson" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,7 +5,7 @@ title: Translation Concordance
 
 An automatically-generated list of lessons translation relationships across our publications.
 
-{% assign original_pages = site.pages | where: "layout", "lesson" %}
+{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'true'" where_exp: "retired" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,7 +5,7 @@ title: Translation Concordance
 
 An automatically-generated list of page translation relationships across our publications.
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout == 'lesson'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}
@@ -18,14 +18,13 @@ An automatically-generated list of page translation relationships across our pub
   <tr>
     {% for l in site.data.snippets.language-list %}
     {% assign sp = page_versions | where: "lang", l | first %}
-    {% assign where_exp: "item", "item.layout == 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>
 {% endfor %}
 </table>
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}
@@ -38,7 +37,6 @@ An automatically-generated list of page translation relationships across our pub
   <tr>
     {% for l in site.data.snippets.language-list %}
     {% assign sp = page_versions | where: "lang", l | first %} 
-    {% assign where_exp: "item", "item.layout != 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -17,7 +17,7 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout == 'lesson" %}
+    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout == 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -13,7 +13,7 @@ An automatically-generated list of lessons translation relationships across our 
   </tr>
   {% for p in original_pages %}
   {% assign reverse_p = p.name | split: "." | first %}
-  {% assign translated_pages = site.pages | where: "original", "lesson" reverse_p %}
+  {% assign translated_pages = site.pages | where: "original", "lesson", reverse_p %}
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -13,7 +13,7 @@ An automatically-generated list of lessons translation relationships across our 
   </tr>
   {% for p in original_pages %}
   {% assign reverse_p = p.name | split: "." | first %}
-  {% assign translated_pages = site.pages | where: "original", "lesson", reverse_p %}
+  {% assign translated_pages = site.pages | where: "original", reverse_p %}
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,13 +5,13 @@ title: Translation Concordance
 
 An automatically-generated list of page translation relationships across our publications.
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout == 'lesson'" %}
+{% assign original_lessons = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout == 'lesson'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}
     <th>{{ l }}</th>{% endfor %}
   </tr>
-  {% for p in original_pages %}
+  {% for p in original_lessons %}
   {% assign reverse_p = p.name | split: "." | first %}
   {% assign translated_pages = site.pages | where: "original", reverse_p %}
   {% assign page_versions =  p | concat: translated_pages %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -17,7 +17,8 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout == 'lesson'" %}
+    {% assign sp = page_versions | where: "lang", l | first %}
+    {% assign where_exp: "item", "item.layout == 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>
@@ -36,7 +37,8 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout != 'lesson'" %}
+    {% assign sp = page_versions | where: "lang", l | first %} 
+    {% assign where_exp: "item", "item.layout != 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,7 +5,7 @@ title: Translation Concordance
 
 An automatically-generated list of lessons translation relationships across our publications.
 
-{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'true'" where_exp: "retired" %}
+{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'true'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -17,8 +17,7 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first %}
-    {% assign where_exp: "item", "item.layout == 'lesson' %}
+    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout == 'lesson" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>
@@ -37,8 +36,7 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first %}
-    {% assign where_exp: "item", "item.layout != 'lesson' %}
+    {% assign sp = page_versions | where: "lang", l | first | where_exp: "item", "item.layout != 'lesson'" %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -5,7 +5,7 @@ title: Translation Concordance
 
 An automatically-generated list of lessons translation relationships across our publications.
 
-{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'true'" %}
+{% assign original_pages = site.pages | where: "layout", "lesson" | where_exp: "item", "item.retired != 'false'" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -3,7 +3,7 @@ layout: blank
 title: Translation Concordance
 ---
 
-An automatically-generated list of page translation relationships across this site.
+An automatically-generated list of lessons translation relationships across our publications.
 
 {% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" %}
 
@@ -13,7 +13,7 @@ An automatically-generated list of page translation relationships across this si
   </tr>
   {% for p in original_pages %}
   {% assign reverse_p = p.name | split: "." | first %}
-  {% assign translated_pages = site.pages | where: "original", reverse_p %}
+  {% assign translated_pages = site.pages | where: "original", "lesson" reverse_p %}
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}

--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -24,7 +24,7 @@ An automatically-generated list of page translation relationships across our pub
 {% endfor %}
 </table>
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" | where_exp: "item", "item.layout != 'post'" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" | where_exp: "item", "item.layout != 'post'" | where_exp: "item", "item.skip_concordance != true" %}
 
 <table>
   <tr>{% for l in site.data.snippets.language-list %}
@@ -36,7 +36,7 @@ An automatically-generated list of page translation relationships across our pub
   {% assign page_versions =  p | concat: translated_pages %}
   <tr>
     {% for l in site.data.snippets.language-list %}
-    {% assign sp = page_versions | where: "lang", l | first %} 
+    {% assign sp = page_versions | where: "lang", l | first %}
     <td><a href="{{sp.url}}">{{ sp.title }}</a></td>
     {% endfor %}
   </tr>


### PR DESCRIPTION
My first attempt at organizing this page to reflect the progress of translated content per #1698. 

Will probably take a few attempts in my learning process.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [ ] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above
- [ ] Duplicate this page and add it to the other languages' folder. I will translate the only sentence myself. 


*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
