### PR TITLE
separate language team from editorial role

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -146,6 +146,7 @@
         Víctor Gayol est enseignant-chercheur en histoire au Centre d'études historiques (Centro de Estudios Históricos) d'El Colegio de Michoacán, A.C. (CPI-CONACYT) au Mexique.
   team_roles:
    - spanish
+   - editorial
    - board
   status: volunteer
 
@@ -175,6 +176,7 @@
         Antonio Rojas Castro est docteur en Littérature espagnole (Université Pompeu Fabra) et chercheur à l'Académie des sciences de Berlin-Brandebourg.
   team_roles:
    - spanish
+   - editorial
    - board
   status: volunteer
 
@@ -557,6 +559,7 @@
   team_roles:
    - managing
    - editorial
+   - english
    - board
   status: volunteer
 
@@ -590,6 +593,7 @@
         Amanda Visconti est directrice du centre des humanités numériques du Scholars' Lab de l'Université de Virginie.
   team_roles:
    - ombuds
+   - english
 
 - name: Megan R. Brett
   team: false
@@ -627,6 +631,7 @@
   team_roles:
    - proghist
    - editorial
+   - english
    - board
    - technical
   status: institutionally-supported
@@ -821,6 +826,7 @@
         Anna-Maria Sichani est spécialiste de l'histoire culturelle et de l'histoire de la littérature, mais aussi des humanités numériques. Elle est actuellement chercheuse en histoire des médias à l'Université du Sussex.
   team_roles:
    - editorial
+   - english
    - proghist
    - ed-manager
    - technical
@@ -920,6 +926,7 @@
         José Antonio Motilla est chercheur en histoire, art, culture et humanités numériques à l'Université autonome de San Luis Potosí au Mexique, et directeur de la bibliothèque Ricardo B. Anaya.
   team_roles:
    - spanish
+   - editorial
    - board
   status: volunteer
 
@@ -948,6 +955,7 @@
         Jennifer Isasi est chercheuse postdoctorale du programme CLIR au LLILAS Benson en Études et collections latino-américaines, et docteure en études hispaniques.
   team_roles:
     - spanish
+    - editorial
     - proghist
     - communication-manager
     - technical
@@ -985,8 +993,9 @@
           Universidad de Ottawa, Canadá
   team_roles:
     - french
+    - editorial
     - board
-    - ombuds-fr
+    - ombuds
   status: institutionally-supported
   bio:
       en: |
@@ -1024,6 +1033,7 @@
             Universidad de Lausanne (Suiza)
   team_roles:
     - french
+    - editorial
     - board
   bio:
         en: |
@@ -1052,6 +1062,7 @@
   team_roles:
     - managing
     - french
+    - editorial
     - proghist
     - board
     - technical
@@ -1093,6 +1104,7 @@
   team_roles:
     - board
     - french
+    - editorial
   status: volunteer
   bio:
         en: |
@@ -1147,6 +1159,7 @@
         Zoe LeBlanc est développeuse spécialiste des Humanités Numériques au Scholar's Lab de l'Université de Virginie..
   team_roles:
    - editorial
+   - english
    - proghist
    - board
    - technical
@@ -1188,6 +1201,7 @@
   team_roles:
     - managing
     - spanish
+    - editorial
     - proghist
     - board
     - global
@@ -1218,6 +1232,7 @@
         Joshua G. Ortiz Baco est un doctorant en espagnol et portugais de l'Université du Texas à Austin.
   team_roles:
     - spanish
+    - editorial
     - board
   status: volunteer
 

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -1,10 +1,10 @@
+# Publication Roles
 # Definitions of editorial sub teams.
 #
 # type: the tag added in ph_authors.yml
 # label: Short label to be displayed alongside the author bio, and in the roles definition list
 # definition: Brief description of that editorial team. If this is a derived label that uses the definition of another role, instead use...
 
-# --- Publication Roles ---
 - type: managing
   label:
     en: Managing Editor
@@ -36,13 +36,13 @@
 # --- Proghist Roles ---
 - type: proghist
   label:
-     en: ProgHist Ltd
-     es: ProgHist Ltd
-     fr: ProgHist Ltd
+    en: ProgHist Ltd
+    es: ProgHist Ltd
+    fr: ProgHist Ltd
   definition:
-     en: This member holds a role in the not-for-profit company ProgHist Ltd, which supports the publications.
-     es: Este miembro funge un cargo en la compañía sin ánimo de lucro ProgHist Ltd, que gestiona las publicaciones.
-     fr: Ce(tte) membre occupe un rôle au sein de la compagnie sans but lucratif ProgHist Ltd, qui soutient les publications.
+    en: This member holds a role in the not-for-profit company ProgHist Ltd, which supports the publications.
+    es: Este miembro funge un cargo en la compañía sin ánimo de lucro ProgHist Ltd, que gestiona las publicaciones.
+    fr: Ce(tte) membre occupe un rôle au sein de la compagnie sans but lucratif ProgHist Ltd, qui soutient les publications.
 - type: technical-lead
   label:
     en: Technical Lead
@@ -143,22 +143,22 @@
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
     fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.
 
-# --- Status ---
+# Status
 - type: volunteer
   label:
-     en: Volunteer
-     es: Voluntario
-     fr: Bénévole
+    en: Volunteer
+    es: Voluntario
+    fr: Bénévole
   definition:
-     en: This member's time on the project is wholly voluntary.
-     es: El tiempo que este miembro dedica al proyecto es voluntario.
-     fr: Ce membre contribue son temps sur une base entièrement bénévole.
+    en: This member's time on the project is wholly voluntary.
+    es: El tiempo que este miembro dedica al proyecto es voluntario.
+    fr: Ce membre contribue son temps sur une base entièrement bénévole.
 - type: institutionally-supported
   label:
-     en: Institutionally Supported
-     es: Apoyado por su institución
-     fr: Soutenu institutionnellement
+    en: Institutionally Supported
+    es: Apoyado por su institución
+    fr: Soutenu institutionnellement
   definition:
-     en: This member's time on the project is either directly or indirectly supported by their employer.
-     es: El tiempo que este miembro dedica al proyecto está directa o indirectamente apoyado por su institución.
-     fr: Le temps que ce membre consacre au projet est directement ou indirectement financé par son employeur.
+    en: This member's time on the project is either directly or indirectly supported by their employer.
+    es: El tiempo que este miembro dedica al proyecto está directa o indirectamente apoyado por su institución.
+    fr: Le temps que ce membre consacre au projet est directement ou indirectement financé par son employeur.

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -3,8 +3,6 @@
 # type: the tag added in ph_authors.yml
 # label: Short label to be displayed alongside the author bio, and in the roles definition list
 # definition: Brief description of that editorial team. If this is a derived label that uses the definition of another role, instead use...
-# source_role: The role type where the definition for this derived role can be found (e.g. pointing from an ES variant of a role to the original EN definition)
-
 
 # --- Publication Roles ---
 - type: managing
@@ -18,31 +16,13 @@
     fr: Premier contact pour les auteurs souhaitant proposer une lesson
 - type: editorial
   label:
-    en: Editor (English)
-    es: Editor(a) (Inglés)
-    fr: Rédacteur (anglais)
+    en: Editor
+    es: Editor(a)
+    fr: Rédacteur
   definition:
-    en: Responsible for editorial work resulting in the review and publication of English-language lessons
-    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en inglés
-    fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en anglais
-- type: spanish
-  label:
-    en: Editor (Spanish)
-    es: Editor(a) (español)
-    fr: Rédacteur (espagnol)
-  definition:
-    en: Responsible for editorial work resulting in the review and publication of Spanish-language lessons
-    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en español
-    fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en espagnol
-- type: french
-  label:
-    en: Editor (French)
-    es: Editor(a) (francés)
-    fr: Rédacteur (français)
-  definition:
-    en: Responsible for editorial work resulting in the review and publication of French-language lessons
-    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones en francés
-    fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons en français
+    en: Responsible for editorial work resulting in the review and publication of lessons
+    es: Responsable del trabajo editorial que deriva en la revisión y publicación de las lecciones
+    fr: Responsable du travail éditorial pour l'évaluation et la publication des lessons
 - type: ombuds
   label:
     en: Ombudsperson
@@ -144,20 +124,6 @@
     en: Keeping the team focused on achieving its goals in a timely manner
     es: Mantener al equipo enfocado en lograr sus objetivos de manera puntual
     fr: Garder l'équipe concentrée sur la réalisation de ses objectifs à l'intérieur des délais prévus
-
-# --- Derived roles ---
-- type: ombuds-es
-  label:
-    en: Ombudsperson (Spanish)
-    es: Mediador (español)
-    fr: Médiateur/médiatrice (espagnol)
-  source_role: ombuds
-- type: ombuds-fr
-  label:
-    en: Ombudsperson (French)
-    es: Mediador (francés)
-    fr: Médiateur/médiatrice (français)
-  source_role: ombuds
 - type: global-lead
   label:
     en: Global Lead
@@ -166,7 +132,7 @@
   definition:
     en: Coordinates the Global Team and facilitates communication with other Programming Historian teams.
     es: Coordina el Equipo Global y facilita la comunicación con el resto de los equipos de Programming Historian.
-    fr: Coordonne l'équipe globale et assure la communication avec les autres équipes du Programming Historian. 
+    fr: Coordonne l'équipe globale et assure la communication avec les autres équipes du Programming Historian.
 - type: global
   label:
     en: Global Team
@@ -175,7 +141,7 @@
   definition:
     en: Managing new global initiatives, as well as trying to improve the cultural and linguistic diversity of the team, our lessons, and of participation in Digital Humanities more generally.
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
-    fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.  
+    fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.
 
 # --- Status ---
 - type: volunteer

--- a/_includes/contact-info.html
+++ b/_includes/contact-info.html
@@ -33,12 +33,7 @@ List subteams within the larger editorial team
 	
 {% for role in member.team_roles %}
 {% assign role_label = (site.data.teamroles | where: "type", role) | first %}
-{% if role_label.source_role %}
-  {% assign source_role = (site.data.teamroles | where: "type", role_label.source_role | first %}
-  {% assign role_definition = source_role.definition %}
-{% else %}
-  {% assign role_definition = role_label.definition %}
-{% endif %}
+{% assign role_definition = role_label.definition %}
 <span class="badge badge-primary" data-toggle="tooltip" data-placement="bottom" title = "{{ role_definition[page.lang] }}">{{ role_label.label[page.lang] }}</span>
 {% endfor %}
 </p>

--- a/_includes/project-team-loop.html
+++ b/_includes/project-team-loop.html
@@ -1,33 +1,33 @@
-
 {% comment %}
-Loops through members of editorial team and then generates their contact info using the contact-info.html include. This is used both on project-team.md as well as es/equipo-de-proyecto.md
+Loops through members of editorial team and then generates their contact info using the contact-info.html include. This
+is used both on project-team.md as well as es/equipo-de-proyecto.md
 {% endcomment %}
 
 <!-- Activate the Bootstrap tooltip javascript manually so definitions will display -->
 <script>$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})</script>
+    $('[data-toggle="tooltip"]').tooltip()
+  })</script>
 
 
-### Programming Historian in English 
-{% assign englishmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'editorial'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
+### Programming Historian in English
+{% assign englishmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'english'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in englishmembers %}
 {% include contact-info.html name=member.name %}
 {% endfor %}
 
-### Programming Historian en espa&ntilde;ol 
+### Programming Historian en espa&ntilde;ol
 {% assign spanishmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'spanish'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in spanishmembers %}
 {% include contact-info.html name=member.name %}
 {% endfor %}
 
-### Programming Historian en fran&ccedil;ais 
+### Programming Historian en fran&ccedil;ais
 {% assign frenchmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'french'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in frenchmembers %}
 {% include contact-info.html name=member.name %}
 {% endfor %}
 
-### ProgHist Ltd 
+### ProgHist Ltd
 {% assign proghistmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'proghist'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in proghistmembers %}
 {% include contact-info.html name=member.name %}
@@ -36,9 +36,9 @@ Loops through members of editorial team and then generates their contact info us
 
 ### {{ site.data.snippets.project-team-roles[page.lang] }}
 <ul>
-{% for team in site.data.teamroles %}
+  {% for team in site.data.teamroles %}
   {% if team.definition %}
   <li><strong>{{ team.label[page.lang] }}</strong>: {{ team.definition[page.lang] }}</li>
   {% endif %}
-{% endfor %}
+  {% endfor %}
 </ul>


### PR DESCRIPTION
This allows us to simplify the logic of generating role labels and definitions. Now, adding the teamrole `english`, `spanish`, or `french` only determines in which section of the team page the person will appear. `editorial` is now only used on those authors who are editing lessons. This allows for there to be e.g. a Spanish team ombudsperson who isn't also listed as an editor.

@acrymble I tried to update ph_authors.yml correctly, but please review carefully to make sure that it reflects who currently holds which roles

closes #1707

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  ~- [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~
- [x] Add the appropriate "Label"
- [ ] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
