### PR TITLE
full-text search using listjs

### DIFF
--- a/_includes/lesson-index.html
+++ b/_includes/lesson-index.html
@@ -24,6 +24,7 @@
 <!--
 this div ('lesson-list', referenced in lessonfilter.js) needs to contain the sort button/elements AND the actual list for the sort buttons to work
 -->
+<input id="search" type="text" placeholder="Search lessons...">
 <div id="lesson-list">
 
 <!--
@@ -40,6 +41,7 @@ Yes, this is confusing. But using two differnt classes allows us to separate fun
 
   <input id="date-sort-text" type="hidden" label="{{site.data.snippets.date[page.lang]}}">
   <input id="difficulty-sort-text" type="hidden" label="{{site.data.snippets.difficulty[page.lang]}}">
+  
 
   <h2 class="results-title">{{ site.data.snippets.filtering-results[page.lang] }}: <span id="results-value">{{ site.data.snippets.all-lessons[page.lang] }} </span> <span id="current-sort" class="sort-desc">{{site.data.snippets.date[page.lang]}}</span></h2>
 

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -32,5 +32,6 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   <span class="topics">{{ lesson.topics | join: ' '}}</span>
   <span class="date">{% if lesson.translation_date %}{{ lesson.translation_date }}{% else %}{{ lesson.date }}{% endif %}</span>
   <span class="difficulty">{{ lesson.difficulty }}</span>
+  <span id="{{lesson.title}}-content" class="content" style="display: none;">{{ lesson.content | markdownify | strip_html }}</span>
 
 </div>

--- a/css/style.css
+++ b/css/style.css
@@ -315,6 +315,25 @@ Lessons Index
     background-color:#ededed;
   }
 
+  /*****************
+    SEARCH
+  *****************/
+
+  #search {
+    width:99.5%;
+    clear:both;
+    margin-bottom:1rem;
+    background-color:#fefefe;
+    color:#666;
+    border:1px solid #999;
+    font: .9rem/1.1rem 'Open Sans',
+    sans-serif;
+    padding: .4rem .6rem;
+    border-radius: 3px;
+    display:inline-block;
+    text-transform:uppercase;
+    text-decoration: none;
+  }
 
   /*****************
     SORT BUTTONS

--- a/js/lessonfilter.js
+++ b/js/lessonfilter.js
@@ -60,12 +60,18 @@ function wireButtons() {
   console.log(uri.toString());
 
   var options = {
-    valueNames: [ 'date', 'title', 'difficulty', 'activity', 'topics' ]
+    valueNames: [ 'date', 'title', 'difficulty', 'activity', 'topics','abstract', 'content' ]
   };
 
   var featureList = new List('lesson-list', options);
   // We need a stateObj for adjusting the URIs on button clicks, but the value is moot for now; could be useful for future functionality.
   var stateObj = { foo: "bar" };
+
+
+  $('#search').on('keyup', function () {
+    var searchString = $(this).val();
+    featureList.search(searchString, ['content', 'abstract', 'title']);
+  });
 
   // When a filter button is clicked
   $('.filter').children().click(function() {

--- a/js/lessonfilter.js
+++ b/js/lessonfilter.js
@@ -67,10 +67,11 @@ function wireButtons() {
   // We need a stateObj for adjusting the URIs on button clicks, but the value is moot for now; could be useful for future functionality.
   var stateObj = { foo: "bar" };
 
-
+  // Filter lessons on search
   $('#search').on('keyup', function () {
     var searchString = $(this).val();
-    featureList.search(searchString, ['content', 'abstract', 'title']);
+    featureList.search(searchString, ['content']);
+    // featureList.fuzzySearch(searchString, ['content']); // List.js has a fuzzy search method but I get fewer results with it than the regular search method. We could create are own fuzzy search function here and then use List.js filtering instead of search.
   });
 
   // When a filter button is clicked


### PR DESCRIPTION
Testing out List.js built in search functionality. Try typing in the lessons main page to filter on lesson content (we could also add other fields but figured content made the most sense).

Few notes:
- I added a comment with the fuzzySearch method, so maybe try that method as well. Though I get fewer hits with it than with the search one 🤔
- We could also still use Lunr.js or build our own fuzzySearch method, and then use List.js filtering to keep our current architecture.
- Do we still want keyword in context?

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
