### PR TITLE
Tweak translation concordance to avoid files with no titles

### DIFF
--- a/translation-concordance.md
+++ b/translation-concordance.md
@@ -26,7 +26,7 @@ An automatically-generated list of page translation relationships across our pub
 {% endfor %}
 </table>
 
-{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" | where_exp: "item", "item.layout != 'post'" | where_exp: "item", "item.skip_concordance != true" %}
+{% assign original_pages = site.pages | where_exp: "item", "item.name != 'redirect.html'" | where_exp: "item", "item.name != 'redirects.json'" | where_exp: "item", "item.name != 'index.md'" | where_exp: "item", "item.original == nil" | where_exp: "item", "item.layout != 'lesson'" | where_exp: "item", "item.layout != 'post'" | where_exp: "item", "item.skip_concordance != true" | where_exp: "item", "item.title != nil"%}
 
 ## Other pages
 


### PR DESCRIPTION
Closes #1972 

The translation concordance page had a bunch of blank rows in its "other pages" table. These were being caused by a series of assets and image files that were making it into the logic of the loop. I added a little logic to the loop for it to avoid pages that have no titles. @jenniferisasi, can you take a look and make sure that this didn't break what you had there before? It's a little brute force, but I think it does what we need. 