### PR TITLE
Issue 2339

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1286,7 +1286,6 @@
     - managing
     - french
     - proghist
-    - global
   status: volunteer
   bio:
     en: |
@@ -1467,7 +1466,6 @@
     - managing
     - spanish
     - proghist
-    - global
   status: volunteer
 
 - name: Joshua G. Ortiz Baco

--- a/_data/teamroles.yml
+++ b/_data/teamroles.yml
@@ -113,17 +113,6 @@
     fr: Responsable global
     pt: Gestor global
   definition:
-    en: Coordinates the Global Team and facilitates communication with other Programming Historian teams.
-    es: Coordina el Equipo Global y facilita la comunicación con el resto de los equipos de Programming Historian.
-    fr: Coordonne l'équipe globale et assure la communication avec les autres équipes du Programming Historian.
-    pt: Coordena a equipe global e facilita a comunicação com outras equipes do Programming Historian.
-- type: global
-  label:
-    en: Global Team
-    es: Equipo global
-    fr: Équipe globale
-    pt: Equipe global
-  definition:
     en: Managing new global initiatives, as well as trying to improve the cultural and linguistic diversity of the team, our lessons, and of participation in Digital Humanities more generally.
     es: Coordinar nuevas iniciativas globales, así como tratar de mejorar la diversidad cultural y lingüística del equipo, de nuestras lecciones y de la participación en Humanidades Digitales en general.
     fr: En charge de nouvelles initiatives à vocation globale, de la diversité culturelle et linguistique de l'équipe et des leçons, et de la participation aux humanités numériques en général.


### PR DESCRIPTION
I am removing the `type: global-team`, and amending the definition of Global Lead in teamroles.yml

I am removing Global Team role labels from Sofia Papastamkou's and Riva Quiroga's bios in ph_authors.yml 

Closes #2339

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
