### PR TITLE
Add remaining alt text

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -776,46 +776,46 @@ front-image-alt:
   pt: Imagem da Scientific American de uma mulher a usar uma máquina de contagem elétrica.
 write-a-lesson-image-alt:
   en: A woman at a desk writing.
-  es: 
+  es: Una mujer escribiendo en un escritorio.
   fr: 
   pt: Uma mulher numa mesa escrevendo.
 editor-guidelines-image-alt:
   en: Two men discussing a book.
-  es: 
+  es: Dos hombres hablando sobre un libro.
   fr: 
   pt: Dois homens discutindo um livro.
 translator-image-alt:
   en: An outdoor scene with a horse, river, and person fishing.
-  es: 
+  es: Una escena con un caballo, un río y una persona pescando. 
   fr: 
   pt: Uma cena ao ar livre com um cavalo, um rio e uma pessoa pescando.
 feedback-image-alt:
   en: A man reading a book.
-  es: 
+  es: Un hombre leyendo un libro. 
   fr: 
   pt: Um homem lendo um livro.
 library-catalogue-image-alt:
   en: A book, hourglass, and assorted objects on a table.
-  es: 
+  es: Un libro, un reloj de arena y otros objetos en una mesa.
   fr: 
   pt: Um livro, uma ampulheta e vários objetos numa mesa. 
 open-an-issue-on-github-image-alt:
   en: Screenshot of GitHub issue tracker with arrow pointing towards the button to contribute a new issue at top right.
-  es: 
+  es: Captura de pantalla del seguimiento de tickets de GitHub con una flecha señalando el botón para contribuir con un nuevo ticket arriba a la derecha.
   fr: 
   pt: Captura de tela do rastreador de problemas do GitHub, com uma seta apontando para o botão para contribuir com uma nova questão no canto superior direito. 
 reviewer-image-alt:
   en: Pair of readers reviewing a note.
-  es: 
+  es: Dos lectores revisando una nota. 
   fr: 
   pt: Par de leitores revendo uma nota.
 supporters-ipp-image-alt:
   en: A bird with a nest filled with eggs.
-  es: 
+  es: Un pájaro con un nido lleno de huevos.
   fr: 
   pt: Um pássaro com um ninho cheio de ovos.
 supporters-individual-image-alt:
   en: A bird sitting on a branch while another bird flies nearby.
-  es: 
+  es: Un pájaro en una rama con otro pájaro volando cerca.
   fr: 
   pt: Um pássaro sentado num galho enquanto outro pássaro voa próximo.

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -803,4 +803,19 @@ open-an-issue-on-github-image-alt:
   en: Screenshot of GitHub issue tracker with arrow pointing towards the button to contribute a new issue at top right.
   es: 
   fr: 
+  pt:
+reviewer-image-alt:
+  en: Pair of readers reviewing a note.
+  es: 
+  fr: 
+  pt: 
+supporters-ipp-image-alt:
+  en: A bird with a nest filled with eggs.
+  es: 
+  fr: 
+  pt: 
+supporters-individual-image-alt:
+  en: A bird sitting on a branch while another bird flies nearby.
+  es: 
+  fr: 
   pt: 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -799,3 +799,8 @@ library-catalogue-image-alt:
   es: 
   fr: 
   pt: 
+open-an-issue-on-github-image-alt:
+  en: Screenshot of GitHub issue tracker with arrow pointing towards the button to contribute a new issue at top right.
+  es: 
+  fr: 
+  pt: 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -774,3 +774,28 @@ front-image-alt:
   es: Imagen de Scientific American que muestra a una mujer trabajando en una máquina contadora eléctrica.
   fr: Image de Scientific American montrant une femme utilisant une compteuse de billets.
   pt: Imagem da Scientific American de uma mulher a usar uma máquina de contagem elétrica.
+write-a-lesson-image-alt:
+  en: A woman at a desk writing.
+  es: 
+  fr: 
+  pt: 
+editor-guidelines-image-alt:
+  en: Two men discussing a book.
+  es: 
+  fr: 
+  pt: 
+translator-image-alt:
+  en: An outdoor scene with a horse, river, and person fishing.
+  es: 
+  fr: 
+  pt: 
+feedback-image-alt:
+  en: A man reading a book.
+  es: 
+  fr: 
+  pt: 
+library-catalogue-image-alt:
+  en: A book, hourglass, and assorted objects on a table.
+  es: 
+  fr: 
+  pt: 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -777,45 +777,45 @@ front-image-alt:
 write-a-lesson-image-alt:
   en: A woman at a desk writing.
   es: Una mujer escribiendo en un escritorio.
-  fr: 
+  fr: Une femme à son bureau en train d'écrire. 
   pt: Uma mulher numa mesa escrevendo.
 editor-guidelines-image-alt:
   en: Two men discussing a book.
   es: Dos hombres hablando sobre un libro.
-  fr: 
+  fr: Deux hommes en train de discuter d'un livre.
   pt: Dois homens discutindo um livro.
 translator-image-alt:
   en: An outdoor scene with a horse, river, and person fishing.
   es: Una escena con un caballo, un río y una persona pescando. 
-  fr: 
+  fr: Scène d'extérieur avec un cheval et un pêcheur en rivière. 
   pt: Uma cena ao ar livre com um cavalo, um rio e uma pessoa pescando.
 feedback-image-alt:
   en: A man reading a book.
   es: Un hombre leyendo un libro. 
-  fr: 
+  fr: Un homme en train de lire un livre.
   pt: Um homem lendo um livro.
 library-catalogue-image-alt:
   en: A book, hourglass, and assorted objects on a table.
   es: Un libro, un reloj de arena y otros objetos en una mesa.
-  fr: 
+  fr: Un livre, un sablier et divers objets posés sur une table. 
   pt: Um livro, uma ampulheta e vários objetos numa mesa. 
 open-an-issue-on-github-image-alt:
   en: Screenshot of GitHub issue tracker with arrow pointing towards the button to contribute a new issue at top right.
   es: Captura de pantalla del seguimiento de tickets de GitHub con una flecha señalando el botón para contribuir con un nuevo ticket arriba a la derecha.
-  fr: 
+  fr: Capture d'écran de l'interface de Github avec une flèche rouge pointant vers le bouton qui permet d'ouvrir un nouveau ticket en haut à droite. 
   pt: Captura de tela do rastreador de problemas do GitHub, com uma seta apontando para o botão para contribuir com uma nova questão no canto superior direito. 
 reviewer-image-alt:
   en: Pair of readers reviewing a note.
   es: Dos lectores revisando una nota. 
-  fr: 
+  fr: Des lecteurs en train de reviser une note. 
   pt: Par de leitores revendo uma nota.
 supporters-ipp-image-alt:
   en: A bird with a nest filled with eggs.
   es: Un pájaro con un nido lleno de huevos.
-  fr: 
+  fr: Un oiseau et sa niche remplie d'oeufs. 
   pt: Um pássaro com um ninho cheio de ovos.
 supporters-individual-image-alt:
   en: A bird sitting on a branch while another bird flies nearby.
   es: Un pájaro en una rama con otro pájaro volando cerca.
-  fr: 
+  fr: Un oiseau posé sur une branche pendant qu'un autre vole à côté. 
   pt: Um pássaro sentado num galho enquanto outro pássaro voa próximo.

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -778,44 +778,44 @@ write-a-lesson-image-alt:
   en: A woman at a desk writing.
   es: 
   fr: 
-  pt: 
+  pt: Uma mulher numa mesa escrevendo.
 editor-guidelines-image-alt:
   en: Two men discussing a book.
   es: 
   fr: 
-  pt: 
+  pt: Dois homens discutindo um livro.
 translator-image-alt:
   en: An outdoor scene with a horse, river, and person fishing.
   es: 
   fr: 
-  pt: 
+  pt: Uma cena ao ar livre com um cavalo, um rio e uma pessoa pescando.
 feedback-image-alt:
   en: A man reading a book.
   es: 
   fr: 
-  pt: 
+  pt: Um homem lendo um livro.
 library-catalogue-image-alt:
   en: A book, hourglass, and assorted objects on a table.
   es: 
   fr: 
-  pt: 
+  pt: Um livro, uma ampulheta e vários objetos numa mesa. 
 open-an-issue-on-github-image-alt:
   en: Screenshot of GitHub issue tracker with arrow pointing towards the button to contribute a new issue at top right.
   es: 
   fr: 
-  pt:
+  pt: Captura de tela do rastreador de problemas do GitHub, com uma seta apontando para o botão para contribuir com uma nova questão no canto superior direito. 
 reviewer-image-alt:
   en: Pair of readers reviewing a note.
   es: 
   fr: 
-  pt: 
+  pt: Par de leitores revendo uma nota.
 supporters-ipp-image-alt:
   en: A bird with a nest filled with eggs.
   es: 
   fr: 
-  pt: 
+  pt: Um pássaro com um ninho cheio de ovos.
 supporters-individual-image-alt:
   en: A bird sitting on a branch while another bird flies nearby.
   es: 
   fr: 
-  pt: 
+  pt: Um pássaro sentado num galho enquanto outro pássaro voa próximo.

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -9,7 +9,7 @@ skip_validation: true
 
 # Author Guidelines
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Step 1: <a href="#step-1-proposing-a-new-lesson">Proposing a New Lesson</a></h2>
 <h2 class="noclear">Step 2: <a href="#step-2-writing-a-new-lesson">Writing and Formatting a New Lesson</a></h2>
 <h2 class="noclear">Step 3: <a href="#step-3-submitting-a-new-lesson">Submitting a New Lesson</a></h2>  

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -10,7 +10,7 @@ The _Programming Historian_ runs on the far-from-endless energy of volunteers, a
 
 ## Write a new lesson
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 
 Writing a tutorial is one of the best ways to teach yourself particular skills and actively engage in the digital humanities community.
 
@@ -21,7 +21,7 @@ If you'd like to propose a lesson (for you or for someone else to write), email 
 
 ## Edit lessons
 
-<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" alt="{{ site.data.snippets.editor-guidelines-image-alt[page.lang] }}"/>
 
 
 Our editorial board members help facilitate peer review and work with authors closely to make improvements to their lessons. Our [guidelines for editors](editor-guidelines) is meant to ensure that everyone, from authors to reviewers to members of the wider community, receive a fair and consistent experience during peer review.
@@ -30,7 +30,7 @@ From time to time we may advertise that we are seeking more editors.
 
 ## Translate a lesson
 
-<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" alt="{{ site.data.snippets.translator-image-alt[page.lang] }}"/>
 
 If you are fluent in more than one of our publication languages (French, English, Spanish), you are invited to get in touch with us about translating one of our published Programming Historian lessons from one language to another. This will help us to assist building multilingual digital humanities communities, and to build your language, method, and technological skills.
 
@@ -38,7 +38,7 @@ We are seeking rigorous and readable translations that take into account the Spa
 
 ## Provide feedback or report problems
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 We welcome [feedback](feedback.html) on any aspect of the _Programming Historian_. Let us know what we can do to make the project better!
 
@@ -47,7 +47,7 @@ We are especially grateful for tips about lessons that seem to be broken. As URL
 
 ## Add us to your Library Catalog
 
-<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" />
+<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" alt="{{ site.data.snippets.library-catalogue-image-alt[page.lang] }}"/>
 
 
 This project is our attempt to demonstrate what open access academic publishing can and should be. Please help us spreading the message and providing the widest possible access to this resource by asking your librarian to include the project in your library catalogue.

--- a/en/feedback.md
+++ b/en/feedback.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # We Appreciate Your Feedback
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 Have you followed the instructions in a lesson meticulously and still run into an error? Thank you for taking the time to report a problem with one of our lessons. Your assistance is crucial for helping us maintain the best possible lessons!
 
@@ -27,7 +27,7 @@ Then, go to the [issues page](https://github.com/programminghistorian/jekyll/iss
 
 Create a new issue with a descriptive title and completing as much information as you can give following the prompt we provide.
 
-<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" />
+<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" alt="{{ site.data.snippets.open-an-issue-on-github-image-alt[page.lang] }}"/>
 
 For more information about GitHub issues, read the GitHub Guide on [Mastering Issues](https://guides.github.com/features/issues/).
 

--- a/en/individual.md
+++ b/en/individual.md
@@ -9,7 +9,7 @@ redirect_from:
 
 # Individual Supporters
 
-<img src="{{site.baseurl}}/images/supporters-individual.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/supporters-individual.png" class="garnish rounded float-left" alt="{{ site.data.snippets.supporters-individual-image-alt[page.lang] }}"/>
 
 Thank you for your interest supporting *Programming Historian*. Individual donors are vital for enabling our continued work, and for helping us to keep our content free to readers around the world. With one in three of our readers living in low and middle income countries, you're also helping to level the playing field, ensuring everyone is empowered to master technology and put it to good use, no matter where they live.
 

--- a/en/ipp.md
+++ b/en/ipp.md
@@ -9,7 +9,7 @@ redirect_from: /ipp
 
 # Institutional Partner Programme
 
-<img src="{{site.baseurl}}/images/supporters-ipp.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/supporters-ipp.png" class="garnish rounded float-left" alt="{{ site.data.snippets.supporters-ipp-image-alt[page.lang] }}"/>
 
 Thank you for your interest in the Institutional Partnership Programme, which provides the core support for the *Programming Historian*'s award winning open access publications. We cannot do our work without your valued support.
 

--- a/en/reviewer-guidelines.md
+++ b/en/reviewer-guidelines.md
@@ -7,7 +7,7 @@ redirect_from: /reviewer-guidelines
 
 # Reviewer Guidelines
 
-<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.reviewer-image-alt[page.lang] }}" />
 
 Reviewing for the _Programming Historian_ is a great way to learn new technical skills and engage with the digital humanities community. We go out of our way to make sure our reviewers get credit and recognition for their work. Because reviewers directly contribute to significantly improving lessons, you can take pride in that your work helps thousands of readers.
 

--- a/en/translator-guidelines.md
+++ b/en/translator-guidelines.md
@@ -8,7 +8,7 @@ skip_validation: true
 ---
 
 # Translator Guidelines
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Step 1: <a href="#proposing-a-new-lesson">Proposing the Translation of a Lesson</a></h2>
 <h2 class="noclear">Step 2: <a href="#writing-a-new-lesson">Writing and Formatting a Translation</a></h2>
 <h2 class="noclear">Step 3: <a href="#submitting-a-new-lesson">Submitting a Translated Lesson</a></h2>

--- a/es/contribuciones.md
+++ b/es/contribuciones.md
@@ -10,7 +10,7 @@ _The Programming Historian en español_ es posible gracias al esfuerzo de volunt
 
 ## Traduce una lección
 
-<img src="/images/translator.png" class="garnish rounded float-right" />
+<img src="/images/translator.png" class="garnish rounded float-right" alt="{{ site.data.snippets.translator-image-alt[page.lang] }}"/>
 
 Si tienes dominio de más de uno de nuestros idiomas (francés, español, inglés), puedes ponerte en contacto con nosotros para traducir una lección ya publicada en _The programming Historian_ de un idioma a otro. De esta manera nos ayudarás en nuestra contribucion en las comunidades de humanidades digitales en español y francés, y profundizarás en un lenguaje, método o tecnología.
 
@@ -19,7 +19,7 @@ Si te interesa colaborar, consulta nuestras [instrucciones para autores y traduc
 
 ## Escribe una lección
 
-<img src="/images/author-sm.png" class="garnish rounded float-right" />
+<img src="/images/author-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}" />
 
 También aceptamos envíos de [nuevas lecciones] por parte de los autores.
 
@@ -31,7 +31,7 @@ Si quieres proponer una lección (escrita por ti o por otra persona), envía un 
 
 ## Conviértete en editor
 
-<img src="/gallery/editor-guidelines.png" class="garnish rounded float-right" />
+<img src="/gallery/editor-guidelines.png" class="garnish rounded float-right" alt="{{ site.data.snippets.editor-guidelines-image-alt[page.lang] }}" />
 
 
 Nuestro Consejo editorial ayuda a facilitar el proceso de revisión y trabaja con los autores de manera estrecha para mejorar las lecciones. Nuestra [Guía para editores] está pensada para asegurar que todos (editores, revisores, miembros de la comunidad) tengan una experiencia justa y coherente durante el proceso de revisión.
@@ -40,7 +40,7 @@ En el futuro, de manera ocasional, publicaremos anuncios buscando más editores.
 
 ## Envía tus comentarios e informa sobre errores
 
-<img src="/images/reader-sm.png" class="garnish rounded float-right" />
+<img src="/images/reader-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}" />
 
 
 Nos gustaría recibir tus [comentarios] sobre cualquier aspecto de _The Programming Historian en español_. ¡Queremos mejorar nuestro trabajo!
@@ -50,7 +50,7 @@ Agradecemos de manera especial alertas sobre lecciones que no funcionan. A medid
 
 ## Añádenos a tu catálogo de biblioteca
 
-<img src="/images/library-catalogue.png" class="garnish float-right" />
+<img src="/images/library-catalogue.png" class="garnish float-right" alt="{{ site.data.snippets.library-catalogue-image-alt[page.lang] }}" />
 
 
 _The Programming Historian_ está registrado en WorldCat en ([español](https://www.worldcat.org/title/programming-historian-en-espanol/oclc/1061292935&referer=brief_results)), en ([inglés](http://www.worldcat.org/title/programming-historian/oclc/951537099)), y en ([francés](https://uva.worldcat.org/title/programming-historian-en-franais/oclc/1104391842)).

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -9,7 +9,7 @@ skip_validation: true
 
 # Guía para autores
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Paso 1: <a href="#paso-1-proponer-una-nueva-leccion">Proponer una nueva lección </a></h2>
 <h2 class="noclear">Paso 2: <a href="#paso-2-escribir-y-dar-formato-a-una-nueva-leccion">Escribir y dar formato a una nueva lección</a></h2>
 <h2 class="noclear">Paso 3: <a href="#paso-3-enviar-una-nueva-leccion">Enviar una nueva lección</a></h2>

--- a/es/guia-para-revisores.md
+++ b/es/guia-para-revisores.md
@@ -7,7 +7,7 @@ original: reviewer-guidelines
 
 # Guía para revisores
 
-<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.reviewer-image-alt[page.lang] }}"/>
 
 Esta guía pretende responder preguntas frecuentes y ayudar a los revisores a comprender mejor su rol durante el proceso editorial.
 

--- a/es/guia-para-traductores.md
+++ b/es/guia-para-traductores.md
@@ -9,7 +9,7 @@ skip_validation: true
 
 # Guía para traductores
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Paso 1: <a href="#paso-1-proponer-una-nueva-traduccion">Proponer una nueva traducción </a></h2>
 <h2 class="noclear">Paso 2: <a href="#paso-2-escribir-y-dar-formato-a-una-nueva-traduccion">Escribir y dar formato a una nueva traducción</a></h2>
 <h2 class="noclear">Paso 3: <a href="#paso-3-enviar-una-nueva-traduccion">Enviar una nueva traducción</a></h2>

--- a/es/retroalimentacion.md
+++ b/es/retroalimentacion.md
@@ -7,7 +7,7 @@ original: feedback
 
 # Agradecemos sus comentarios
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 ¿Has seguido meticulosamente las instrucciones de una lección y aún así has encontrado algún fallo o error? Gracias por tomarte el tiempo de reportar un problema con una de nuestras lecciones. ¡Tu ayuda es crucial para ayudarnos a mantener las mejores lecciones posibles!
 
@@ -22,7 +22,7 @@ Primero, si no tienes una ya, [abre una cuenta personal gratis en GitHub](https:
 
 Después ve a la [página de "issues"](https://github.com/programminghistorian/jekyll/issues?state=open) de nuestro Repositorio. Crea un nuevo "issue" con un título descriptivo y danos toda la información que puedas siguiendo las indicaciones que proporcionamos. 
 
-![](https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png)
+<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" alt="{{ site.data.snippets.open-an-issue-on-github-image-alt[page.lang] }}"/>
 
 Para más información sobre los "issues", lee la guía de GitHub en [Mastering Issues](https://guides.github.com/features/issues/).
 

--- a/fr/consignes-auteurs.md
+++ b/fr/consignes-auteurs.md
@@ -7,7 +7,7 @@ skip_validation: true
 
 # Consignes aux auteur(e)s
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear"> Étape 1 : <a href="#proposer-une-nouvelle-leçon">Proposer une nouvelle leçon</a></h2>
 <h2 class="noclear">Étape 2 : <a href="#écrire-une-nouvelle-leçon">Écrire et mettre en forme une nouvelle leçon</a></h2>
 <h2 class="noclear">Étape 3 : <a href="#soumettre-une-nouvelle-leçon">Soumettre une nouvelle leçon</a></h2>

--- a/fr/consignes-evaluateurs.md
+++ b/fr/consignes-evaluateurs.md
@@ -7,7 +7,7 @@ original: reviewer-guidelines
 
 # Consignes aux évaluateurs et évaluatrices
 
-<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.reviewer-image-alt[page.lang] }}"/>
 
 Devenir évaluateur(trice) pour le _Programming Historian en français_ est une excellente manière d'acquérir de nouvelles compétences techniques et de vous insérer dans la communauté des humanités numériques. Nous faisons tout notre possible pour nous assurer que les évaluateurs et les évaluatrices reçoivent crédit et reconnaissance pour leur travail. Parce qu'en tant évaluateur(trice), vous contribuez directement à améliorer de manière significative la qualité des leçons, vous pouvez être fier(ère) de votre travail qui aide ainsi des milliers de lecteurs et de lectrices.
 

--- a/fr/consignes-traducteurs.md
+++ b/fr/consignes-traducteurs.md
@@ -6,7 +6,7 @@ skip_validation: true
 ---
 
 # Consignes aux traducteurs et aux traductrices
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Étape 1: <a href="#proposer-la-traduction-dune-leçon">Proposer la traduction d'une leçon </a></h2>
 <h2 class="noclear">Étape 2: <a href="#traduire-une-leçon-et-la-mettre-en-page">Traduire une leçon et la mettre en page</a></h2>
 <h2 class="noclear">Étape 3: <a href="#soumettre-la-leçon-traduite">Soumettre la leçon traduite</a></h2>

--- a/fr/contribuer.md
+++ b/fr/contribuer.md
@@ -10,7 +10,7 @@ Le _Programming Historian en français_ est porté par des volontaires. Leur én
 
 ## Écrire une nouvelle leçon
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 
 Écrire un tutoriel est l'un des meilleurs moyens pour acquérir des compétences spécifiques et être partie prenante dans la communauté des humanités numériques.
 
@@ -20,7 +20,7 @@ Si vous souhaitez proposer une leçon, que vous en soyez l'auteur(e) ou pas, mer
 
 ## Assurer le suivi éditorial d'une leçon
 
-<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" alt="{{ site.data.snippets.editor-guidelines-image-alt[page.lang] }}"/>
 
 Les membres de notre comité éditorial apportent leur concours lors de l'évaluation par les pairs et travaillent avec les auteur(e)s pour améliorer leurs leçons. Nos [consignes aux rédacteurs et rédactrices][redacteurs] visent à ce que tout se passe au mieux, lors de l'évaluation par les pairs, pour tout le monde, auteur(e)s, évaluateurs et évaluatrices, et plus largement pour les membres de la communauté.
 
@@ -28,7 +28,7 @@ Il nous arrive de temps en temps de faire des appels pour recruter des membres p
 
 ## Traduire une leçon
 
-<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" alt="{{ site.data.snippets.translator-image-alt[page.lang] }}"/>
 
 Si vous parlez couramment plus d'une des langues dans lesquelles le _Programming Historian_ paraît (français, anglais, espagnol), nous vous invitons à prendre contact avec nous pour traduire une des leçons publiées d'une langue à une autre. Cela nous aidera à être partie prenante dans les communautés des humanités numériques hispanophone et francophone et vous permettra de renforcer vos compétences linguistiques, méthodologiques et techniques.
 
@@ -36,7 +36,7 @@ Nous recherchons des traductions rigoureuses et lisibles qui tiennent compte des
 
 ## Faire un retour ou signaler un problème
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 Nous vous invitons à nous faire des [retours d'expérience](/fr/reaction.html) sur tout aspect du _Programming Historian en français_. D'avance merci de nous aider à améliorer le projet.
 
@@ -45,7 +45,7 @@ Nous apprécions tout particulièrement les informations reçues sur les liens c
 
 ## Nous ajouter dans le catalogue de votre bibliothèque
 
-<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" />
+<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" alt="{{ site.data.snippets.library-catalogue-image-alt[page.lang] }}"/>
 
 
 Ce projet est notre démonstration de ce que l'édition scientifique en accès libre peut et doit être. Merci de nous aider à disséminer le message  et à fournir le plus large accès possible à cette ressource en demandant à votre bibliothèque d'enregister le projet dans son catalogue.

--- a/fr/reaction.md
+++ b/fr/reaction.md
@@ -7,7 +7,7 @@ original: feedback
 
 # Vos commentaires sont les bienvenus
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 
 Vous avez suivi méticuleusement les instructions d'une leçon et avez tout de même rencontré une erreur? Merci de prendre le temps de signaler celle-ci ou de proposer un changement. Votre aide est cruciale pour nous aider à continuer d'offrir les meilleures leçons possible!
@@ -25,7 +25,7 @@ Rendez-vous ensuite sur la [page rassemblant les "issues"](https://github.com/pr
 
 Créez vous une nouvelle "issue" en utilisant un titre clair, et fournissez le plus d'informations possible au sujet du problème que vous avez identifié en suivant le message guide que nous fournissons.
 
-<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" />
+<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" alt="{{ site.data.snippets.open-an-issue-on-github-image-alt[page.lang] }}"/>
 
 Pour plus d'informations sur les "issues" GitHub, vous pouvez lire le guide GitHub [Mastering Issues](https://guides.github.com/features/issues/).
 

--- a/pt/contribua.md
+++ b/pt/contribua.md
@@ -10,7 +10,7 @@ O _Programming Historian em português_ funciona através da energia inesgotáve
 
 ## Escreva uma nova lição
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 
 Escrever um tutorial é uma das melhores formas de se ensinar competências específicas e de se envolver ativamente na comunidade das humanidades digitais.
 
@@ -20,7 +20,7 @@ Se desejar propor uma lição (escrita por si ou para outra pessoa escrever), en
 
 ## Edite lições
 
-<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/gallery/editor-guidelines.png" class="garnish rounded float-right" alt="{{ site.data.snippets.editor-guidelines-image-alt[page.lang] }}"/>
 
 Os membros do nosso conselho editorial ajudam a facilitar a revisão por pares e trabalham em estreita colaboração com os autores para melhorar as suas lições. As [nossas diretrizes para editores](directrizes-editor) visam assegurar que todos, desde os autores aos revisores, passando pelos membros da comunidade em geral, recebam uma experiência justa e consistente durante a revisão por pares.
 
@@ -28,7 +28,7 @@ Periodicamente, podemos anunciar a procura de mais editores.
 
 ## Traduza uma lição
 
-<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/translator.png" class="garnish rounded float-right" alt="{{ site.data.snippets.translator-image-alt[page.lang] }}"/>
 
 Se você é fluente em mais do que um dos idiomas de publicação (francês, inglês, espanhol, português), está convidado a entrar em contato conosco para traduzir de um idioma para o outro uma das lições do _Programming Historian_ já publicadas. Isto irá ajudar-nos a criar comunidades multilingues de humanidades digitais e a desenvolver o seu idioma, método e competências tecnológicas.
 
@@ -37,7 +37,7 @@ Procuramos traduções rigorosas e legíveis que tenham em conta os contextos de
 
 ## Dê a sua opinião ou comunique problemas
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-right" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 Agradecemos pelo [feedback](/pt/reportar-um-erro) de qualquer aspecto do _Programming Historian em português_. Diga-nos o que podemos fazer para tornar o projeto melhor!
 
@@ -45,7 +45,7 @@ Estamos especialmente gratos por dicas sobre lições que apresentam links quebr
 
 ## Nos adicione ao seu Catálogo de Bibliotecas
 
-<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" />
+<img src="{{site.baseurl}}/images/library-catalogue.png" class="garnish float-right" alt="{{ site.data.snippets.library-catalogue-image-alt[page.lang] }}"/>
 
 Este projeto é a nossa tentativa de demonstrar que a publicação acadêmica pode e deve ser de acesso aberto. Por favor, ajude-nos a divulgar essa mensagem e a proporcionar o maior acesso possível a este recurso, solicitando ao bibliotecário que inclua o projeto no catálogo da sua biblioteca.
 

--- a/pt/directrizes-autor.md
+++ b/pt/directrizes-autor.md
@@ -7,7 +7,7 @@ original: author-guidelines
 
 # Directrizes para Autores
 
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Etapa 1: <a href="#etapa-1-propor-uma-nova-lição">Propor uma nova lição</a></h2>
 <h2 class="noclear">Etapa 2: <a href="#etapa-2-escrever-e-formatar-uma-nova-lição">Escrever e formatar uma nova lição</a></h2>
 <h2 class="noclear">Etapa 3: <a href="#etapa-3-submeter-uma-nova-lição">Submeter uma nova lição</a></h2>

--- a/pt/directrizes-revisor.md
+++ b/pt/directrizes-revisor.md
@@ -7,7 +7,7 @@ original: reviewer-guidelines
 
 # Diretrizes para Revisores
 
-<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reviewer-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.reviewer-image-alt[page.lang] }}"/>
 
 O processo de revisão do _Programming Historian em português_ é uma excelente forma de aprender novas competências técnicas e de se envolver com a comunidade das humanidades digitais. Fazemos todo o possível para garantir que os nossos revisores recebam crédito e reconhecimento pelo seu trabalho. Como os revisores contribuem directamente para melhorar significativamente as lições, eles podem ter orgulho que o seu trabalho irá ajudar milhares de leitores.
 

--- a/pt/directrizes-tradutor.md
+++ b/pt/directrizes-tradutor.md
@@ -6,7 +6,7 @@ skip_validation: true
 ---
 
 # Directrizes para Tradutores
-<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/author-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>
 <h2 class="noclear">Step 1: <a href="#propor-a-tradução-de-uma-lição">Propor a tradução de uma lição</a></h2>
 <h2 class="noclear">Step 2: <a href="#traduzir-uma-lição">Escrever e formatar uma tradução</a></h2>
 <h2 class="noclear">Step 3: <a href="#submeter-uma-lição-traduzida">Submeter uma lição traduzida</a></h2>

--- a/pt/reportar-um-erro.md
+++ b/pt/reportar-um-erro.md
@@ -6,7 +6,7 @@ original: feedback
 
 # Agradecemos o _Feedback_
 
-<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" />
+<img src="{{site.baseurl}}/images/reader-sm.png" class="garnish rounded float-left" alt="{{ site.data.snippets.feedback-image-alt[page.lang] }}"/>
 
 Seguiu as instruções em uma lição meticulosamente e ainda assim encontrou um erro? Obrigado por reservar um tempo para relatar um problema com uma de nossas lições. Oseu contributo é crucial para nos ajudar a manter as melhores lições possíveis! 
 
@@ -23,7 +23,7 @@ Em seguida, vá até à [página de questões](https://github.com/programminghis
 
 Crie uma nova questão com um título descritivo e preencha o máximo de informações que puder, seguindo o aviso que fornecemos. 
 
-<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" />
+<img src="https://cloud.githubusercontent.com/assets/1126864/3697100/52b37768-139e-11e4-816e-c3eee5516997.png" class="full-width rounded" alt="{{ site.data.snippets.open-an-issue-on-github-image-alt[page.lang] }}"/>
 
 Para mais informação sobre as questões no GitHub, consulte o Guia GitHub sobre [Mastering Issues](https://guides.github.com/features/issues/).
 


### PR DESCRIPTION
refs #2072. This pull request adds remaining alt text for the shared images that show up in multiple places on the site on the site. 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
