### PR TITLE
Issue 1955 and 2028

### DIFF
--- a/en/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/en/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -196,7 +196,16 @@ Don't forget to wait until the command prompt appears again to type the followin
 
 `gem install rubygems-update`
 
-If you get a permissions error at this point, entering `echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile` followed by `source ~/.bash_profile` instead of the command above may help.
+If you get a permissions error at this point, setting `GEM_HOME` to your user directory may help. Try entering:
+
+`echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc` 
+`echo 'export GEM_HOME=$HOME/gems' >> ~/.bashrc` 
+`echo 'export PATH=$HOME/gems/bin:$PATH' >> ~/.bashrc` followed by `source ~/.bashrc`.
+
+<div class="alert alert-warning">
+Some users of macOS Catalina and macOS Big Sur have reported encountering difficulties installing Ruby & Ruby Gems. This lesson pre-dates the release of those operating systems, but the code supplied here has been adapted to offer a possible solution. Users who continue to face issues, may find <a href="https://github.com/monfresh/install-ruby-on-macos">this script</a> useful. 
+</div>  
+
 
 ### NodeJS <a id="section2-4"></a>
 

--- a/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
+++ b/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
@@ -241,6 +241,8 @@ Espera hasta que el prompt vuelva a aparecer para ingresar el siguiente comando:
 
 En caso de recibir un error de permisos luego de instalar Ruby, incluye la dirección de Gems en tu sistema. Prueba lo siguiente:
 
+`echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc` 
+`echo 'export GEM_HOME=$HOME/gems' >> ~/.bashrc` 
 `echo 'export PATH=$HOME/gems/bin:$PATH' >> ~/.bashrc` seguido de `source ~/.bashrc`.
 
 <div class="alert alert-warning">

--- a/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
+++ b/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
@@ -235,11 +235,18 @@ En la línea de comandos, ingresa:
 
 `brew install ruby`
 
-(Si estás utilizando el sistema operativo Catalina, puede que recibas un error de permisos luego de instalar Ruby. Puedes arreglar esto incluyendo la dirección de Gems en tu sistema. Ingresa el siguiente comando: export `GEM_HOME="$HOME/.gem"`)
-
 Espera hasta que el prompt vuelva a aparecer para ingresar el siguiente comando:
 
 `gem install rubygems-update`
+
+En caso de recibir un error de permisos luego de instalar Ruby, incluye la dirección de Gems en tu sistema. Prueba lo siguiente:
+
+`echo 'export PATH=$HOME/gems/bin:$PATH' >> ~/.bashrc` seguido de `source ~/.bashrc`.
+
+<div class="alert alert-warning">
+Algunas personas que utilizan macOS Catalina y macOS Big Sur han reportado dificultades para instalar Ruby y Ruby Gems. Si bien esta lección fue publicada antes de la aparición de esos sistemas operativos, el código compartido aquí ha sido adaptado para ofrecer una posible solución. Si sigues encontrando problemas, <a href="https://github.com/monfresh/install-ruby-on-macos">estas indicaciones (en inglés)</a> podrían ser de utilidad. 
+</div> 
+
 
 ### NodeJS <a id="section2-4"></a>
 


### PR DESCRIPTION
I am updating `en/lessons/building-static-sites-with-jekyll-github-pages.md` and `es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md` to improve the advice for users who encounter a permissions error after they attempt `gem install rubygems-update`. I am also adding an alert warning to indicate that users of macOS Catalina and Big Sur may encounter difficulties in this lesson.

Closes #1955 and Closes #2028

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
