### PR TITLE
Add alt attributes

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -758,3 +758,9 @@ managing_editor:
   es: Riva Quiroga
   fr: Sofia Papastamkou
   pt: Daniel Alves
+
+front-image-alt:
+  en: Image from Scientific American of a woman at an Electrical Counting Machine.
+  es: 
+  fr: 
+  pt: 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -761,6 +761,6 @@ managing_editor:
 
 front-image-alt:
   en: Image from Scientific American of a woman at an Electrical Counting Machine.
-  es: 
+  es: Imagen de Scientific American que muestra a una mujer trabajando en una máquina contadora eléctrica.
   fr: 
-  pt: 
+  pt: Imagem da Scientific American de uma mulher a usar uma máquina de contagem elétrica

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -762,5 +762,5 @@ managing_editor:
 front-image-alt:
   en: Image from Scientific American of a woman at an Electrical Counting Machine.
   es: Imagen de Scientific American que muestra a una mujer trabajando en una máquina contadora eléctrica.
-  fr: 
-  pt: Imagem da Scientific American de uma mulher a usar uma máquina de contagem elétrica
+  fr: Image de Scientific American montrant une femme utilisant une compteuse de billets.
+  pt: Imagem da Scientific American de uma mulher a usar uma máquina de contagem elétrica.

--- a/_includes/contact-info.html
+++ b/_includes/contact-info.html
@@ -15,7 +15,7 @@
 {% endcomment %}
 {% assign avatar = member.name | slugify: "latin" %}
 <div class="col-3">
-  <img class="rounded-circle" src="{{site.baseurl}}/avatars/{{avatar}}.png">
+  <img class="rounded-circle" src="{{site.baseurl}}/avatars/{{avatar}}.png" alt="{{ member.name }}">
 </div>
 
 <div class="col-9">

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -16,7 +16,7 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   {% endif %}
 
   <div class="lesson-image">
-    <a href="{{ lesson.url }}"><img class="rounded" src="/gallery/{{ canonical_slug }}.png"></a>
+    <a href="{{ lesson.url }}"><img class="rounded" src="/gallery/{{ canonical_slug }}.png" alt="{{ lesson.avatar_alt }}"></a>
   </div>
 
   <h3 class="above-title">{{ include.authors }}</h3>

--- a/en/index.md
+++ b/en/index.md
@@ -3,7 +3,7 @@ layout: base
 title: The Programming Historian
 ---
 <div class="container" style="text-align:center">
-	<img class="home-image" src="{{ site.baseurl }}/images/about.png" />
+	<img class="home-image" src="{{ site.baseurl }}/images/about.png" alt="{{ site.data.snippets.front-image-alt[page.lang] }}" />
 </div>
 
 <div class="home-block">

--- a/pt/licoes/preservar-os-seus-dados-de-investigacao.md
+++ b/pt/licoes/preservar-os-seus-dados-de-investigacao.md
@@ -25,7 +25,7 @@ activity: sustaining
 topics: [data-management]
 abstract: "Esta lição irá sugerir maneiras pelas quais os historiadores podem documentar e estruturar os seus dados de pesquisa, a fim de garantir que continuem sendo acessíveis no futuro."
 original: preserving-your-research-data
-avatar_alt: A large barrel
+avatar_alt: Um barril grande
 doi: 10.46430/phpt0001
 ---
 


### PR DESCRIPTION
Refs #2072. This fulfills one piece of the accessibility audit by using alt text when we have it for images. 

### Checklist

- [ ] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
