### PR TITLE
Refactor feed to automatically add new languages

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -28,24 +28,19 @@ skip_concordance: true
 		</item>
 		{% endfor %}
 
-				{% assign pages = site.pages | where:'layout','lesson'| where: 'lang', 'en' | sort:'date' | reverse %}
+{% for lang in site.data.snippets.language-list %}
+				{% assign pages = site.pages | where:'layout','lesson'| where: 'lang', lang | sort:'date' | reverse %}
 				{% for page in pages limit:10 %}
 						{% include feed-item.html %}
 				{% endfor %}
+{% endfor %}
 
-				{% assign pages = site.pages | where:'layout','lesson'|  where:'lang','es' | sort:'translation_date' | reverse %}
+{% for lang in site.data.snippets.language-list %}
+				{% assign pages = site.pages | where:'layout','lesson'|  where:'lang',lang | sort:'translation_date' | reverse %}
 				{% for page in pages limit:10 %}
 						{% include feed-item.html %}
 				{% endfor %}
+{% endfor %}
 
-				{% assign pages = site.pages | where:'layout','lesson'|  where:'lang','fr' | sort:'translation_date' | reverse %}
-				{% for page in pages limit:10 %}
-						{% include feed-item.html %}
-				{% endfor %}
-
-				{% assign pages = site.pages | where:'layout','lesson'|  where:'lang','pt' | sort:'translation_date' | reverse %}
-				{% for page in pages limit:10 %}
-						{% include feed-item.html %}
-				{% endfor %}
 	</channel>
 </rss>


### PR DESCRIPTION
Closes #2001. Refactors feed.xml to automatically add new languages and also does a little bit to de-center English in our feed. Now it will check all languages for both original lessons and translations. 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the Travis CI checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
