### PR TITLE
Update retroalimentacion.md

### DIFF
--- a/es/retroalimentacion.md
+++ b/es/retroalimentacion.md
@@ -39,4 +39,4 @@ Para más información sobre "pull requests", visita la guía de GitHub en [Fork
 
 ## Más recursos sobre Git y GitHub
 
-Utilizar Git y GitHub puede ser razonablemente simple una vez adquieras práctica. Si estás interesado en aprender más y contribuir, el sitio de [GitHub](https://help.github.com/articles/good-resources-for-learning-git-and-github/) es un buen sitio para empezar. También puedes revisar la guía de [Inicio Rápido](https://docs.github.com/es/github/get-started/quickstart) que está disponible en español. 
+Utilizar Git y GitHub puede ser razonablemente simple una vez adquieras práctica. Si estás interesado en aprender más y contribuir, el sitio de [GitHub](https://help.github.com/articles/good-resources-for-learning-git-and-github/) es un buen sitio para empezar. También puedes revisar la guía de [Inicio Rápido](https://docs.github.com/es/get-started/quickstart) que está disponible en español. 

--- a/es/retroalimentacion.md
+++ b/es/retroalimentacion.md
@@ -39,4 +39,4 @@ Para más información sobre "pull requests", visita la guía de GitHub en [Fork
 
 ## Más recursos sobre Git y GitHub
 
-Utilizar Git y GitHub puede ser razonablemente simple una vez adquieras práctica. Si estás interesado en aprender más y contribuir, el sitio de [GitHub](https://help.github.com/articles/good-resources-for-learning-git-and-github/) es un buen sitio para empezar. También puedes revisar la guía de [Inicio Rápido](https://docs.github.com/es/github/getting-started-with-github/quickstart) que está disponible en español. 
+Utilizar Git y GitHub puede ser razonablemente simple una vez adquieras práctica. Si estás interesado en aprender más y contribuir, el sitio de [GitHub](https://help.github.com/articles/good-resources-for-learning-git-and-github/) es un buen sitio para empezar. También puedes revisar la guía de [Inicio Rápido](https://docs.github.com/es/github/get-started/quickstart) que está disponible en español. 


### PR DESCRIPTION
I am replacing this link https://docs.github.com/es/github/getting-started-with-github/quickstart at paragraph 42 (which returns a 404) with https://docs.github.com/es/get-started/quickstart. The new link is operable, but we are aware that GitHub's Spanish translation of their Quickstart Guide is incomplete.

Closes #2314 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
