### PR TITLE
add PT "retired lessons" scope and directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,11 @@ defaults:
       lesson: false
       retired: true
   - scope:
+      path: "pt/licoes/retirado"
+    values:
+      lesson: false
+      retired: true
+  - scope:
       path: "es/lecciones"
     values:
       lesson: true


### PR DESCRIPTION
This adds a scope in the _config.yml to handle (in the far future) retired Portuguese lessons.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  ~- [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
~- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above~

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
