### PR TITLE
corrected wording of line 371

### DIFF
--- a/en/lessons/exploring-and-analyzing-network-data-with-python.md
+++ b/en/lessons/exploring-and-analyzing-network-data-with-python.md
@@ -368,7 +368,7 @@ Diameter uses a simple command: `nx.diameter(G)`. However, running this command 
 
 {% include figure.html filename="exploring-and-analyzing-network-data-with-python-1.png" caption="Force-directed network visualization of the Quaker data, created in Gephi" %}
 
-Since there is no shortest path between nodes of one component and nodes of another, `nx.diameter()` returns the "not connected" error. You can remedy this by first finding out if your Graph "is connected" (i.e. all one component) and, if not connected, finding the largest component and calculating diameter on that component alone. Here's the code:
+Since there is no available path between nodes of one component and nodes of another, `nx.diameter()` returns the "not connected" error. You can remedy this by first finding out if your Graph "is connected" (i.e. all one component) and, if not connected, finding the largest component and calculating diameter on that component alone. Here's the code:
 
 ```python
 # If your Graph has more than one component, this will return False:


### PR DESCRIPTION
Closes #2173 

Clarified the wording at the location pointed out -- the suggested correction by the person who raised the issue is, I think, also not clearer than what it is currently published, so I suggest 'since there is no **available** path between...'

Language teams tagged in case the lesson is currently being translated

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
