### PR TITLE
Palladio link fix

### DIFF
--- a/_posts/2016-07-05-spanish-editor.md
+++ b/_posts/2016-07-05-spanish-editor.md
@@ -15,7 +15,7 @@ Adam Crymble (University of Hertfordshire) will offer support on the practices o
 
 Launched in 2012, The Programming Historian offers more than 45 novice-friendly, peer-reviewed tutorials that help humanists learn a wide range of digital tools, techniques, and workflows to facilitate their research. The Programming Historian is a volunteer-led initiative, controlled entirely by the ‘Editorial Board of the Programming Historian’ with the help of community contributors. It is not a legal entity, and does not currently receive direct funding from any source. Read our reviews:
 
-* Lincoln Mullen, '[Review of the Programming Historian](http://jah.oxfordjournals.org/content/103/1/299.2.full)', The Journal of American History, vol. 103, no. 1 (2016), pp. 299-301.
+* Lincoln Mullen, '[Review of the Programming Historian](https://academic.oup.com/jah/article/103/1/299/1751315)', The Journal of American History, vol. 103, no. 1 (2016), pp. 299-301.
 * Cameron Blevins, '[Review of the Programming Historian](http://jitp.commons.gc.cuny.edu/review-of-the-programming-historian/)', The Journal of Interactive Technology & Pedagogy, vol. 8 (2015)
 
 Interested candidates should submit a 1-page expression of interest outlining your interests, experience, and vision for the role, to Adam Crymble (adam.crymble@gmail.com) by 31 July 2016. Please direct any questions to Adam in the first instance.

--- a/en/lessons/creating-network-diagrams-from-historical-sources.md
+++ b/en/lessons/creating-network-diagrams-from-historical-sources.md
@@ -29,7 +29,7 @@ doi: 10.46430/phen0044
 Introduction
 ------------
 
-Network visualizations can help humanities scholars reveal hidden and complex patterns and structures in textual sources. This tutorial explains how to extract network data (people, institutions, places, etc) from historical sources through the use of non-technical methods developed in Qualitative Data Analysis (QDA) and Social Network Analysis (SNA), and how to visualize this data with the platform-independent and particularly easy-to-use [*Palladio*](http://palladio.designhumanities.org/#/).
+Network visualizations can help humanities scholars reveal hidden and complex patterns and structures in textual sources. This tutorial explains how to extract network data (people, institutions, places, etc) from historical sources through the use of non-technical methods developed in Qualitative Data Analysis (QDA) and Social Network Analysis (SNA), and how to visualize this data with the platform-independent and particularly easy-to-use [*Palladio*](http://hdlab.stanford.edu/palladio/).
 
 
 {% include figure.html caption="Figure 1: A network visualization in Palladio and what you will be able to create by the end of this tutorial." filename="image09.png" %}
@@ -135,7 +135,7 @@ The following steps will explain how to visualize network data in Palladio but I
 
 Step by Step:
 
-**1. Palladio.** Go to [*http://palladio.designhumanities.org/*](http://palladio.designhumanities.org/)*.*
+**1. Palladio.** Go to [*http://hdlab.stanford.edu/palladio/*](http://hdlab.stanford.edu/palladio/)*.*
 
 **2. Start.** On their website click the “Start” button.
 

--- a/es/lecciones/creando-diagramas-de-redes-desde-fuentes-historicas.md
+++ b/es/lecciones/creando-diagramas-de-redes-desde-fuentes-historicas.md
@@ -37,7 +37,7 @@ doi: 10.46430/phes0002
 Introducción
 ------------
 
-La visualizaciones de redes pueden ayudar a los humanistas a revelar patrones complejos escondidos y estructuras en fuentes textuales. Este tutorial explica cómo extraer datos en red (personas, instituciones, lugares, etcétera.) de fuentes históricas a través del uso de métodos no especializados desarrollados en el marco del análisis de datos qualitativos (Qualitative Data Analysis, QDA) y el análisis de redes sociales (Social Network Analysis, SNA), y cómo visualizar estos datos con [*Palladio*](http://palladio.designhumanities.org/#/), una aplicación independiente de plataforma y que es particularmente fácil de usar.
+La visualizaciones de redes pueden ayudar a los humanistas a revelar patrones complejos escondidos y estructuras en fuentes textuales. Este tutorial explica cómo extraer datos en red (personas, instituciones, lugares, etcétera.) de fuentes históricas a través del uso de métodos no especializados desarrollados en el marco del análisis de datos qualitativos (Qualitative Data Analysis, QDA) y el análisis de redes sociales (Social Network Analysis, SNA), y cómo visualizar estos datos con [*Palladio*](http://hdlab.stanford.edu/palladio/), una aplicación independiente de plataforma y que es particularmente fácil de usar.
 
 {% include figure.html caption="Figura 1: Una visualización de redes en Palladio y lo que vas a poder crear al final de este tutorial." filename="diagramas-de-redes-01.png" %}
 
@@ -143,7 +143,7 @@ Los siguientes pasos explican cómo visualizar datos en red en Palladio, pero ta
 
 Paso a paso:
 
-**1. Palladio.** Entra a [*http://palladio.designhumanities.org/*](http://palladio.designhumanities.org/)*.*
+**1. Palladio.** Entra a [*http://hdlab.stanford.edu/palladio/*](http://hdlab.stanford.edu/palladio/)*.*
 
 **2. Comienza.** En el sitio web haz clic en el botón "Start".
 


### PR DESCRIPTION
The Palladio tool used in the lesson: (https://programminghistorian.org/en/lessons/creating-network-diagrams-from-historical-sources#visualize-network-data-in-palladio) has apparently been moved from:

http://palladio.designhumanities.org/ to http://hdlab.stanford.edu/palladio/.

I have updated the links in both the English and Spanish lessons. I just tested the whole lesson and while some of the screenshots are *slightly* out of date now, the lesson is otherwise fine.

This is a minor fix and does not require a new DOI.


### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [ ] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
