### PR TITLE
PT support us menu updates

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -258,7 +258,9 @@ menu-support-ipp:
   fr:
     title: Partenariat institutionnel
     link: /fr/pi
-  pt: 
+  pt:
+    title: Programa de Parceiros Institucionais
+    link: /pt/apoie-nos#programa-de-parceiros-institucionais
 menu-support-individual:
   en:
     title: Individual Supporters
@@ -270,6 +272,8 @@ menu-support-individual:
     title: Dons individuels
     link: /fr/dons
   pt: 
+    title: Doações
+    link: /pt/apoie-nos#doações
 menu-support-supporters:
   en:
     title: Our Supporters


### PR DESCRIPTION
Should fix the missing links to the various support-us sections on the PT menu.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
