### PR TITLE
restore language name snippet

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -359,7 +359,7 @@ loading-search:
   pt:
 search-lessons:
   en: SEARCH LESSONS
-  es: BUSCAR LECCIONES 
+  es: BUSCAR LECCIONES
   fr: RECHERCHER LES LEÇONS
   pt:
 start-searching:
@@ -373,19 +373,19 @@ type-search-terms:
   fr: ENTRER UN OU PLUSIEURS TERMES DE RECHERCHE...
   pt:
 search-info:
-  en: | 
+  en: |
     To search for relevant terms, enter them into the search bar and either press the enter key or the search button. All searches are case insensitive. If multiple terms are entered, results will include lessons that have all terms, as well as lessons that contain *either term*. Results with more of the terms will be scored higher in the list.
-    
+
     To only return results with multiple terms, add the `+` symbol before the term. For example, `+Twitter +Network` will return lessons that contain *both* "twitter" and "network". To only return results that *do not* contain a term use the `-` symbol. For example, `-Twitter +Network` will return lessons that contain "network" but not "twitter". For more detailed information, visit this guide on searching: <https://lunrjs.com/guides/searching.html>
-  es: | 
-    Para buscar términos relevantes, escríbelos en la barra de búsqueda y aprieta la tecla "enter" o haz clic en el botón "buscar lecciones". Las búsquedas no distinguen mayúsculas y minúsculas. Si se ingresan múltiples términos, los resultados incluirán tanto lecciones que los contengan todos, como lecciones que contengan *solo alguno*. Los resultados que incluyan más de un término aparecerán primero en la lista. 
+  es: |
+    Para buscar términos relevantes, escríbelos en la barra de búsqueda y aprieta la tecla "enter" o haz clic en el botón "buscar lecciones". Las búsquedas no distinguen mayúsculas y minúsculas. Si se ingresan múltiples términos, los resultados incluirán tanto lecciones que los contengan todos, como lecciones que contengan *solo alguno*. Los resultados que incluyan más de un término aparecerán primero en la lista.
 
     Para obtener solo resultados con múltiples términos, agrega el símbolo `+` antes de cada uno. Por ejemplo, `+Twitter +Red` devolverá lecciones que contienen *tanto* "twitter" como "red". Para obtener solo resultados que *no* contengan cierto término, utiliza el símbolo `-`. Por ejemplo, `-Twitter +Red` devolverá lecciones que contienen "red" pero no "twitter". Para información más detallada, puedes revisar la guía sobre búsquedas (en inglés): <https://lunrjs.com/guides/searching.html>
   fr: |
     Pour obtenir des résultats en utilisant plusieurs termes de recherche, faites précéder chaque terme du symbole `+`. Par exemple, en insérant `+Twitter +réseau`, vous obtiendrez les tutoriels qui contiennent tous les deux termes. Pour *exclure* un terme des résultats obtenus, vous pouvez utiliser le symbole `-`. Par exemple, en insérant `-Twitter +réseau`, vous obtiendrez les tutoriels qui contiennent le terme "réseau", mais pas "Twitter". Pour en savoir plus sur les modalités de recherche, merci de consulter ce guide <https://lunrjs.com/guides/searching.html>
 
   pt: |
-    
+
 
 # lesson headers
 editor:
@@ -614,12 +614,33 @@ available-lesson:
   es: Disponible en
   fr: Disponible en
   pt:
+language-name:
+  en:
+    en: English
+    es: inglés
+    fr: anglais
+    pt:
+  pt:
+    en:
+    es:
+    fr:
+    pt:
+  es:
+    en: Spanish
+    es: español
+    fr: espagnol
+    pt:
+  fr:
+    en: French
+    es: francés
+    fr: français
+    pt:
 original:
   en: original
   es: original
   fr: originale
   pt:
-language-name:
+language-name-abbreviation:
     en: EN
     es: ES
     fr: FR

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -183,21 +183,23 @@ All lesson metadata and alerts should follow the convention of pulling appropria
   {% include support-alert.html %}
   {% endif %}
 
-{% if translation_candidates.size >0 %} 
+  {% if translation_candidates.size >0 %}
 
-<div class="alert alert-warning">
-  <!-- Banner pointing to the original and other translations of this lesson when they exist -->
-{{ site.data.snippets.available-lesson[page.lang] }}:  
+  <div class="alert alert-warning">
+    <!-- Banner pointing to the original and other translations of this lesson when they exist -->
+    {{ site.data.snippets.available-lesson[page.lang] }}:
 
-      <a  href="{{ translation_source.url }}"> {{ site.data.snippets.language-name[translation_source.lang]}} </a> ({{ site.data.snippets.original[translation_source.lang]}})  |   
-      
-{% for candidate in translation_candidates %} 
+    <a href="{{ translation_source.url }}"> {{ site.data.snippets.language-name-abbreviation[translation_source.lang]}}
+    </a> ({{ site.data.snippets.original[translation_source.lang]}}) |
 
-      <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name[candidate.lang]}} </a> {% unless forloop.last %} | {% endunless %}
+    {% for candidate in translation_candidates %}
 
-  {% endfor %}
+    <a href="{{ candidate.url }}"> {{ site.data.snippets.language-name-abbreviation[candidate.lang]}} </a>
+    {% unless forloop.last %} | {% endunless %}
+
+    {% endfor %}
   </div>
- {% endif %}
+  {% endif %}
 
   {% if page.retired %}
   <div class="alert alert-warning">

--- a/en/lessons/preserving-your-research-data.md
+++ b/en/lessons/preserving-your-research-data.md
@@ -447,4 +447,4 @@ UK Data Archive, 'Documenting your Data'
   [platform agnostic]: http://en.wikipedia.org/wiki/Cross-platform
   [Markdown]: http://en.wikipedia.org/wiki/Markdown
   [Komodo Edit]: http://komodoide.com/komodo-edit/
-  [Text Wrangler]: https://itunes.apple.com/gb/app/id404010395?mt=12
+  [Text Wrangler]: https://www.barebones.com/products/textwrangler/

--- a/es/lecciones/preservar-datos-de-investigacion.md
+++ b/es/lecciones/preservar-datos-de-investigacion.md
@@ -268,4 +268,4 @@ UK Data Archive, 'Documenting your Data'
 [PRINCE2]: https://es.wikipedia.org/wiki/PRINCE2
 [independientes de plataforma]: https://es.wikipedia.org/wiki/Multiplataforma#Programaci.C3.B3n_multiplataforma
 [Komodo Edit]: http://komodoide.com/komodo-edit/
-[Text Wrangler]: https://itunes.apple.com/gb/app/id404010395?mt=12
+[Text Wrangler]: https://www.barebones.com/products/textwrangler/


### PR DESCRIPTION
closes #1807

Restores the `language-name` snippet that we incorrectly removed during #1798

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  ~- [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
