### PR TITLE
Correcting a link in ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2445,7 +2445,7 @@
   github: rolrodr
   email: rolando@ad.unc.edu
   twitter: bibliothiccario
-  url: "https://www.rolandorodriguez.dev"
+  url: "https://rolandorodriguez.dev/"
   sortname: Rodriguez
   affiliation:
     en: |


### PR DESCRIPTION
I am updating a link in ph_authors.yml (l.2448) to correct the link provided to Rolando Rodriguez's homepage from the following pages: /en/project-team, /es/equipo-de-proyecto, /fr/equipe-projet, and /pt/equipe.

Closes #2565

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
