### PR TITLE
Update sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md

### DIFF
--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -604,7 +604,7 @@ file, under the same directory as your `main.md`. Let's see if this
 works. Save your file, switch to the terminal window and run:
 
 ```
-$ pandoc main.docx --filter pandoc-citeproc -o main.md
+$ pandoc main.docx --filter pandoc-citeproc -o main.docx
 ```
 
 The "pandoc-citeproc" filter will parse any citation tags found in your document. The result
@@ -725,32 +725,16 @@ with academic journal design based on GitHub and
 [readthedocs.org](http://readthedocs.org) (tools usually used for technical
 documentation).
 
-[^1]:  Don't worry if you don't understand some of of this terminology yet!
+[^1]: Don't worry if you don't understand some of of this terminology yet!
 
-[^2]:  The source files for this document can be [downloaded from
-GitHub](https://github.com/dhcolumbia/pandoc-workflow). Use the "raw" option when viewing in
-GitHub to see the source Markdown. The authors would like to thank Alex Gil and his colleagues
-from Columbia's Digital Humanities Center, and the participants of openLab at the Studio in the
-Butler library for testing the code in this tutorial on a variety of platforms.
+[^2]: The source files for this document can be [downloaded from GitHub](https://github.com/dhcolumbia/pandoc-workflow). Use the "raw" option when viewing in GitHub to see the source Markdown. The authors would like to thank Alex Gil and his colleagues from Columbia's Digital Humanities Center, and the participants of openLab at the Studio in the Butler library for testing the code in this tutorial on a variety of platforms.
 
-[^3]:  See Charlie Stross's excellent discussion of this topic in [Why Microsoft Word Must
-Die](http://www.antipope.org/charlie/blog-static/2013/10/why-microsoft-word-must-die.html).
+[^3]: See Charlie Stross's excellent discussion of this topic in [Why Microsoft Word Must Die](http://www.antipope.org/charlie/blog-static/2013/10/why-microsoft-word-must-die.html).
 
-[^4]:  Note that the .bib extension may be "registered" to Zotero in your operating system.
-That means when you click on a .bib file it is likely that Zotero will be called to open it,
-whereas we want to open it within a text editor. Eventually, you may want to associate the .bib
-extension with your text editor.
+[^4]: Note that the .bib extension may be "registered" to Zotero in your operating system. That means when you click on a .bib file it is likely that Zotero will be called to open it, whereas we want to open it within a text editor. Eventually, you may want to associate the .bib extension with your text editor.
 
-[^5]:  There are no good solutions for directly arriving at MS Word from LaTeX.
+[^5]: There are no good solutions for directly arriving at MS Word from LaTeX.
 
-[^6]:  It is a good idea to get into the habit of not using spaces in folder or file names.
-Dashes or underscores instead of spaces in your filenames ensure lasting cross-platform
-compatibility.
+[^6]: It is a good idea to get into the habit of not using spaces in folder or file names. Dashes or underscores instead of spaces in your filenames ensure lasting cross-platform compatibility.
 
-[^7]:  Thanks to [@njbart](https://github.com/njbart) for the correction. In response to our
-original suggestion, `Some sentence that needs citation.^[@fyfe_digital_2011 argues that too.]`
-[he writes](https://github.com/programminghistorian/jekyll/issues/46#issuecomment-59219906):
-"This is not recommended since it keeps you from switching easily between footnote and
-author-date styles. Better use the \[corrected\] (no circumflex, no final period inside the
-square braces, and the final punctuation of the text sentence after the square braces; with
-footnote styles, pandoc automatically adjusts the position of the final punctuation)."
+[^7]: Thanks to [@njbart](https://github.com/njbart) for the correction. In response to our original suggestion, `Some sentence that needs citation.^[@fyfe_digital_2011 argues that too.]` [he writes](https://github.com/programminghistorian/jekyll/issues/46#issuecomment-59219906): "This is not recommended since it keeps you from switching easily between footnote and author-date styles. Better use the \[corrected\] (no circumflex, no final period inside the square braces, and the final punctuation of the text sentence after the square braces; with footnote styles, pandoc automatically adjusts the position of the final punctuation)."

--- a/es/lecciones/escritura-sostenible-usando-pandoc-y-markdown.md
+++ b/es/lecciones/escritura-sostenible-usando-pandoc-y-markdown.md
@@ -305,7 +305,7 @@ bibliography: proyecto.bib
 Esto le dice a Pandoc que busque tu bibliografía en el archivo `proyecto.bib` dentro del mismo directorio de tu archivo `principal.md`. Veamos si esto trabaja. Guarda tu archivo, ve a la ventana de terminal y ejecuta:
 
 ```
-$ pandoc principal.docx --filter pandoc-citeproc -o principal.md
+$ pandoc principal.docx --filter pandoc-citeproc -o principal.docx
 ```
 
 El filtro "pandoc-citeproc" compila todas tus etiquetas de citas. El resultado debe ser un archivo de MS Word formateado decentemente. Si tienes instalado LaTeX, conviértelo a .pdf utilizando la misma sintaxis para mejores resultados. No te preocupes si las cosas no aparecen exactamente de la manera que tú quisieras -recuerda que vas a afinar el formato de todo una vez y más tarde, lo más cerca posible del momento de la publicación. Por ahora solamente estamos creando borradores basados en valores por defecto.


### PR DESCRIPTION
Removed line breaks causing footnote errors, fixed small error in code. Closes #1833 

I've also updated the Spanish lesson to fix the small error in code that the authors alerted me to.


### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
