### PR TITLE
Editing team roles 'archivist'

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -350,7 +350,6 @@
   team_roles:
     - proghist
     - finance-manager
-    - archive
   status: institutionally-supported
 
 - name: Amanda Morton
@@ -2226,4 +2225,5 @@
       Anisa Hawes, Programming Historian.
   team_roles:
     - proghist
+    - archive
   status: institutionally-supported

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -14,13 +14,13 @@
   definition:
     en: First point of contact for authors with lesson ideas
     es: Primer contacto para autores con ideas de lecciones
-    fr: Premier contact pour les auteurs souhaitant proposer une lesson
+    fr: Premier contact pour les auteur(e)s souhaitant proposer une lesson
     pt: Primeiro contacto para os autores com ideias para lições
 - type: editorial
   label:
     en: Editor
     es: Editor(a)
-    fr: Rédacteur
+    fr: Rédacteur/rédactrice
     pt: Editor(a)
   definition:
     en: Responsible for editorial work resulting in the review and publication of lessons
@@ -167,7 +167,7 @@
   label:
     en: Institutionally Supported
     es: Apoyado por su institución
-    fr: Soutenu institutionnellement
+    fr: Soutenu(e) institutionnellement
     pt: Apoiado institucionalmente
   definition:
     en: This member's time on the project is either directly or indirectly supported by their employer.


### PR DESCRIPTION
Editing team roles 'archivist'. I will be taking over the role of 'archivist' from @drjwbaker, so I am removing the role from his profile, and adding it to mine. Closes #2192.  

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
