### PR TITLE
Minor spelling fix

### DIFF
--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -13,7 +13,7 @@ Portuguese: Daniel Alves (dra@fcsh.unl.pt)
 2. Your email address
 
 ## Lesson Metadata
-3. Submission Langauge (delete as appropriate) English / Español / Français / Portuguese
+3. Submission Language (delete as appropriate) English / Español / Français / Portuguese
 4. Proposed Lesson Title
 5. Lesson Abstract (3-4 sentences)
 6. Case Study Description (details about your historical example problem)


### PR DESCRIPTION
A member of our community has identified a typing error at line 16 of our EN Lesson.Query.Form.txt.

Closes #2416 

minor spelling fix

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
- [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
