### PR TITLE
Update to team roles

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1234,6 +1234,7 @@
     - spanish
     - editorial
     - board
+    - new-pub-manager
   status: volunteer
 
 - name: Armando Luza

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -142,6 +142,15 @@
     en: Managing new global initiatives, as well as trying to improve the cultural and linguistic diversity of the team, our lessons, and of participation in Digital Humanities more generally.
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
     fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.
+- type: new-pub-manager
+  label:
+    en: New Publications Manager
+    es: Mánager de publicaciones nuevas
+    fr: Responsable de nouvelles publications
+  definition:
+    en: Coordinates the process for creating new publications and facilitates communication with other Programming Historian teams.
+    es: Coordina el proceso de creación de publicaciones nuevas y facilita la comunicación con el resto de los equipos de Programming Historian.
+    fr: Responsable de la création de nouvelles publications et assure la communication avec les autres équipes du Programming Historian.
 
 # Status
 - type: volunteer

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -146,7 +146,7 @@
   label:
     en: New Publications Manager
     es: Mánager de publicaciones nuevas
-    fr: Responsable de nouvelles publications
+    fr: Responsable des nouvelles publications
   definition:
     en: Coordinates the process for creating new publications and facilitates communication with other Programming Historian teams.
     es: Coordina el proceso de creación de publicaciones nuevas y facilita la comunicación con el resto de los equipos de Programming Historian.


### PR DESCRIPTION
Updated project team roles to include New Publications Manager

### Checklist

- [X] Assign yourself in the "Assignees" menu
- [X] Assign at least one individual or team to "Reviewers"
- [X] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.

I borrowed from the existing descriptions but I want to make sure that the new publications manager descriptions in `teamroles.yml` are worded correctly in French. 


- [X] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)

#1723


