### PR TITLE
Fix 2 typos in /en/author-guidelines

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -86,7 +86,7 @@ This second section covers more specific matters of writing style, such as which
 
 ### Dates and Time
  *	For centuries, use eighteenth century not 18th century. Avoid national-centric phrases such as "long eighteenth century" which have specific meaning to British eighteenth century specialists, but not to anyone else.
- *	For decades, write the 1950s (not "the 1950s" or "the fifties").
+ *	For decades, write the 1950s (not "the 50s" or "the fifties").
  *	Compress date sequences as follows; 1816-17, 1856-9, 1854-64.
  *	For dates written in numeric form, use the format YYYY-MM-DD, which conforms to the standard ISO 8601:2004. This avoids ambiguity.
  *	Use BCE/CE not BC/AD for dates (eg 325BCE).
@@ -269,7 +269,7 @@ Lines of code should be formatted to distinguish them clearly from prose:
 ```
 They will look like this
 ```
-` and this ` respectively.
+`and this` respectively.
 
 --
 Follow best practice in writing your code:


### PR DESCRIPTION
There were 2 typos in the English author guidelines.

Firstly: 

> For decades, write the 1950s (not “the 1950s” or “the fifties”)

now reads:

> For decades, write the 1950s (not “the 50s” or “the fifties”)

---

Secondly: 

the inline code example "and this" now renders properly as inline code.


### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
