### PR TITLE
Update link for No. 14 Canadian General Hospital, Resolves #1923

### DIFF
--- a/en/lessons/applied-archival-downloading-with-wget.md
+++ b/en/lessons/applied-archival-downloading-with-wget.md
@@ -387,7 +387,7 @@ examples of Wget's power and potential.
   [curl]: http://chronicle.com/blogs/profhacker/download-a-sequential-range-of-urls-with-curl/41055
   [Indian Affairs Annual Reports database]: http://www.collectionscanada.gc.ca/databases/indianaffairs/index-e.html
   [View a scanned page of original Report]: http://www.collectionscanada.gc.ca/databases/indianaffairs/001074-119.02-e.php?page_id_nbr=1
-  [No. 14 Canadian General Hospital]: http://collectionscanada.gc.ca/pam_archives/index.php?fuseaction=genitem.displayItem&lang=eng&rec_nbr=2005110&rec_nbr_list=3366167,3203123,2005097,2005100,2005101,2005099,2005096,2005110,2005108,2005106
+  [No. 14 Canadian General Hospital]: https://www.bac-lac.gc.ca/eng/CollectionSearch/Pages/record.aspx?app=fonandcol&IdNumber=2005110&new=-8585971893141232328
   [http://data2.archives.ca/e/e061/e001518109.jpg]: http://data2.archives.ca/e/e061/e001518029.jpg
   [leading zeros]: http://en.wikipedia.org/wiki/Leading_zero
   [On the viewer page]: http://www.nla.gov.au/apps/cdview/?pi=nla.ms-ms5393-1


### PR DESCRIPTION
@spapastamkou flagged in #1923 that the earlier Library and Archives Canada link to the No. 14 Canadian General Hospital had been broken. This is a result of the search engine updating. 

Rather than tracking down Kellen who is I believe outside of academia now, this should be a straightforward link update. It actually makes the lesson a bit easier as file numbers are now also listed in the collection page.