### PR TITLE
Issue 2502

### DIFF
--- a/en/lessons/temporal-network-analysis-with-r.md
+++ b/en/lessons/temporal-network-analysis-with-r.md
@@ -183,7 +183,8 @@ thenetwork <- network(
   vertex.attr = PHVertexAttributes,
   vertex.attrnames = c("vertex.id", "name", "region"),
   directed = FALSE,
-  bipartite = FALSE
+  bipartite = FALSE,
+  multiple = TRUE
 )
 plot(thenetwork)
 ```

--- a/es/lecciones/analisis-temporal-red.md
+++ b/es/lecciones/analisis-temporal-red.md
@@ -166,7 +166,8 @@ la_red <- network(
   VinculosEstaticosPH,
   vertex.attr = AtributosVerticesPH,
   vertex.attrnames = c("id.vertice", "nombre", "region"), directed = FALSE,
-  bipartite = FALSE
+  bipartite = FALSE,
+  multiple - TRUE
 )
 plot(la_red)
 ```


### PR DESCRIPTION
I am updating the code in /en/lessons/temporal-network-analysis-with-r and /es/lecciones/analisis-temporal-red to resolve an error [`Error: `multiple` is `FALSE`, but `x` contains parallel edges.`] produced at the Static Visualizations/Visualizaciones estáticas step.

Adding `multiple = TRUE` resolves this, and enables users to produce the plot as shown. I've tested this in  RStudio (2021.09.0) and also R Console (R 4.1.1 ).

Closes #2502 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] ~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
