### PR TITLE
Add space and move comma for FR citation format

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -674,12 +674,12 @@ journal-subtitle: # ENGLISH ONLY FOR NOW, DO NOT TRANSLATE
 title-open-quote:
   en: '"'
   es: '"'
-  fr: '« '
+  fr: '«&#x202F;'
   pt: '"'
 title-close-quote:
   en: ',"'
   es: '",'
-  fr: ' »,'
+  fr: '&#x202F;»,'
   pt: '",'
 available-lesson:
   en: Available in

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -674,12 +674,12 @@ journal-subtitle: # ENGLISH ONLY FOR NOW, DO NOT TRANSLATE
 title-open-quote:
   en: '"'
   es: '"'
-  fr: '«'
+  fr: '« '
   pt: '"'
 title-close-quote:
   en: ',"'
   es: '",'
-  fr: ',»'
+  fr: ' »,'
   pt: '",'
 available-lesson:
   en: Available in


### PR DESCRIPTION
on `title-open-quote` and title-close-quote` for the lesson.html to display citations in the right way for punctuation in French

Per @spapastamkou request in issue #2553  

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [ ] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
