### PR TITLE
Update instalacion-mac

### DIFF
--- a/es/lecciones/instalacion-mac.md
+++ b/es/lecciones/instalacion-mac.md
@@ -68,7 +68,7 @@ Si no está visible el panel de Caja de Herramientas (Toolbox) a la derecha de l
 Ahora bien, una vez descargado e instalado el editor es necesario configurarlo para que puedas correr los programas de Python. En la ventana de la derecha (caja de herramientas o Toolbox) hay que hacer clic en el icono de engranaje y seleccionar "`New Command…`" Esta acción abre una nueva ventana de diálogo. Ahí se deberá renombrar como "`Ejecutar Python`". En el campo activo "`Command`" deberás escribir:
 
 ``` python
-%(python) %f
+%(python3) %f
 ```
 
 Y en el campo activo "`Start in`" debes escribir:


### PR DESCRIPTION
I am updating the code at line 71 of `es/lecciones/instalacion-mac`, replacing `%(python) %f` with `%(python3) %f`.

I see that `en/lessons/mac-installation` and `pt/licoes/instalacao-mac` have already been updated.

Closes #2147

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
