### PR TITLE
Add project page block for PT team

### DIFF
--- a/_includes/project-team-loop.html
+++ b/_includes/project-team-loop.html
@@ -27,7 +27,7 @@ is used both on project-team.md as well as es/equipo-de-proyecto.md
 {% include contact-info.html name=member.name %}
 {% endfor %}
 
-### Programming Historian en portugu&ecirc;s
+### Programming Historian em portugu&ecirc;s
 {% assign portuguesemembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'portuguese'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in portuguesemembers %}
 {% include contact-info.html name=member.name %}

--- a/_includes/project-team-loop.html
+++ b/_includes/project-team-loop.html
@@ -27,6 +27,12 @@ is used both on project-team.md as well as es/equipo-de-proyecto.md
 {% include contact-info.html name=member.name %}
 {% endfor %}
 
+### Programming Historian en portugu&ecirc;s
+{% assign portuguesemembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'portuguese'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
+{% for member in portuguesemembers %}
+{% include contact-info.html name=member.name %}
+{% endfor %}
+
 ### ProgHist Ltd
 {% assign proghistmembers = site.data.ph_authors | where_exp: "member", "member.team_roles contains 'proghist'" | where_exp: "member", "member.team == true" | sort: "sortname" %}
 {% for member in proghistmembers %}

--- a/en/lessons/working-with-batches-of-pdf-files.md
+++ b/en/lessons/working-with-batches-of-pdf-files.md
@@ -158,7 +158,7 @@ Always make a backup copy of your data before using the commands in this course.
 
 # Assessing Your PDF(s)
 
-In order to make this lesson as realistic as possible, you will be guided by a concrete historical case study. The study draws on the extensive collection of the [International Labour Organization (ILO)](http://web.archive.org/web/20200513194548/https://ilostat.ilo.org/resources/methods/icls/icls-documents//), in particular the sources of the First International Conference of Labour Statisticians.
+In order to make this lesson as realistic as possible, you will be guided by a concrete historical case study. The study draws on the extensive collection of the [International Labour Organization (ILO)](http://web.archive.org/web/20200606003222/https://ilostat.ilo.org/resources/methods/icls/icls-documents/), in particular the sources of the First International Conference of Labour Statisticians.
 
 You are interested in what topics were discussed by the labour statisticians. For this purpose you will want to analyze all available documents of this conference using Topic Modelling. This assumes that all documents are available in plain text.
 


### PR DESCRIPTION
Attempt to add the Portuguese team to the Project Team page. As per #1802 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
