### PR TITLE
create search.json template and instances for each lang

### DIFF
--- a/_layouts/search.json
+++ b/_layouts/search.json
@@ -1,0 +1,20 @@
+---
+---
+
+
+[
+{% assign corpus = site.pages | where: "layout", "lesson" | where: "lang", page.lang %}
+{% for page in corpus %}
+{% capture search_block %}
+{{ page.title }}
+{{ page.content | markdownify }}
+{{ page.abstract | markdownify }}
+{% endcapture %}
+{
+  "id": {% increment counter %},
+  "url": {{ page.url | absolute_url | jsonify }},
+  "title": {{ page.title  | jsonify }},
+  "body": {{ search_block | strip_html | jsonify }}
+}{% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+]

--- a/en/search.json
+++ b/en/search.json
@@ -1,0 +1,3 @@
+---
+layout: search
+---

--- a/es/search.json
+++ b/es/search.json
@@ -1,0 +1,3 @@
+---
+layout: search
+---

--- a/fr/search.json
+++ b/fr/search.json
@@ -1,0 +1,3 @@
+---
+layout: search
+---


### PR DESCRIPTION
re: #1018

This PR adds a new template that generates a single JSON file for each language, encoding the full text of every lesson. These will be used by the search index microservice to generate a lunr index to allow full text search

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
 ~- [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~
- [X] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
