### PR TITLE
Update ph_authors.yml and teamroles.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2219,7 +2219,6 @@
       Anisa Hawes, Programming Historian.
   team_roles:
     - proghist
-    - archive
   status: institutionally-supported
 
 - name: Nicolás Vaughan

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -84,17 +84,6 @@
     es: Responsable de la coordinación del equipo de comunicación
     fr: Responsable de la coordination de l'équipe de communication
     pt: Responsável por coordenar os esforços da equipe de comunicação
-- type: archive
-  label:
-    en: Archivist
-    es: Archivista
-    fr: Archiviste
-    pt: Arquivista
-  definition:
-    en: Responsible for archiving the project
-    es: Responsable del archivo del proyecto
-    fr: Responsable de l'archive du projet
-    pt: Responsável por gerir o arquivo do projeto
 - type: finance-manager
   label:
     en: Finance Manager


### PR DESCRIPTION
Removing   
`team_roles:
    - archive` from my bio in `ph_authors.yml`.

Removing
`- type: archive
  label:
    en: Archivist
    es: Archivista
    fr: Archiviste
    pt: Arquivista
  definition:
    en: Responsible for archiving the project
    es: Responsable del archivo del proyecto
    fr: Responsable de l'archive du projet
    pt: Responsável por gerir o arquivo do projeto`

from the list of Team Roles in`teamroles.yml`

Closes #2264 

I am removing the label 'archivist' from my bio on the /project-team pages, and from the /project-team#project-team-roles list so that our list of roles is shorter. I will continue to take this responsibility, as detailed on the wiki (https://github.com/programminghistorian/jekyll/wiki/ProgHist-services-to-Publications).

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
