### PR TITLE
Fix broken link to data.csv

### DIFF
--- a/en/lessons/mapping-with-python-leaflet.md
+++ b/en/lessons/mapping-with-python-leaflet.md
@@ -51,7 +51,7 @@ If you are using a code editor such as Sublime Text, to import the folder you co
 
 We're going to start with a plain comma-separated values (CSV) data file and create a web map from it.
 
-[The data file can be downloaded here.] (/assets/mapping-with-python-leaflet/census.csv). You can grab this by either opening the link in your browser and saving the page, or you can use the curl command from your command line:
+[The data file can be downloaded here]({{ site.baseurl }}/assets/mapping-with-python-leaflet/census.csv). You can grab this by either opening the link in your browser and saving the page, or you can use the curl command from your command line:
 
 ```curl -O https://programminghistorian.org/assets/mapping-with-python-leaflet/census.csv```
 


### PR DESCRIPTION
closes #2198 

I think the problem was the space between ] and (, but I also added the site.baseurl variable since that's the pattern used elsewhere; e.g. crowdsourced-data-normalization-with-pandas.md

*add the reason for your pull request here*

### Checklist

- [ ] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [ ] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
