### PR TITLE
Issue 1995

### DIFF
--- a/en/lesson-template.md
+++ b/en/lesson-template.md
@@ -17,32 +17,13 @@ This file can be used as a template for writing your lesson. It includes informa
 
 **Delete everything above this line when ready to submit your lesson**.
 
-title: YOUR TITLE HERE
-collection: lessons
-layout: lesson
-slug: LEAVE BLANK
-date: LEAVE BLANK
-translation_date: LEAVE BLANK
+---
+title: YOUR TITLE HERE  
+collection: lessons  
+layout: lesson  
 authors:
 - FORENAME SURNAME 1
 - FORENAME SURNAME 2, etc
-reviewers:
-- LEAVE BLANK
-editors:
-- LEAVE BLANK
-translator:
-- FORENAME SURNAME 1
-- FORENAME SURNAME 2, etc
-translation-editor:
-- LEAVE BLANK
-translation-reviewer:
-- LEAVE BLANK
-original: LEAVE BLANK
-review-ticket: LEAVE BLANK
-difficulty: LEAVE BLANK
-activity: LEAVE BLANK
-topics: LEAVE BLANK
-abstract: LEAVE BLANK
 ---
 
 # A Table of Contents

--- a/es/plantilla-leccion.md
+++ b/es/plantilla-leccion.md
@@ -12,7 +12,7 @@ collection: lessons
 layout: lesson  
 authors:
 - NOMBRE APELLIDO 1
-- NOMBRE APELLIDO 1, etc
+- NOMBRE APELLIDO 2, etc
 ---
 
 # Contenidos

--- a/es/plantilla-leccion.md
+++ b/es/plantilla-leccion.md
@@ -6,33 +6,13 @@ Este archivo puede ser utilizado como plantilla para desarrollar tu lección. Co
 
 **Borra todo lo que está hasta esta línea cuando envíes tu lección**
 
-title: |
-  EL TÍTULO DE LA LECCIÓN
-collection: lessons
-layout: lesson
-slug: DEJAR EN BLANCO
-date: DEJAR EN BLANCO
-translation_date: DEJAR EN BLANCO
+---
+title: EL TÍTULO DE LA LECCIÓN  
+collection: lessons  
+layout: lesson  
 authors:
 - NOMBRE APELLIDO 1
-- NOMBRE APELLIDO 2, etc
-reviewers:
-- DEJAR EN BLANCO
-editors:
-- DEJAR EN BLANCO
-translator:
-- NOMBRE APELLIDO 1
-translation-editor:
-- DEJAR EN BLANCO
-translation-reviewer:
-- DEJAR EN BLANCO
-original: DEJAR EN BLANCO
-review-ticket: DEJAR EN BLANCO
-difficulty: DEJAR EN BLANCO
-activity: DEJAR EN BLANCO
-topics: DEJAR EN BLANCO
-abstract: DEJAR EN BLANCO
-doi: DEJAR EN BLANCO
+- NOMBRE APELLIDO 1, etc
 ---
 
 # Contenidos

--- a/fr/modele-tuto.md
+++ b/fr/modele-tuto.md
@@ -17,32 +17,13 @@ Vous pouvez utiliser ce fichier en tant que modèle pour écrire votre leçon. I
 
 **Au moment de la soumission de votre leçon, merci d'effacer tout ce qui précède cette ligne**.
 
-title: VOTRE TITRE
-collection: lessons
-layout: lesson
-slug: NE PAS REMPLIR
-date: NE PAS REMPLIR
-translation_date: NE PAS REMPLIR
+---
+title: VOTRE TITRE  
+collection: lessons  
+layout: lesson  
 authors:
 - PRÉNOM NOM 1
 - PRÉNOM NOM 2, etc
-reviewers:
-- NE PAS REMPLIR
-editors:
-- NE PAS REMPLIR
-translator:
-- PRÉNOM NOM 1
-- PRÉNOM NOM 2, etc
-translation-editor:
-- NE PAS REMPLIR
-translation-reviewer:
-- NE PAS REMPLIR
-original: NE PAS REMPLIR
-review-ticket: NE PAS REMPLIR
-difficulty: NE PAS REMPLIR
-activity: NE PAS REMPLIR
-topics: NE PAS REMPLIR
-abstract: NE PAS REMPLIR
 ---
 
 # Table de matières

--- a/pt/licoes-modelo.md
+++ b/pt/licoes-modelo.md
@@ -17,32 +17,13 @@ Este ficheiro pode ser utilizado como modelo para escrever a sua lição. Inclui
 
 **Apague tudo o que está acima desta linha quando estiver pronto a submeter a lição**.
 
-title: O SEU TÍTULO
-collection: lessons
-layout: lesson
-slug: DEIXAR EM BRANCO
-date: DEIXAR EM BRANCO
-translation_date: DEIXAR EM BRANCO
+---
+title: O SEU TÍTULO  
+collection: lessons  
+layout: lesson  
 authors:
 - PRIMEIRO NOME APELIDO 1
 - PRIMEIRO NOME APELIDO 2, etc
-reviewers:
-- DEIXAR EM BRANCO
-editors:
-- DEIXAR EM BRANCO
-translator:
-- PRIMEIRO NOME APELIDO 1
-- PRIMEIRO NOME APELIDO 2, etc
-translation-editor:
-- DEIXAR EM BRANCO
-translation-reviewer:
-- DEIXAR EM BRANCO
-original: DEIXAR EM BRANCO
-review-ticket: DEIXAR EM BRANCO
-difficulty: DEIXAR EM BRANCO
-activity: DEIXAR EM BRANCO
-topics: DEIXAR EM BRANCO
-abstract: DEIXAR EM BRANCO
 ---
 
 # Índice


### PR DESCRIPTION
I am updating the lesson templates, simplifying the YAML to the minimum + upper three dashes --- + authors: with the understanding that editors / or technical editor will add in the remaining fields later in the workflow:

This change aims to reduce early-phase errors for authors and editors, and updates en/lesson-template.md, es/plantilla-leccion.md, fr/modele-tuto.md, and pt/licoes-modelo.md.

Closes #1995 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
