### PR TITLE
Accessibility audit pt 2

### DIFF
--- a/_includes/author-info.html
+++ b/_includes/author-info.html
@@ -5,7 +5,7 @@
 {% assign authorCount = page.authors | size %}
 
 <div class="author-info">
-    <h5 class="author-name">{{ site.data.snippets.about-the[page.lang] }} {% if authorCount == 1 %}{{ site.data.snippets.the-authors.singular[page.lang] }}{% else %}{{ site.data.snippets.the-authors.plural[page.lang] }}{% endif %}</h5>
+    <h2 class="author-name">{{ site.data.snippets.about-the[page.lang] }} {% if authorCount == 1 %}{{ site.data.snippets.the-authors.singular[page.lang] }}{% else %}{{ site.data.snippets.the-authors.plural[page.lang] }}{% endif %}</h2>
 </div>
 <div class="author-description">
   {% for author in page.authors %}

--- a/_includes/homepage_block.html
+++ b/_includes/homepage_block.html
@@ -6,7 +6,7 @@
     <div class="media-body p-3">
       <a href="/{{ include.lang }}"><h1>{{ site.data.snippets.enter[include.lang] }} <em>{{ site.data.snippets.journal-title[include.lang] }}</em></h1></a>
       {% if site.data.snippets.journal-subtitle[include.lang] %}
-      <h3 class="text-center">({{ site.data.snippets.journal-subtitle[include.lang] }})</h3>
+      <h2 class="text-center">({{ site.data.snippets.journal-subtitle[include.lang] }})</h2>
       {% endif %}
       <hr>
       <ul class="nav nav-justified mb-3">

--- a/_includes/homepage_block.html
+++ b/_includes/homepage_block.html
@@ -6,7 +6,7 @@
     <div class="media-body p-3">
       <a href="/{{ include.lang }}"><h1>{{ site.data.snippets.enter[include.lang] }} <em>{{ site.data.snippets.journal-title[include.lang] }}</em></h1></a>
       {% if site.data.snippets.journal-subtitle[include.lang] %}
-      <h4 class="text-center">({{ site.data.snippets.journal-subtitle[include.lang] }})</h4>
+      <h3 class="text-center">({{ site.data.snippets.journal-subtitle[include.lang] }})</h3>
       {% endif %}
       <hr>
       <ul class="nav nav-justified mb-3">

--- a/_includes/lesson_describe.html
+++ b/_includes/lesson_describe.html
@@ -16,7 +16,7 @@ lesson-slug.html computes the correct lesson slug, and then this include determi
   {% endif %}
 
   <div class="lesson-image">
-    <a href="{{ lesson.url }}"><img class="rounded" src="/gallery/{{ canonical_slug }}.png"></a>
+    <a href="{{ lesson.url }}"><img class="rounded" src="/gallery/{{ canonical_slug }}.png"><span class="visually-hidden">link to lesson on {{ lesson.title }}</span></a>
   </div>
 
   <h3 class="above-title">{{ include.authors }}</h3>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -76,7 +76,7 @@ match the new entry you made in `_data/snippets.yml`
 
       <li class="nav-item" role="menuitem">
         <a class="nav-link" href="{{site.baseurl}}{{site.data.snippets.menu-lessons[page.lang].link}}"
-          role="menuitem">{{site.data.snippets.menu-lessons[page.lang].title}}</a>
+          role="link">{{site.data.snippets.menu-lessons[page.lang].title}}</a>
       </li>
 
       <li class="nav-item dropdown mobile-drop" role="menu">
@@ -95,7 +95,7 @@ match the new entry you made in `_data/snippets.yml`
       
       <li class="nav-item" role="menuitem">
         <a class="nav-link" href="{{site.baseurl}}{{site.data.snippets.menu-blog[page.lang].link}}"
-          role="menuitem">{{site.data.snippets.menu-blog[page.lang].title}}</a>
+          role="link">{{site.data.snippets.menu-blog[page.lang].title}}</a>
       </li>
      
 
@@ -107,8 +107,8 @@ match the new entry you made in `_data/snippets.yml`
       {% endcomment %}
       {% assign all_translations = translation_candidates | push: translation_source %}
 
-      <li class="nav-item">
-        <div class="btn-group" role="group" aria-label="Language selector">
+      <li class="nav-item" role="menu">
+        <div class="btn-group" role="menuitem" aria-label="Language selector">
           {% for lang in site.data.snippets.language-list %}
 
           {% if page.lang == lang %}
@@ -129,11 +129,12 @@ match the new entry you made in `_data/snippets.yml`
           {% endfor %}
         </div>
       </li>
-      <li class="nav-item" id="low-contrast-button">
+      <li class="nav-item" id="low-contrast-button" role="menu">
         <div class="theme-switch-wrapper">
-          <label class="theme-switch">
-            <input type="checkbox">
+          <label class="theme-switch" role="menuitem">
+            <input type="checkbox" role="menuitemcheckbox">
             <span class="slider round">
+              <span class="visually-hidden">night mode toggle</span>
             </span>
           </label>
         </div>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -260,7 +260,7 @@ All lesson metadata and alerts should follow the convention of pulling appropria
     {% endif %}
     {% assign vol_no = page_year | minus: vol_start | plus: 1 %}
 
-    <h5 class="suggested-citation-header">{{ site.data.snippets.suggested-citation[page.lang] }}</h5>
+    <h2 class="suggested-citation-header">{{ site.data.snippets.suggested-citation[page.lang] }}</h2>
     <div class="suggested-citation-text">
       <p class="suggested-citation-text">{% include author.html %},
         {{ site.data.snippets.title-open-quote[page.lang] }}{{ page.title | strip }}{{ site.data.snippets.title-close-quote[page.lang] }}{% if page.translator %}

--- a/css/style.css
+++ b/css/style.css
@@ -1135,3 +1135,8 @@ input:checked+.slider:before {
   white-space: nowrap;
   width: 1px;
 }
+
+div.card div.media-body.p-3 h3{
+  font-size:1.2rem;
+  margin-top:1.8rem;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1126,6 +1126,8 @@ input:checked+.slider:before {
   border-radius: 50%;
 }
 
+/* hidden text for image links and other controls so as to accommodate screen readers*/
+
 .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
@@ -1136,8 +1138,20 @@ input:checked+.slider:before {
   width: 1px;
 }
 
+/* hacking some header stylings because we were cheating around accessible structuring to get the design we wanted */
+
 div.card div.media-body.p-3 h2{
   font-size:1.2rem;
   margin-top:1.8rem;
+  letter-spacing: normal;
+}
+
+div.author-info h2.author-name, div.citation-info h2.suggested-citation-header{
+  font-family: 'Roboto Condensed';
+  font-weight: 600;
+  font-size: 1.2rem;
+  color: var(--font-color);
+  text-transform: uppercase;
+  margin-top: 1.4rem;
   letter-spacing: normal;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1125,3 +1125,13 @@ input:checked+.slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1136,7 +1136,8 @@ input:checked+.slider:before {
   width: 1px;
 }
 
-div.card div.media-body.p-3 h3{
+div.card div.media-body.p-3 h2{
   font-size:1.2rem;
   margin-top:1.8rem;
+  letter-spacing: normal;
 }

--- a/js/header_links.js
+++ b/js/header_links.js
@@ -5,7 +5,7 @@ $(function() {
     var $el, icon, id;
     $el = $(el);
     id = $el.attr('id');
-    icon = '<i class="fa fa-link" style="font-size: 0.8em"></i>';
+    icon = '<i class="fa fa-link" style="font-size: 0.8em"><span class="visually-hidden">link to this section</span></i>';
     if (id) {
       return $el.append($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
     }


### PR DESCRIPTION
refs #2072 - This should address aria roles for the nav bar, hidden screen reader text for image links, skipping header types on lesson pages, and hidden screen reader text for some of the custom controls and links that we have. 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
