### PR TITLE
Place multiple translations into one banner #1738

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -177,7 +177,14 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
 </header>
 
-<div class="alert alert-warning">
+<div class="alert alert-warning"> 
+{% unless page == translation_source %}
+  <!-- If this lesson is translated, banner pointing to the original language source of this lesson -->
+{{ site.data.snippets.translation-source[source.lang] }} {{ site.data.snippets.language-name[source.lang]}}: <a href="{{ translation_source.url }}">{{ translation_source.title }}</a>
+  {% endunless %}
+</div>
+  
+<div class="alert alert-warning"> 
   {% for candidate in translation_candidates %}
   {% unless page.lang == candidate.lang %}
   <!-- Banner pointing to translations of this lesson when they exist -->
@@ -186,17 +193,17 @@ All lesson metadata and alerts should follow the convention of pulling appropria
       href="{{ candidate.url }}">{{ candidate.title }}</a>
   {% endunless %}
   {% endfor %}
-
-
+  
   {% for candidate in translation_candidates %}
   {% unless page.lang == candidate.lang %}
   <!-- Banner pointing to translations of this lesson when they exist -->
-    {{ site.data.snippets.translation-target[page.lang]}}
+    {{ site.data.snippets.translation-target[candidate.lang]}}
     {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
       href="{{ candidate.url }}">{{ candidate.title }}</a>
   {% endunless %}
   {% endfor %}
-   </div>
+</div>
+
 
   {% if page.retired %}
   <div class="alert alert-warning">

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -177,30 +177,26 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
 </header>
 
-<div class="container">
-
-  {% if site.lesson_donation_alerts %}
-  {% include support-alert.html %}
-  {% endif %}
-
-  {% unless page == translation_source %}
-  <!-- If this lesson is translated, banner pointing to the original language source of this lesson -->
-  <div class="alert alert-warning">
-    {{ site.data.snippets.translation-source[page.lang] }} {{ site.data.snippets.language-name.en[page.lang]}}: <a
-      href="{{ translation_source.url }}">{{ translation_source.title }}</a>
-  </div>
+<div class="alert alert-warning">
+  {% for candidate in translation_candidates %}
+  {% unless page.lang == candidate.lang %}
+  <!-- Banner pointing to translations of this lesson when they exist -->
+    {{ site.data.snippets.translation-target[candidate.lang]}}
+    {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
+      href="{{ candidate.url }}">{{ candidate.title }}</a>
   {% endunless %}
+  {% endfor %}
+
 
   {% for candidate in translation_candidates %}
   {% unless page.lang == candidate.lang %}
   <!-- Banner pointing to translations of this lesson when they exist -->
-  <div class="alert alert-warning">
     {{ site.data.snippets.translation-target[page.lang]}}
     {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
       href="{{ candidate.url }}">{{ candidate.title }}</a>
-  </div>
   {% endunless %}
   {% endfor %}
+   </div>
 
   {% if page.retired %}
   <div class="alert alert-warning">

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -183,19 +183,22 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% include support-alert.html %}
   {% endif %}
 
+
 {% unless page == translation_source %}
   <!-- If this lesson is translated, banner pointing to the original language source of this lesson -->
-<div class="alert alert-warning"> 
-  {{ site.data.snippets.translation-source[source.lang] }} {{ site.data.snippets.language-name.en[source.lang]}}: <a href="{{ translation_source.url }}">{{ translation_source.title }}</a>
+ <div class="alert alert-warning"> 
+  {{ site.data.snippets.translation-source[page.lang] }} {{ site.data.snippets.language-name.en[page.lang]}}: <a href="{{ translation_source.url }}">{{ translation_source.title }}</a>
+ </div> 
   {% endunless %}
 
   {% for candidate in translation_candidates %}
   {% unless page.lang == candidate.lang %}
   <!-- Banner pointing to translations of this lesson when they exist -->
+  <div class="alert alert-warning"> 
     {{ site.data.snippets.translation-target[candidate.lang]}}
-    {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
+    {{ site.data.snippets.language-name[candidate.lang][candidate.lang]}}: <a
       href="{{ candidate.url }}">{{ candidate.title }}</a>
-</div>
+  </div>
   {% endunless %}
   {% endfor %}
   

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -177,33 +177,28 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
 </header>
 
-<div class="alert alert-warning"> 
+<div class="container">
+
+  {% if site.lesson_donation_alerts %}
+  {% include support-alert.html %}
+  {% endif %}
+
 {% unless page == translation_source %}
   <!-- If this lesson is translated, banner pointing to the original language source of this lesson -->
-{{ site.data.snippets.translation-source[source.lang] }} {{ site.data.snippets.language-name[source.lang]}}: <a href="{{ translation_source.url }}">{{ translation_source.title }}</a>
-  {% endunless %}
-</div>
-  
 <div class="alert alert-warning"> 
+  {{ site.data.snippets.translation-source[source.lang] }} {{ site.data.snippets.language-name.en[source.lang]}}: <a href="{{ translation_source.url }}">{{ translation_source.title }}</a>
+  {% endunless %}
+
   {% for candidate in translation_candidates %}
   {% unless page.lang == candidate.lang %}
   <!-- Banner pointing to translations of this lesson when they exist -->
     {{ site.data.snippets.translation-target[candidate.lang]}}
     {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
       href="{{ candidate.url }}">{{ candidate.title }}</a>
+</div>
   {% endunless %}
   {% endfor %}
   
-  {% for candidate in translation_candidates %}
-  {% unless page.lang == candidate.lang %}
-  <!-- Banner pointing to translations of this lesson when they exist -->
-    {{ site.data.snippets.translation-target[candidate.lang]}}
-    {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
-      href="{{ candidate.url }}">{{ candidate.title }}</a>
-  {% endunless %}
-  {% endfor %}
-</div>
-
 
   {% if page.retired %}
   <div class="alert alert-warning">


### PR DESCRIPTION
This is mainly a layout issue https://github.com/programminghistorian/jekyll/issues/1738 - put all of the various translation links of a lesson into a single banner.

Let's wait before we merged it, as its linked to the second part of https://github.com/programminghistorian/jekyll/issues/1738 : a language accessibility perspective "message in x language; title in x lang." I am also working on it and will make a different PR asap.



