### PR TITLE
Rm warning - The Old Bailey API now works

### DIFF
--- a/en/lessons/naive-bayesian.md
+++ b/en/lessons/naive-bayesian.md
@@ -22,17 +22,6 @@ doi: 10.46430/phen0038
 {% include toc.html %}
 
 
-
-
-
-# WARNING - Technical issues with Old Bailey Online website
-
-As of August 2016, the Old Bailey Online experienced some issues that are currently being resolved by their project team. One of those issues includes the temporary suspension of the API which are used as the basis of this tutorial.
-
-While those fixes are underway the example in this tutorial will not work properly.
-
-You can still read through to build an understanding of how this process works, without actually running the working code. We apologise for this problem. If you notice that it has been rectified and we have not yet updated this tutorial or removed this notice, please let us know!
-
 ## Introduction
 
 A few years back, William Turkel wrote a series of blog posts called [A


### PR DESCRIPTION
A reader has alerted us to the fact that the warning which prefaces our EN lesson Supervised Classification: The Naive Bayesian Returns to the Old Bailey is no longer required, because the Old Bailey Online API is fixed.

"This notebook is prefaced with a warning that the required API is down in 2016. The required API is up in 2021."

Closes #2372 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
