### PR TITLE
Fix lesson tables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -865,7 +865,7 @@ Figures
   }
   
   .table-wrapper {
-  overflow-x: scroll;
+    overflow-x: scroll;
   }
 
   tr:nth-child(even) {background-color: #f2f2f2}

--- a/en/lesson-template.md
+++ b/en/lesson-template.md
@@ -79,13 +79,16 @@ It will appear in a coloured box and can be useful for drawing attention to part
 2. Here is another item
 3. Here is the final item
 
-###A Sample Table
+### A Sample Table
+
+<div class="table-wrapper" markdown="block">
 
 | Heading 1 | Heading 2 | Heading 3 |
 | --------- | --------- | --------- |
 | Row 1, column 1 | Row 1, column 2 | Row 1, column 3|
 | Row 2, column 1 | Row 2, column 2 | Row 2, column 3|
 | Row 3, column 1 | Row 3, column 2 | Row 3, column 3|
+</div>
 Table 1: This table contains...
 
 ### Referencing

--- a/es/plantilla-leccion.md
+++ b/es/plantilla-leccion.md
@@ -50,11 +50,15 @@ Bloque de código para insertar imágenes:
 
 ### Ejemplo de una tabla:
 
+<div class="table-wrapper" markdown="block">
+
 | Encabezado 1 | Encabezado 2 | Encabezado 3 |
 | --------- | --------- | --------- |
 | Fila 1, columna 1 | Fila 1, columna 2 | Fila 1, columna 3|
 | Fila 2, columna 1 | Fila 2, columna 2 | Fila 2, columna 3|
 | Fila 3, columna 1 | Fila 3, columna 2 | Fila 3, columna 3|
+
+</div>
 
 ### Una nota a pie de página:
 

--- a/fr/modele-tuto.md
+++ b/fr/modele-tuto.md
@@ -86,13 +86,18 @@ Le message sera encadré et dans une couleur différente, il servira ainsi à at
 2. Voici un autre item
 3. Voici un dernier item
 
-###Comment formater un tableau
+### Comment formater un tableau
+
+<div class="table-wrapper" markdown="block">
 
 | en-tête 1 | en-tête 2 | en-tête 3 |
 | --------- | --------- | --------- |
 | ligne 1, colonne 1 | ligne 1, colonne 2 | ligne 1, colonne 3|
 | ligne 2, colonne 1 | ligne 2, colonne 2 | ligne 2, colonne 3|
 | ligne 3, colonne 1 | ligne 3, colonne 2 | ligne 3, colonne 3|
+
+</div>
+
 Tableau 1: Ce tableau contient...
 
 ### Références

--- a/pt/licoes-modelo.md
+++ b/pt/licoes-modelo.md
@@ -79,13 +79,18 @@ Este aparecerá numa caixa colorida, podendo ser útil para chamar a atenção p
 2. Aqui está outro item
 3. Aqui está o item final
 
-###Uma amostra de tabela
+### Uma amostra de tabela
+
+<div class="table-wrapper" markdown="block">
 
 | Cabeçalho 1 | Cabeçalho 2 | Cabeçalho 3 |
 | --------- | --------- | --------- |
 | Linha 1, coluna 1 | Linha 1, coluna 2 | Linha 1, coluna 3|
 | Linha 2, coluna 1 | Linha 2, coluna 2 | Linha 2, coluna 3|
 | Linha 3, coluna 1 | Linha 3, coluna 2 | Linha 3, coluna 3|
+
+</div>
+
 Tabela 1: Esta tabela contem...
 
 ### Referências


### PR DESCRIPTION
This PR adds scrolling tables to all our lesson templates. Going forward all tables should be wrapped in divs with class `table-wrapper` to ensure we have responsive tables on different screen sizes

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
