### PR TITLE
Typo fixed in line 25

### DIFF
--- a/es/retroalimentacion.md
+++ b/es/retroalimentacion.md
@@ -22,11 +22,11 @@ Gracias por tomarte el tiempo de advertirnos de un problema o de sugerir un camb
 
 Contacta a <a href="mailto:vgayol@colmich.edu.mx">Víctor Gayol</a>, <a href="mailto:mariajose@neogranadina.org">Maria José Afanador-Llach</a> o a <a href="mailto:rojas.castro.antonio@gmail.com">Antonio Rojas Castro</a>. Puedes encontrar más sobre el equipo editorial en [Equipo de proyecto](./equipo-de-proyecto.html).
 
-También nos puedes encontar en Twitter en [@ProgHist](https://twitter.com/proghist).
+También nos puedes encontrar en Twitter en [@ProgHist](https://twitter.com/proghist).
 
 ## Opción 2: inicia un "Issue" en GitHub
 
-Primero, si no tienes una ya,[abre una cuenta personal gratis en GitHub](https://help.github.com/articles/signing-up-for-a-new-github-account). Si ya tienes una cuenta inicia sesión.
+Primero, si no tienes una ya, [abre una cuenta personal gratis en GitHub](https://help.github.com/articles/signing-up-for-a-new-github-account). Si ya tienes una cuenta inicia sesión.
 
 Después ve a la [página de "issues"](https://github.com/programminghistorian/jekyll/issues?state=open) de nuestro Repositorio.
 
@@ -50,7 +50,7 @@ Ahora pulsa en el más reciente "commit" para la lección:
 
 ![](https://cloud.githubusercontent.com/assets/1126864/4781629/901b4330-5cb2-11e4-9bc9-d211daa5e987.png)
 
-Después, para comentar en una línea, coloca el cursor sobre el número de una línea y un signo azul de suma (+) aparecerá; pulsando en este va a abrir una caja de comentarios para esa línea en particular. La línea que necesita arreglarse se puede ocultar; si es así, pulsa en el botón de expandir para mostrar las líneas ocultas.
+Después, para comentar en una línea, coloca el cursor sobre el número de una línea y un signo azul de suma (+) aparecerá; pulsando en éste va a abrir una caja de comentarios para esa línea en particular. La línea que necesita arreglarse se puede ocultar; si es así, pulsa en el botón de expandir para mostrar las líneas ocultas.
 
 ![](https://cloud.githubusercontent.com/assets/1126864/4781633/27b780b4-5cb3-11e4-81aa-0ed217b94a2f.png)
 

--- a/es/retroalimentacion.md
+++ b/es/retroalimentacion.md
@@ -50,7 +50,7 @@ Ahora pulsa en el más reciente "commit" para la lección:
 
 ![](https://cloud.githubusercontent.com/assets/1126864/4781629/901b4330-5cb2-11e4-9bc9-d211daa5e987.png)
 
-Después, para comentar en una línea, coloca el cursor sobre el número de una línea y un signo azul de suma (+) aparecerá; pulsando en éste va a abrir una caja de comentarios para esa línea en particular. La línea que necesita arreglarse se puede ocultar; si es así, pulsa en el botón de expandir para mostrar las líneas ocultas.
+Después, para comentar en una línea, coloca el cursor sobre el número de una línea y un signo azul de suma (+) aparecerá; pulsando en este va a abrir una caja de comentarios para esa línea en particular. La línea que necesita arreglarse se puede ocultar; si es así, pulsa en el botón de expandir para mostrar las líneas ocultas.
 
 ![](https://cloud.githubusercontent.com/assets/1126864/4781633/27b780b4-5cb3-11e4-81aa-0ed217b94a2f.png)
 


### PR DESCRIPTION
Typo fixed in line 25

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
