### PR TITLE
Issue 2595

### DIFF
--- a/en/vacancies.md
+++ b/en/vacancies.md
@@ -4,20 +4,4 @@ layout: blank
 redirect_from: /vacancies
 ---
 
-# Job Vacancy - Education and Community Lead
-
-- Employer: ProgHist Ltd, publisher of _Programming Historian_
-- Salary: £26,000 (pro rata) + home office budget
-- Hours: 0.4 full time equivalent; open-ended contract
-- Location : Remote home working; the successful candidate must have permission to work in the UK by the start of their employment
-
-
-_Programming Historian_ is looking for an outstanding Education and Community Lead to join our global-facing digital humanities team in a remote part-time role, to support our multilingual publishing teams.
-
-The candidate’s primary role is to administer, develop, improve, and provide community-facing activities aimed at better supporting educators, learners, and project partners in their use of _Programming Historian_. This will include but is not limited to hosting virtual events, training teachers how to use Programming Historian effectively, planning and executing our communication strategy, and building relationships with current and potential supporting organisations.
-
-The _Programming Historian_ team is committed to diversity, and we insist on a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or technical experience. The candidate will help us live these values.
-
-**Closing date for applications is 30 May 2022**
-
-More information about this role and information about how to apply are available in the [Job Information Pack](/images/blog/Job-Description-Education-and-Community-Lead.pdf).
+Thank you for your interest in opportunities with _Programming Historian_. We do not have any open positions at the moment.

--- a/es/vacantes.md
+++ b/es/vacantes.md
@@ -4,19 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-# Job Vacancy - Education and Community Lead
-
-- Employer: ProgHist Ltd, publisher of _Programming Historian_
-- Salary: £26,000 (pro rata) + home office budget
-- Hours: 0.4 full time equivalent; open-ended contract
-- Location : Remote home working; the successful candidate must have permission to work in the UK by the start of their employment
-
-_Programming Historian_ is looking for an outstanding Education and Community Lead to join our global-facing digital humanities team in a remote part-time role, to support our multilingual publishing teams.
-
-The candidate’s primary role is to administer, develop, improve, and provide community-facing activities aimed at better supporting educators, learners, and project partners in their use of _Programming Historian_. This will include but is not limited to hosting virtual events, training teachers how to use Programming Historian effectively, planning and executing our communication strategy, and building relationships with current and potential supporting organisations.
-
-The _Programming Historian_ team is committed to diversity, and we insist on a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or technical experience. The candidate will help us live these values.
-
-**Closing date for applications is 30 May 2022**
-
-More information about this role and information about how to apply are available in the [Job Information Pack](/images/blog/Job-Description-Education-and-Community-Lead.pdf).
+Thank you for your interest in opportunities with _Programming Historian_. We do not have any open positions at the moment.

--- a/fr/postes-vacants.md
+++ b/fr/postes-vacants.md
@@ -4,19 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-# Job Vacancy - Education and Community Lead
-
-- Employer: ProgHist Ltd, publisher of _Programming Historian_
-- Salary: £26,000 (pro rata) + home office budget
-- Hours: 0.4 full time equivalent; open-ended contract
-- Location : Remote home working; the successful candidate must have permission to work in the UK by the start of their employment
-
-_Programming Historian_ is looking for an outstanding Education and Community Lead to join our global-facing digital humanities team in a remote part-time role, to support our multilingual publishing teams.
-
-The candidate’s primary role is to administer, develop, improve, and provide community-facing activities aimed at better supporting educators, learners, and project partners in their use of _Programming Historian_. This will include but is not limited to hosting virtual events, training teachers how to use Programming Historian effectively, planning and executing our communication strategy, and building relationships with current and potential supporting organisations.
-
-The _Programming Historian_ team is committed to diversity, and we insist on a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or technical experience. The candidate will help us live these values.
-
-**Closing date for applications is 30 May 2022**
-
-More information about this role and information about how to apply are available in the [Job Information Pack](/images/blog/Job-Description-Education-and-Community-Lead.pdf).
+Thank you for your interest in opportunities with _Programming Historian_. We do not have any open positions at the moment.

--- a/pt/vagas.md
+++ b/pt/vagas.md
@@ -4,19 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-# Job Vacancy - Education and Community Lead
-
-- Employer: ProgHist Ltd, publisher of _Programming Historian_
-- Salary: £26,000 (pro rata) + home office budget
-- Hours: 0.4 full time equivalent; open-ended contract
-- Location : Remote home working; the successful candidate must have permission to work in the UK by the start of their employment
-
-_Programming Historian_ is looking for an outstanding Education and Community Lead to join our global-facing digital humanities team in a remote part-time role, to support our multilingual publishing teams.
-
-The candidate’s primary role is to administer, develop, improve, and provide community-facing activities aimed at better supporting educators, learners, and project partners in their use of _Programming Historian_. This will include but is not limited to hosting virtual events, training teachers how to use Programming Historian effectively, planning and executing our communication strategy, and building relationships with current and potential supporting organisations.
-
-The _Programming Historian_ team is committed to diversity, and we insist on a harassment-free space for all contributors to the project, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or technical experience. The candidate will help us live these values.
-
-**Closing date for applications is 30 May 2022**
-
-More information about this role and information about how to apply are available in the [Job Information Pack](/images/blog/Job-Description-Education-and-Community-Lead.pdf).
+Thank you for your interest in opportunities with _Programming Historian_. We do not have any open positions at the moment.


### PR DESCRIPTION
I am removing the live advertisement for Education and Community Lead from our website, because the application window has now closed.

I am replacing the live advertisement with a holding message.

Closes #2595 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ]  if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
