### PR TITLE
Issue 1767 - Lessons' banners layout 

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -615,9 +615,9 @@ translation-target:
   fr: Cette leçon a été traduite en
   pt:
 available-lesson:
-  en: available in
-  es: 
-  fr: disponible en
+  en: Available in
+  es: Disponible en
+  fr: Disponible en
   pt:
 language-name:
     en: EN

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -614,27 +614,17 @@ translation-target:
   es: Esta lección ha sido traducida al
   fr: Cette leçon a été traduite en
   pt:
-language-name:
-  en:
-    en: English
-    es: inglés
-    fr: anglais
-    pt:
+available-lesson:
+  en: available in
+  es: 
+  fr: disponible en
   pt:
-    en:
-    es:
-    fr:
-    pt:
-  es:
-    en: Spanish
-    es: español
-    fr: espagnol
-    pt:
-  fr:
-    en: French
-    es: francés
-    fr: français
-    pt:
+language-name:
+    en: EN
+    es: ES
+    fr: FR
+    pt: PT
+    
 translation-source:
   en: This lesson was originally published in
   es: Esta lección fue publicada originalmente en

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -619,16 +619,16 @@ available-lesson:
   es: Disponible en
   fr: Disponible en
   pt:
+original:
+  en: original
+  es: original
+  fr: originale
+  pt:
 language-name:
     en: EN
     es: ES
     fr: FR
     pt: PT
-  original:
-  en: original
-  es: original
-  fr: originale
-  pt:
 
 peer-review:
   en: Peer-reviewed

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -609,11 +609,6 @@ title-close-quote:
   es: '",'
   fr: ',»'
   pt:
-translation-target:
-  en: This lesson has been translated into
-  es: Esta lección ha sido traducida al
-  fr: Cette leçon a été traduite en
-  pt:
 available-lesson:
   en: Available in
   es: Disponible en

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -624,11 +624,10 @@ language-name:
     es: ES
     fr: FR
     pt: PT
-    
-translation-source:
-  en: This lesson was originally published in
-  es: Esta lección fue publicada originalmente en
-  fr: Cette leçon a été à l'origine publiée en
+  original:
+  en: original
+  es: original
+  fr: originnale
   pt:
 
 peer-review:

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -627,7 +627,7 @@ language-name:
   original:
   en: original
   es: original
-  fr: originnale
+  fr: originale
   pt:
 
 peer-review:

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -182,15 +182,19 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% if site.lesson_donation_alerts %}
   {% include support-alert.html %}
   {% endif %}
- 
 
-{{ if translation_candidates.size >0 }} 
+{% if translation_candidates.size >0 %} 
+
 <div class="alert alert-warning">
   <!-- Banner pointing to the original and other translations of this lesson when they exist -->
-{{ site.data.snippets.available-lesson[page.lang] }} :  
+{{ site.data.snippets.available-lesson[page.lang] }}:  
+
+      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> ({{ site.data.snippets.original[translation_source.lang]}})  |   
+      
 {% for candidate in translation_candidates %} 
-      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> ({{ site.data.snippets.original[translation_source.lang]}})  |  
-      <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
+
+      <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> {% unless forloop.last %} | {% endunless %}
+
   {% endfor %}
   </div>
  {% endif %}

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -184,16 +184,13 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% endif %}
 
 <div class="alert alert-warning">
- 
   <!-- Banner pointing to the original and other translations of this lesson when they exist -->
 {{ site.data.snippets.available-lesson[page.lang] }} :  
 {% for candidate in translation_candidates %} 
-      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> (original)  |  
+      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> ({{ site.data.snippets.original[translation_source.lang]}})  |  
       <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
-
   {% endfor %}
   </div>
-
 
 
 In order to translate "original" you'll need to use one of the snippets to do that, also.

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -192,9 +192,6 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% endfor %}
   </div>
 
-
-In order to translate "original" you'll need to use one of the snippets to do that, also.
-
   {% if page.retired %}
   <div class="alert alert-warning">
     <h2>{{ site.data.snippets.retired[page.lang] }}</h2>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -183,24 +183,20 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% include support-alert.html %}
   {% endif %}
 
-  {% unless page == translation_source %}
-  <!-- If this lesson is translated, banner pointing to the original language source of this lesson -->
-  <div class="alert alert-warning">
-    {{ site.data.snippets.translation-source[page.lang] }} {{ site.data.snippets.language-name.en[page.lang]}}: <a
-      href="{{ translation_source.url }}">{{ translation_source.title }}</a>
-  </div>
-  {% endunless %}
 
-  {% for candidate in translation_candidates %}
-  {% unless page.lang == candidate.lang %}
-  <!-- Banner pointing to translations of this lesson when they exist -->
-  <div class="alert alert-warning">
-    {{ site.data.snippets.translation-target[page.lang]}}
-    {{ site.data.snippets.language-name[candidate.lang][page.lang]}}: <a
-      href="{{ candidate.url }}">{{ candidate.title }}</a>
+ {% for candidate in translation_candidates %} 
+<div class="alert alert-warning">
+ 
+  <!-- Banner pointing to the original and other translations of this lesson when they exist -->
+{{ site.data.snippets.available-lesson[page.lang] }} :  <a
+      href="{{ translation_source.url }}"> {{ site.data.snippets.language-name.en[page.lang]}} </a> (original)  |  <a
+      href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
+
   </div>
-  {% endunless %}
   {% endfor %}
+
+
+
 
   {% if page.retired %}
   <div class="alert alert-warning">

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -182,7 +182,9 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% if site.lesson_donation_alerts %}
   {% include support-alert.html %}
   {% endif %}
+ 
 
+{{ if translation_candidates.size >0 }} 
 <div class="alert alert-warning">
   <!-- Banner pointing to the original and other translations of this lesson when they exist -->
 {{ site.data.snippets.available-lesson[page.lang] }} :  
@@ -191,6 +193,7 @@ All lesson metadata and alerts should follow the convention of pulling appropria
       <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
   {% endfor %}
   </div>
+ {% endif %}
 
   {% if page.retired %}
   <div class="alert alert-warning">

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -186,7 +186,6 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
  {% for candidate in translation_candidates %} 
 <div class="alert alert-warning">
- 
   <!-- Banner pointing to the original and other translations of this lesson when they exist -->
 {{ site.data.snippets.available-lesson[page.lang] }} :  <a
       href="{{ translation_source.url }}"> {{ site.data.snippets.language-name.en[page.lang]}} </a> (original)  |  <a
@@ -194,8 +193,6 @@ All lesson metadata and alerts should follow the convention of pulling appropria
 
   </div>
   {% endfor %}
-
-
 
 
   {% if page.retired %}

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -183,17 +183,20 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% include support-alert.html %}
   {% endif %}
 
-
- {% for candidate in translation_candidates %} 
 <div class="alert alert-warning">
+ 
   <!-- Banner pointing to the original and other translations of this lesson when they exist -->
-{{ site.data.snippets.available-lesson[page.lang] }} :  <a
-      href="{{ translation_source.url }}"> {{ site.data.snippets.language-name.en[page.lang]}} </a> (original)  |  <a
-      href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
+{{ site.data.snippets.available-lesson[page.lang] }} :  
+{% for candidate in translation_candidates %} 
+      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> (original)  |  
+      <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> 
 
-  </div>
   {% endfor %}
+  </div>
 
+
+
+In order to translate "original" you'll need to use one of the snippets to do that, also.
 
   {% if page.retired %}
   <div class="alert alert-warning">


### PR DESCRIPTION
Group together original-translation banners into a simpler layout -- following / closing https://github.com/programminghistorian/jekyll/issues/1767 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
