### PR TITLE
updated pull request template to remove references to travis

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@
 - [ ] Assign at least one individual or team to "Reviewers"
   - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
 - [ ] Add the appropriate "Label"
-- [ ] [Ensure the Github Actions checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
+- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
 - [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
 - [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above
 
-*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
+*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*


### PR DESCRIPTION
### Checklist

- [ ] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the Github Actions checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing Travis errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Travis Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-travis-errors). Then contact the technical team if you need further help.*
