### PR TITLE
Update support-us.md - May 2020

### DIFF
--- a/en/support-us.md
+++ b/en/support-us.md
@@ -17,7 +17,8 @@ The Programming Historian is a volunteer-driven project. We are committed to ope
 
 The project is grateful for the following support:
 
-- Web development is supported by the [dSHARP lab at Carnegie Mellon University](http://dsharp.library.cmu.edu/) and the [Andrew W. Mellon Foundation](https://mellon.org/) [2018-Present]
+- DOI infrastructure is supported by the [University of Sussex Library](https://www.sussex.ac.uk/library/) [2020-Present].
+- Web development is supported by the [dSHARP lab at Carnegie Mellon University](http://dsharp.library.cmu.edu/) and the [Andrew W. Mellon Foundation](https://mellon.org/) [2018-Present].
 - Ongoing hosting support from the Roy Rosenzweig Center for New Media ([RRCHNM](http://chnm.gmu.edu/)) [2011-Present].
 - Funding to support the project "The Programming Historian: developing and sustaining impact in the Global South" provided by the [ESRC Impact Accelerator Account, University of Sussex](http://www.sussex.ac.uk/staff/research/rqi/rqi_information_and_support/rqi_impact_funding/if-esrciaa/) [2019]. 
 - Funding to support the development of a style guide provided by the [School of Humanities, University of Hertfordshire](https://www.herts.ac.uk/study/schools-of-study/humanities) [2019].
@@ -26,7 +27,9 @@ The project is grateful for the following support:
 - Seed funding and project management support from the Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) [2011-2013].
 - Our founding [Patreon](https://www.patreon.com/theprogramminghistorian) subscribers Rachel Murphy ('Subscriber' tier), Miriam Posner ('Sponsor' tier), and Tim Hitchcock ('Patron' tier). We would particularly like to thank the following 'Patron' tier [Patreon](https://www.patreon.com/theprogramminghistorian) subscribers: Tim Hitchcock, Shawn Graham, Jeff Blackadar.
 - Our [Institutional Partner Programme](en/support-us#institutional-partner-programme) members:
-  - [KU Leuven Libraries](https://bib.kuleuven.be/) (2020-)
+  - [KU Leuven Libraries](https://bib.kuleuven.be/) [2020-Present]
+  - [Institute of Historical Research Wohl Library](https://www.history.ac.uk/library) [2020-Present]
+  - [University of Sussex Library](https://www.sussex.ac.uk/library/) [2020-Present]
 
 ## Donate to Us
 

--- a/es/apoyanos.md
+++ b/es/apoyanos.md
@@ -16,6 +16,7 @@ original: support-us
 ## Colaboradores
 El proyecto agradece el siguiente apoyo:
 
+- La infraestructura para la asignación de DOI está apoyada por la [Biblioteca de la Universidad de Sussex](https://www.sussex.ac.uk/library/) [2020-Presente]
 - El desarrollo web está respaldado por el [laboratorio dSHARP en la Universidad Carnegie Mellon](http://dsharp.library.cmu.edu) y la [Fundación Andrew W. Mellon](https://mellon.org) [2018-Presente]
 - Apoyo continuado de alojamiento web del [Centro para la Historia y los Nuevos Medios Roy Rosenzweig](http://chnm.gmu.edu/) [2011-Presente]
 - Financiación para apoyar el proyecto "Programming Historian: desarrollo y mantenimiento del impacto en el Sur Global", proporcionado por el [ESRC Impact Accelerator Account, Universidad de Sussex](http://www.sussex.ac.uk/staff/research/rqi/rqi_information_and_support/rqi_impact_funding/if-esrciaa/) [2019]
@@ -25,7 +26,9 @@ El proyecto agradece el siguiente apoyo:
 - Fondos iniciales y soporte de administración de la Red en Historia y Medio Ambiente de Canadá ([NiCHE](http://niche-canada.org/)) [2011-2013]
 - Nuestros primeros suscriptores de *Patreon* Rachel Murphy (nivel 'Suscriptor'), Miriam Posner (nivel 'Patrocinador') y Tim Hitchcock (nivel 'Mecenas'). En particular, agradecemos la contribución de los siguientes suscriptores de Patreon de nivel 'Mecenas': Tim Hitchcock, Shawn Graham, Jeff Blackadar.
 - Los miembros de nuestro [Programa de Instituciones Asociadas](es/apoyanos#programa-de-instituciones-asociadas):
-  - [Bibliotecas de la Universidad Católica de Lovaina](https://bib.kuleuven.be/) (2020-)
+  - [Bibliotecas de la Universidad Católica de Lovaina](https://bib.kuleuven.be/) (2020-Presente)
+  - [Instituto de Investigación Histórica de la Biblioteca Wohl](https://www.history.ac.uk/library) [2020-Presente]
+  - [Biblioteca de la Universidad de Sussex](https://www.sussex.ac.uk/library/) [2020-Presente]
 
 ## Donaciones
 Los patrocinadores individuales del _Programming Historian en Español_ son vitales para aumentar, mejorar y mantener nuestro trabajo. Aceptamos donativos únicos y recurrentes.  
@@ -43,7 +46,7 @@ Al unirte al Programa de Instituciones Asociadas recibirás los siguientes benef
 - Acceso al detalle de los gastos anuales de ProgHist Ltd.
 - Reconocimiento de tu contribución en nuestra página de Patrocinadores.
 - Derecho a usar la membresía a este programa en las actividades de promoción de tu institución.
-- Necesitas asesoría sobre cómo implementar una publicación de acceso abierto, flujos de trabajo para publicaciones multilingües o sobre cómo adaptar artículos de _Programming Historian_ para la realización de un taller? La membresía te da acceso a asesoría _ad hoc_ de parte de nuestro equipo experto (previa solicitud; no incluye consultoría formal). 
+- Necesitas asesoría sobre cómo implementar una publicación de acceso abierto, flujos de trabajo para publicaciones multilingües o sobre cómo adaptar artículos de _Programming Historian_ para la realización de un taller? La membresía te da acceso a asesoría _ad hoc_ de parte de nuestro equipo experto (previa solicitud; no incluye consultoría formal).
 - Para bibliotecas socias: lista de todos los artículos publicados por las distintas ediciones de The Programming Historian (previa solicitud).
 
 El costo de asociación para 2020 corresponde a £1000 libras esterlinas (aproximadamente $1300 dólares / €1180 euros). Las instituciones de [países elegibles para Ayuda Oficial al Desarrollo (AOD)](https://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/DAC_List_ODA_Recipients2018to2020_flows_En.pdf) pueden asociarse por £150 libras esterlinas (aproximadamente $195 dólares / €175 euros). Estos costos son anuales y su período de vigencia se inicia con la fecha del primer pago. En el mes de enero se publica la actualización de los costos para cada año.

--- a/fr/nous-soutenir.md
+++ b/fr/nous-soutenir.md
@@ -17,13 +17,14 @@ Le Programming Historian est un projet porté par des volontaires. Parce que nou
 
 Le projet est reconnaissant pour leur soutien à:
 
+- La [Bibliothèque de l'université du Sussex](https://www.sussex.ac.uk/library/) pour la réalisation d'une infrastructure d'attribution d'identifiants DOI [2020-actuellement].
 - [dSHARP lab at Carnegie Mellon University](http://dsharp.library.cmu.edu/) et [Andrew W. Mellon Foundation](https://mellon.org/) pour soutenir notre développement web [2018-actuellement].
 - Roy Rosenzweig Center for New Media ([RRCHNM](http://chnm.gmu.edu/)) pour nous offrir des services d'hébergement [2011-actuellement].
 - [ESRC Impact Accelerator Account, Université du Sussex](http://www.sussex.ac.uk/staff/research/rqi/rqi_information_and_support/rqi_impact_funding/if-esrciaa/) pour le soutien du projet "The Programming Historian: developing and sustaining impact in the Global South" [2019]
 - La [faculté de sciences humaines de l'université du Hertfordshire](https://www.herts.ac.uk/study/schools-of-study/humanities) pour avoir financé le développement d'une feuille de style [2019].
 - La [faculté d'histoire, d'histoire de l'art et de philosophie de l'université du Sussex](http://www.sussex.ac.uk/hahp/) pour le financement des efforts du Programming Historian de se doter d'un statut juridique [2019].
-- [British Academy](https://www.britac.ac.uk/) pour le financement d'un atelier d'écriture à Bogota en Colombie [2018].
-- Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) pour le soutien de projet émergent et de gestion de projet [2011-2013].
+- La [British Academy](https://www.britac.ac.uk/) pour le financement d'un atelier d'écriture à Bogota en Colombie [2018].
+- Le Network in Canadian History & Environment ([NiCHE](http://niche-canada.org/)) pour le soutien de projet émergent et de gestion de projet [2011-2013].
 - Nos donateurs fondateurs [Patreon](https://www.patreon.com/theprogramminghistorian) Rachel Murphy (niveau "Abonné"), Miriam Posner (niveau "Parrain/Marraine") et Tim Hitchcock (niveau "Mécène"). Nous souhaitons remercier tout particulièrement les donateurs de niveau "Mécène" suivants: Tim Hitchcock, Shawn Graham, Jeff Blackadar.
 - Les membres de notre [programme de partenariat institutionnel](fr/nous-soutenir#partenariat-institutionnel):
   - Les bibliothèques de la [KU Leuven](https://bib.kuleuven.be/) (2020-)


### PR DESCRIPTION
Edit to support-us.md to represent launch of DOIs and new IPP members. Translation required, specifically:

- Addition of l20 to represent Sussex support on DOIs https://github.com/programminghistorian/jekyll/issues/1684#issuecomment-628223399
	- new text is `DOI infrastructure is supported by the [University of Sussex Library](https://www.sussex.ac.uk/library/) [2020-Present].`
- Addition of l31 and l32 to show names of new IPP members.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
