### PR TITLE
Update extracting-illustrated-pages.md

### DIFF
--- a/en/lessons/extracting-illustrated-pages.md
+++ b/en/lessons/extracting-illustrated-pages.md
@@ -75,7 +75,7 @@ More experienced readers may wish to simply install the dependencies and run the
 - `hathitrust-api` ([Install docs](https://github.com/rlmv/hathitrust-api))
 - `internetarchive` ([Install docs](https://archive.org/services/docs/api/internetarchive/))
 - `jupyter` ([Install docs](https://jupyter.org/install))
-- `requests` ([Install docs](https://requests.readthedocs.io/en/master/)) [creator recommends `pipenv` installation; for `pip` install see [PyPI](https://pypi.org/project/requests2/)]
+- `requests` ([Install docs](https://requests.readthedocs.io/en/latest/user/install/#install)) [creator recommends `pipenv` installation; for `pip` install see [PyPI](https://pypi.org/project/requests2/)]
 
 ## Lesson Files
 


### PR DESCRIPTION
I am replacing a broken link <https://requests.readthedocs.io/en/master/> at line 78 of [Extracting Illustrated Pages from Digital Libraries with Python](https://programminghistorian.org/en/lessons/extracting-illustrated-pages) with <https://requests.readthedocs.io/en/latest/user/install/#install>.

Closes #2607 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
