### PR TITLE
Update generating-an-ordered-data-set-from-an-OCR-text-file.md

### DIFF
--- a/en/lessons/generating-an-ordered-data-set-from-an-OCR-text-file.md
+++ b/en/lessons/generating-an-ordered-data-set-from-an-OCR-text-file.md
@@ -166,8 +166,8 @@ Code ripped from https://www.datacamp.com/community/tutorials/fuzzy-string-pytho
 def lev(seq1, seq2):
     """ levenshtein_ratio_and_distance:
         For all i and j, distance[i,j] will contain the Levenshtein
-        distance between the first i characters of s and the
-        first j characters of t
+        distance between the first i characters of seq1 and the
+        first j characters of seq2
     """
     # Initialize matrix of zeros
     rows = len(seq1)+1


### PR DESCRIPTION
I am making a correction to the code block in the Levenshtein Distance section of EN generating-an-ordered-data-set-from-an-OCR-text-file.md

Replacing `s` with `seq1` at line 169
 Replacing `t` with `seq2` at line 170

Closes #2396

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
