### PR TITLE
Issue 2446

### DIFF
--- a/assets/fetch-and-parse-data-with-openrefine/pg1105.html
+++ b/assets/fetch-and-parse-data-with-openrefine/pg1105.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <!-- saved from url=(0052)http://www.gutenberg.org/cache/epub/1105/pg1105.html -->
-<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title> </title><meta http-equiv="Content-Style-Type" content="text/css"><link href="http://purl.org/dc/terms/" rel="schema.DCTERMS">
-<link href="http://id.loc.gov/vocabulary/relators/" rel="schema.MARCREL">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title> </title><meta http-equiv="Content-Style-Type" content="text/css"><link href="https://dublincore.org/specifications/dublin-core/dcmi-terms/" rel="schema.DCTERMS">
+<link href="https://id.loc.gov/vocabulary/relators.html" rel="schema.MARCREL">
 <meta name="DCTERMS.title" content="The Sonnets">
 <meta name="DCTERMS.source" content="http://www.gutenberg.orgfiles/1105/1105.txt">
 <meta scheme="DCTERMS.RFC4646" name="DCTERMS.language" content="en">

--- a/en/lessons/code-reuse-and-modularity.md
+++ b/en/lessons/code-reuse-and-modularity.md
@@ -176,4 +176,4 @@ Suggested Readings
 
 -   [Python Basics][]
 
-  [Python Basics]: http://www.astro.ufl.edu/~warner/prog/python.html
+  [Python Basics]: https://users.astro.ufl.edu/~warner/prog/python.html

--- a/es/lecciones/reutilizacion-de-codigo-y-modularidad.md
+++ b/es/lecciones/reutilizacion-de-codigo-y-modularidad.md
@@ -116,4 +116,4 @@ Lecturas recomendadas:
 
 [modularidad]: https://es.wikipedia.org/wiki/Modularidad_(informática)
 [encapsulamiento]: https://es.wikipedia.org/wiki/Encapsulamiento_(informática)
-[Python Basics]: http://www.astro.ufl.edu/~warner/prog/python.html
+[Python Basics]: https://users.astro.ufl.edu/~warner/prog/python.html

--- a/pt/licoes/reutilizacao-codigo-modularidade-python.md
+++ b/pt/licoes/reutilizacao-codigo-modularidade-python.md
@@ -107,4 +107,4 @@ Leituras recomendadas
 
 -   [Python Basics][] (em inglês)
 
-  [Python Basics]: http://www.astro.ufl.edu/~warner/prog/python.html
+  [Python Basics]: https://users.astro.ufl.edu/~warner/prog/python.html


### PR DESCRIPTION
I am updating x3 problem links across the site.

A Mixed Content error in PR [2443](https://github.com/programminghistorian/jekyll/pull/2443) drew our attention to two problem links in assets/fetch-and-parse-data-with-openrefine/pg1105.html

line 3 http://purl.org/dc/terms/ resolves to https://dublincore.org/specifications/dublin-core/dcmi-terms/
line 4 http://id.loc.gov/vocabulary/relators/ resolves to https://id.loc.gov/vocabulary/relators.html

Meanwhile, a reader has contacted us to say that a link given as http://www.astro.ufl.edu/~warner/prog/python.html in fact resolves to https://users.astro.ufl.edu/~warner/prog/python.html in the following lessons:

EN code-reuse-and-modularity
ES reutilizacion-de-codigo-y-modularidad
PT reutilizacao-codigo-modularidade-python

Closes #2446 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
