### PR TITLE
Fixes blockquote margins and contrast in nightmode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,7 @@ Color Styles
   --a-hover-active-color: #555;
   --header-lesson-color: #f5f5f5;
   --header-helpers-color: #ccc;
+  --blockquote-color: #eeeeee;
 }
 
 [data-theme="night"] {
@@ -33,6 +34,7 @@ Color Styles
   --a-hover-active-color: #9A97F3;
   --header-lesson-color: #171f24;
   --header-helpers-color: #444444;
+  --blockquote-color: #535353;
 }
 
 @media screen {
@@ -683,7 +685,17 @@ Lesson Typography
 
   b, strong { font-weight: bold; }
 
-  blockquote { margin: 1em 2em; padding: 0 1em 0 1em; font-style: italic; border:1px solid #666; background: #eeeeee;}
+  blockquote { 
+    margin: 1em 2em; 
+    padding: 0 1em 0 1em; 
+    font-style: italic; 
+    border:1px solid #666; 
+    background: var(--blockquote-color);
+  }
+  
+  blockquote p{
+    margin-top: 1rem;
+  }
 
   hr {
     display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 2em 0; padding: 0; }


### PR DESCRIPTION
closes #2094 

Corrects the contrast in blockquotes for nightmode...…and also fixes the top margins for paragraphs in blockquotes because that's been bugging me forever and I couldn't help myself..

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
