### PR TITLE
Issue 1876 - add bug warning to XML/XSL lesson

### DIFF
--- a/en/lessons/transforming-xml-with-xsl.md
+++ b/en/lessons/transforming-xml-with-xsl.md
@@ -19,13 +19,13 @@ avatar_alt: A peacock with a woman's head
 doi: 10.46430/phen0059
 ---
 
-{% include toc.html %}
-
-
-
-<div class="alert alert-warning text-center">
+<div class="alert alert-warning">
 A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	 18 August 2020.
 </div>
+
+
+{% include toc.html %}
+
 
 ## Introduction
 

--- a/en/lessons/transforming-xml-with-xsl.md
+++ b/en/lessons/transforming-xml-with-xsl.md
@@ -23,7 +23,9 @@ doi: 10.46430/phen0059
 
 
 
-
+<div class="alert alert-warning text-center">
+A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	
+</div>
 
 ## Introduction
 

--- a/en/lessons/transforming-xml-with-xsl.md
+++ b/en/lessons/transforming-xml-with-xsl.md
@@ -24,7 +24,7 @@ doi: 10.46430/phen0059
 
 
 <div class="alert alert-warning text-center">
-A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	
+A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	 18 August 2020.
 </div>
 
 ## Introduction

--- a/es/lecciones/transformacion-datos-xml-xsl.md
+++ b/es/lecciones/transformacion-datos-xml-xsl.md
@@ -32,7 +32,9 @@ doi: 10.46430/phes0041
 
 {% include toc.html %}
 
-
+<div class="alert alert-warning text-center">
+A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	 18 August 2020.
+</div>
 
 
 ## Introducción

--- a/es/lecciones/transformacion-datos-xml-xsl.md
+++ b/es/lecciones/transformacion-datos-xml-xsl.md
@@ -31,7 +31,7 @@ doi: 10.46430/phes0041
 ---
 
 <div class="alert alert-warning">
-A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	 18 August 2020.
+Se ha reportado un problema con las instrucciones de esta lección. Se advierte a los lectores que, en su estado actual, no es posible completarla debido a cambios en la tecnología utilizada que están más allá del control de su autor. Actualmente estamos investigando formas de solucionar este problema, por lo que agradecemos tu paciencia. 18 de agosto de 2020. 
 </div>
 
 {% include toc.html %}

--- a/es/lecciones/transformacion-datos-xml-xsl.md
+++ b/es/lecciones/transformacion-datos-xml-xsl.md
@@ -30,12 +30,11 @@ avatar_alt: Dibujo de un pavo real con sus plumas extendidas.
 doi: 10.46430/phes0041
 ---
 
-{% include toc.html %}
-
-<div class="alert alert-warning text-center">
+<div class="alert alert-warning">
 A problem with the instructions in this lesson has been reported. Readers are advised that they will not be able to complete the lesson in its current form due to changes in technology beyond the control of the author. We are investigating solutions and appreciate your patience.	 18 August 2020.
 </div>
 
+{% include toc.html %}
 
 ## Introducción
 


### PR DESCRIPTION
As per #1876 the XSL transformations lesson currently cannot be completed. To ensure readers know this, I've added a warning message to the top of both the English and Spanish version of the lesson. This warning is in English.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
