### PR TITLE
Fixing lesson testers

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -141,11 +141,11 @@ All lesson metadata and alerts should follow the convention of pulling appropria
             </div>
             {% endif %}
 
-            {% if page.lesson-tester %}
+            {% if page.lesson-testers %}
             <div>
               <h3>{{site.data.snippets.lesson-testers[page.lang]}}</h3>
               <ul>
-                {% for lesson-tester-name in page.lesson-tester %}
+                {% for lesson-tester-name in page.lesson-testers %}
                 {% assign lesson-tester = site.data.ph_authors | where: "name", lesson-tester-name | first %}
                 <li>{{ lesson-tester-name }}{% if lesson-tester.orcid %}
                   {% include orcid.html author = lesson-tester %}{% endif %}</li>


### PR DESCRIPTION
This fixes issues with lesson-tester field not rendering

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
