### PR TITLE
Issue 2603

### DIFF
--- a/en/lessons/basic-text-processing-in-r.md
+++ b/en/lessons/basic-text-processing-in-r.md
@@ -283,7 +283,7 @@ Let us now apply the techniques from the previous section to an entire State of 
 To do so, we will combine the `readLines` function to read the text into R and the `paste` function to combine all of the lines into a single object. We will build the URL of the text file using the `sprintf` function as this format will make it easily modified to grab other addresses.[^3]
 
 ```{r}
-base_url <- "https://programminghistorian.org/assets/basic-text-processing-in-r"
+base_url <- "https://github.com/programminghistorian/jekyll/tree/gh-pages/assets/basic-text-processing-in-r/"
 url <- sprintf("%s/sotu_text/236.txt", base_url)
 text <- paste(readLines(url), collapse = "\n")
 ```

--- a/es/lecciones/procesamiento-basico-de-textos-en-r.md
+++ b/es/lecciones/procesamiento-basico-de-textos-en-r.md
@@ -266,7 +266,7 @@ Vamos a aplicar las técnicas de la sección previa a un discurso del Estado de 
 Para hacer esto, vamos a combinar la función `readLines` (leer líneas) para cargar el texto en R y la función `paste` (pegar) para combinar todas las líneas en un único objeto. Vamos a crear la URL del archivo de texto usando la función `sprintf` puesto que este formato permitirá su fácil modificación para otras direcciones web[^7][^8].
 
 ```{r}
-base_url <- "https://programminghistorian.org/assets/basic-text-processing-in-r"
+base_url <- "https://github.com/programminghistorian/jekyll/tree/gh-pages/assets/basic-text-processing-in-r"
 url <- sprintf("%s/sotu_text/236.txt", base_url)
 texto <- paste(readLines(url), collapse = "\n")
 ```

--- a/pt/licoes/processamento-basico-texto-r.md
+++ b/pt/licoes/processamento-basico-texto-r.md
@@ -429,7 +429,7 @@ Para tal, vamos combinar a função `readLines` (ler linhas) para carregar o tex
 
 ```{r}
 
-base_url <- "https://programminghistorian.org/assets/basic-text-processing-in-r"
+base_url <- "https://github.com/programminghistorian/jekyll/tree/gh-pages/assets/basic-text-processing-in-r"
 
 url <- sprintf("%s/sotu_text/236.txt", base_url)
 


### PR DESCRIPTION
A reader has written to us, pointing out that the link to the assets directory for /en/lessons/basic-text-processing-in-r, /es/lecciones/procesamiento-basico-de-textos-en-r, and /pt/licoes/processamento-basico-texto-r has been written incorrectly as https://programminghistorian.org/assets/basic-text-processing-in-r. The correct full link is: https://github.com/programminghistorian/jekyll/tree/gh-pages/assets/basic-text-processing-in-r.

N.B. As this is a link within code, it is not written as a 'relative' link but is given in full.

Closes #2603 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [ ] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [ ] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
