### PR TITLE
Issue 2183 - remove new pub manager role

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1501,7 +1501,6 @@
   team_roles:
     - spanish
     - editorial
-    - new-pub-manager
   status: volunteer
 
 - name: Armando Luza

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -150,17 +150,6 @@
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
     fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.
     pt: Responsável por coordenar novas iniciativas globais, assim como por alargar a diversidade cultural e linguística da equipe, das lições e da participação no movimento das Humanidades Digitais em geral.
-- type: new-pub-manager
-  label:
-    en: New Publications Manager
-    es: Mánager de publicaciones nuevas
-    fr: Responsable des nouvelles publications
-    pt: Gestor de novas publicações
-  definition:
-    en: Coordinates the process for creating new publications and facilitates communication with other Programming Historian teams.
-    es: Coordina el proceso de creación de publicaciones nuevas y facilita la comunicación con el resto de los equipos de Programming Historian.
-    fr: Responsable de la création de nouvelles publications et assure la communication avec les autres équipes du Programming Historian.
-    pt: Coordena o processo para a criação de novas publicações e facilita a comunicação entre equipes do Programming Historian.
 
 # Status
 - type: volunteer


### PR DESCRIPTION
Closes #2183 

This removes the "New Publication Manager" role from the project, as this work will be transferred to our new Publication Assistant next week.

I've also updated the Wiki pages accordingly.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
