### PR TITLE
Rm obsolete mention of notebooks using Python 2

### DIFF
--- a/en/lessons/introduction-to-stylometry-with-python.md
+++ b/en/lessons/introduction-to-stylometry-with-python.md
@@ -53,7 +53,7 @@ Please note that the code in this lesson has been designed to run sequentially. 
 
 ## Prior Reading
 
-If you do not have experience with the Python programming language or are finding examples in this tutorial difficult, the author recommends you read the lessons on [Working with Text Files in Python](/lessons/working-with-text-files) and [Manipulating Strings in Python](/lessons/manipulating-strings-in-python). Please note, that those lessons were written in Python version 2 whereas this one uses Python version 3. The differences in [syntax](https://en.wikipedia.org/wiki/Syntax) between the two versions of the language can be subtle. If you are confused at any time, follow the examples as written in this lesson and use the other lessons as background material. (More precisely, the code in this tutorial was written using [Python 3.6.4](https://www.python.org/downloads/release/python-364/); the [f-string construct](https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals) in the line `with open(f'data/federalist_{filename}.txt') as f:`, for example, requires Python 3.6 or a more recent version of the language.)
+If you do not have experience with the Python programming language or are finding examples in this tutorial difficult, the author recommends you read the lessons on [Working with Text Files in Python](/lessons/working-with-text-files) and [Manipulating Strings in Python](/lessons/manipulating-strings-in-python).
 
 ## Required materials
 
@@ -67,7 +67,7 @@ To work through this lesson, you will need to download and unzip the archive of 
 
 This lesson uses the following Python language versions and [libraries](https://en.wikipedia.org/wiki/Library_(computing)):
 
-* [Python 3.x](https://www.python.org/downloads/) - the latest stable version is recommended.
+* [Python 3.x](https://www.python.org/downloads/) - the latest stable version is recommended
 * [nltk](https://www.nltk.org/) - Natural Language Toolkit, usually abbreviated `nltk`.
 * [matplotlib](https://matplotlib.org/)
 

--- a/en/lessons/introduction-to-stylometry-with-python.md
+++ b/en/lessons/introduction-to-stylometry-with-python.md
@@ -67,7 +67,7 @@ To work through this lesson, you will need to download and unzip the archive of 
 
 This lesson uses the following Python language versions and [libraries](https://en.wikipedia.org/wiki/Library_(computing)):
 
-* [Python 3.x](https://www.python.org/downloads/) - the latest stable version is recommended
+* [Python 3.x](https://www.python.org/downloads/) - the latest stable version is recommended.
 * [nltk](https://www.nltk.org/) - Natural Language Toolkit, usually abbreviated `nltk`.
 * [matplotlib](https://matplotlib.org/)
 

--- a/fr/lecons/introduction-a-la-stylometrie-avec-python.md
+++ b/fr/lecons/introduction-a-la-stylometrie-avec-python.md
@@ -58,7 +58,7 @@ Veuillez noter que le code informatique de cette leçon a été conçu pour êtr
 
 ## Lectures préalables
 
-Si vous n'avez pas d'expérience de programmation en Python ou si vous trouvez les exemples dans ce tutoriel difficiles, l'auteur vous recommande de lire les leçons intitulées [Travailler avec des fichiers texte en Python](/fr/lecons/travailler-avec-des-fichiers-texte) et [Manipuler des chaînes de caractères en Python](/fr/lecons/manipuler-chaines-caracteres-python). Notez aussi que ces leçons ont à l'origine été rédigées en Python 2 tandis que ce tutoriel utilise Python 3. Les différences de [syntaxe](https://fr.wikipedia.org/wiki/Syntaxe) entre les deux versions du langage peuvent être subtiles. En cas de conflit, suivez les exemples tels qu'ils sont codés dans le présent tutoriel et n'utilisez les autres ressources qu'à titre indicatif. (Plus précisément, le code intégré à ce tutoriel a été écrit en [Python 3.6.4](https://www.python.org/downloads/release/python-364/); la chaîne de type [f-string](https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals) qui apparaît dans la ligne `with open(f'data/federalist_{filename}.txt') as f:`, par exemple, requiert Python 3.6 ou une version plus récente du langage.)
+Si vous n'avez pas d'expérience de programmation en Python ou si vous trouvez les exemples dans ce tutoriel difficiles, l'auteur vous recommande de lire les leçons intitulées [Travailler avec des fichiers texte en Python](/fr/lecons/travailler-avec-des-fichiers-texte) et [Manipuler des chaînes de caractères en Python](/fr/lecons/manipuler-chaines-caracteres-python). 
 
 ## Matériel requis
 


### PR DESCRIPTION
The referenced lessons have been using Python 3 syntax for at least two years.

I had drafted a note under Required materials > The Software replacing the comment here about requiring Python version 3.6 or newer, but I suspect this would only be pedantic since 3.6 [reaches end of life in December 2021](https://endoflife.date/python).

Closes #2353

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
