### PR TITLE
Issue 2680

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1254,7 +1254,7 @@
   status: volunteer
 
 - name: Sofia Papastamkou
-  email: spapastamkou@gmail.com
+  email: francais@programminghistorian.org
   twitter: s_papastamkou
   github: spapastamkou
   team: true
@@ -1427,7 +1427,7 @@
 
 - name: Riva Quiroga
   twitter: rivaquiroga
-  email: riva.quiroga@uc.cl
+  email: espanol@programminghistorian.org
   github: rivaquiroga
   team: true
   team_start: 2019
@@ -1625,7 +1625,7 @@
 
 - name: Daniel Alves
   twitter: danielalvesfcsh
-  email: dra@fcsh.unl.pt
+  email: portugues@programminghistorian.org
   github: DanielAlvesLABDH
   orcid: 0000-0002-3541-8197
   team: true
@@ -1766,7 +1766,7 @@
 - name: Alex Wermer-Colan
   github: hawc2
   twitter: alexwermercolan
-  email: alwermercolan@gmail.com
+  email: english@programminghistorian.org
   url: "http://www.alexwermercolan.com/"
   team: true
   team_start: 2020

--- a/assets/forms/Formulaire.Tutoriel.txt
+++ b/assets/forms/Formulaire.Tutoriel.txt
@@ -2,10 +2,10 @@
 
 Si vous souhaitez écrire un tutoriel et le soumettre au Programming Historian, merci de remplir cette fiche en fournissant toutes les informations qui permettront au comité éditorial de discuter de votre idée. Pour toute question sur ce formulaire, merci de contacter directement notre rédacteur ou rédactrice en chef:
 
-Anglais: Alex Wermer-Colan (alex.wermer-colan@temple.edu)
-Espagnol: Riva Quiroga (riva.quiroga@uc.cl)
-Français: Sofia Papastamkou (spapastamkou@gmail.com)
-Portugais: Daniel Alves (dra@fcsh.unl.pt)
+Anglais: Alex Wermer-Colan (english@programminghistorian.org)
+Espagnol: Riva Quiroga (espanol@programminghistorian.org)
+Français: Sofia Papastamkou (francais@programminghistorian.org)
+Portugais: Daniel Alves (portugues@programminghistorian.org)
 
 
 ## Vous

--- a/assets/forms/Formulario.Consulta.Leccion.txt
+++ b/assets/forms/Formulario.Consulta.Leccion.txt
@@ -2,10 +2,10 @@
 
 Si estás interesado en escribir un tutorial y enviarlo a Programming Historian, por favor llena este formulario para darle al Consejo Editorial suficientes detalles para valorar tu idea. Si estás teniendo problemas con el formulario puedes contactar al Jefe de Redacción directamente:
 
-Inglés: Alex Wermer-Colan (alex.wermer-colan@temple.edu)
-Español: Riva Quiroga (riva.quiroga@uc.cl)
-Francés: Sofia Papastamkou (spapastamkou@gmail.com)
-Portugués: Daniel Alves (dra@fcsh.unl.pt)
+Inglés: Alex Wermer-Colan (english@programminghistorian.org)
+Español: Riva Quiroga (espanol@programminghistorian.org)
+Francés: Sofia Papastamkou (francais@programminghistorian.org)
+Portugués: Daniel Alves (portugues@programminghistorian.org)
 
 ## Acerca de ti
 1. Nombre

--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -2,10 +2,10 @@
 
 If you are interested in writing a lesson and submitting it to the Programming Historian, please fill in this form to give the Editorial Board enough detail to comment on your idea. If you are experiencing difficulty with the form you can contact our Managing Editor directly:
 
-English: Alex Wermer-Colan (alex.wermer-colan@temple.edu)
-Spanish: Riva Quiroga (riva.quiroga@uc.cl)
-French: Sofia Papastamkou (spapastamkou@gmail.com)
-Portuguese: Daniel Alves (dra@fcsh.unl.pt)
+English: Alex Wermer-Colan (english@programminghistorian.org)
+Spanish: Riva Quiroga (espanol@programminghistorian.org)
+French: Sofia Papastamkou (francais@programminghistorian.org)
+Portuguese: Daniel Alves (portugues@programminghistorian.org)
 
 
 ## About You

--- a/assets/forms/formulario.proposta.licao.txt
+++ b/assets/forms/formulario.proposta.licao.txt
@@ -2,10 +2,10 @@
 
 Se estiver interessado em escrever uma lição e enviá-la ao Programming Historian, preencha este formulário para fornecer ao Conselho Editorial detalhes suficientes para comentar a sua ideia. Se tiver dificuldades com o formulário, pode entrar em contato com o nosso Editor-chefe diretamente: 
 
-Inglês: Alex Wermer-Colan (alex.wermer-colan@temple.edu)
-Espanhol: Riva Quiroga (riva.quiroga@uc.cl)
-Francês: Sofia Papastamkou (spapastamkou@gmail.com)
-Português: Daniel Alves (dra@fcsh.unl.pt)
+Inglês: Alex Wermer-Colan (english@programminghistorian.org)
+Espanhol: Riva Quiroga (espanol@programminghistorian.org)
+Francês: Sofia Papastamkou (francais@programminghistorian.org)
+Português: Daniel Alves (portugues@programminghistorian.org)
 
 ## Sobre o autor
 1. Nome

--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -15,7 +15,7 @@ skip_validation: true
 <h2 class="noclear">Step 3: <a href="#step-3-submitting-a-new-lesson">Submitting a New Lesson</a></h2>  
 
 
-These guidelines have been developed to help you understand the process of creating a tutorial for the English *Programming Historian*. They include practical and philosophical details of the tutorial writing process, as well as an indication of the workflow and the peer review process. If at any time you are unclear, please email the managing editor, {% include managing-editor.html lang=page.lang %}.
+These guidelines have been developed to help you understand the process of creating a tutorial for the English *Programming Historian*. They include practical and philosophical details of the tutorial writing process, as well as an indication of the workflow and the peer review process. If at any time you are unclear, please [email the managing editor](mailto:english@programminghistorian.org).
 
 ## Step 1: Proposing a New Lesson
 
@@ -25,7 +25,7 @@ We welcome tutorials relevant to the humanities, pitched at any level of technic
 The scope and length of the tutorial should be appropriate to the complexity of the task. Tutorials should not exceed 8,000 words (including code). Shorter lessons are welcome. Longer lessons may need to be split into multiple tutorials.
 </div>
 
-If you have an idea for a new lesson, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and send it to {% include managing-editor.html lang=page.lang %}.
+If you have an idea for a new lesson, complete a lesson [proposal form](/assets/forms/Lesson.Query.Form.txt) and send it to [the managing editor](mailto:english@programminghistorian.org).
 
 You can get a sense of what we publish by looking through our [published lessons]({{site.baseurl}}/en/lessons), reading our [reviewer guidelines]({{site.baseurl}}/en/reviewer-guidelines) or browsing [lessons in development](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/lessons). Please also take a moment to check our [Lesson Concordance document](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) to see which methods we have already covered in our published or forthcoming lessons. 
 

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -16,7 +16,7 @@ Writing a tutorial is one of the best ways to teach yourself particular skills a
 
 We don't simply accept or reject articles like traditional journals. Our editors collaborate with you to help craft your essay to be as clear and as useful as possible--a great way to improve your technical writing skills. Please read more about our [submission process]({{site.baseurl}}/en/author-guidelines).
 
-If you'd like to propose a lesson (for you or for someone else to write), email {% include managing-editor.html lang=page.lang %}.
+If you'd like to propose a lesson (for you or for someone else to write), [email the managing editor](mailto:english@programminghistorian.org).
 
 
 ## Edit lessons
@@ -61,7 +61,7 @@ The English edition of the project is indexed by the [Directory of Open Access J
 
 ## Make a suggestion
 
-No matter how you'd like to be involved, you can always email {% include managing-editor.html lang=page.lang %} with any comments, questions, complaints, or suggestions.  We endeavor to respond to all emails promptly.
+No matter how you'd like to be involved, you can always [email the managing editor](mailto:english@programminghistorian.org) with any comments, questions, complaints, or suggestions.  We endeavor to respond to all emails promptly.
 
 
 Thanks for your help in improving the _Programming Historian_!

--- a/es/contribuciones.md
+++ b/es/contribuciones.md
@@ -27,7 +27,7 @@ Escribir un tutorial es una de las mejores maneras de profundizar en un método 
 
 Nuestro objetivo no es aceptar o rechazar artículos como una revista académica tradicional. Por el contrario, nuestro equipo editorial colaborará y te ayudará a mejorar la escritura de la lección y cómo plantearla de manera adecuada para que resulte clara y útil. Nuestro proceso de revisión contribuye a mejorar las lecciones y tu destreza a la hora de escribir sobre temas técnicos o especializados. Por favor, no dudes en leer más sobre el proceso de [envío].
 
-Si quieres proponer una lección (escrita por ti o por otra persona), envía un email a {% include managing-editor.html lang=page.lang %}.
+Si quieres proponer una lección (escrita por ti o por otra persona), [envía un email al Jefe de redacción](mailto:espanol@programminghistorian.org).
 
 ## Conviértete en editor
 
@@ -62,7 +62,7 @@ Este proyecto se propone demostrar cómo deben ser las publicaciones académicas
 
 ## O simplemente ponte en contacto con nosotros
 
-Si se te ocurren más formas de participación, siempre puedes escribirnos un email a {% include managing-editor.html lang=page.lang %} con comentarios, preguntas, quejas o sugerencias. Nos comprometemos a responder a todos los mensajes tan pronto como sea posible.
+Si se te ocurren más formas de participación, siempre puedes [escribirnos un email al Jefe de redacción](mailto:espanol@programminghistorian.org) con comentarios, preguntas, quejas o sugerencias. Nos comprometemos a responder a todos los mensajes tan pronto como sea posible.
 
 ¡Gracias por ayudarnos a mejorar _Programming Historian en español_!
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -15,7 +15,7 @@ skip_validation: true
 <h2 class="noclear">Paso 3: <a href="#paso-3-enviando-una-nueva-lección">Enviar una nueva lección</a></h2>
 
 
-Estas directrices han sido desarrolladas para ayudarte a entender el proceso de creación de un tutorial para *Programming Historian* en Español. Incluyen detalles prácticos sobre el proceso de redacción de un tutorial, así como indicaciones sobre el flujo de trabajo y el proceso de revisión entre pares. Si en algún momento hay algo que no te queda claro, por favor envía un correo electrónico a {% include managing-editor.html lang=page.lang %}.
+Estas directrices han sido desarrolladas para ayudarte a entender el proceso de creación de un tutorial para *Programming Historian* en Español. Incluyen detalles prácticos sobre el proceso de redacción de un tutorial, así como indicaciones sobre el flujo de trabajo y el proceso de revisión entre pares. Si en algún momento hay algo que no te queda claro, por favor [envía un correo electrónico a Jefe de redacción](mailto:espanol@programminghistorian.org).
 
 ## Paso 1: Proponer una nueva lección
 
@@ -23,7 +23,7 @@ Estas directrices han sido desarrolladas para ayudarte a entender el proceso de 
 Aceptamos tutoriales relevantes para las humanidades, dirigidos a cualquier nivel de aptitud técnica y experiencia, que se centren en un problema o proceso, que puedan ser sostenibles a largo plazo y que estén dirigidos a una audiencia global. El alcance y la longitud del tutorial han de corresponderse con la complejidad de la tarea que se enseña. Los tutoriales no deben exceder las 8.000 palabras (incluyendo el código) sin el permiso explícito del editor, el que se otorgará únicamente en circunstancias excepcionales. Esperamos que la mayoría de las lecciones tengan entre 4.000 y 6.000 palabras. Si resulta pertinente, puede que solicitemos dividir en varios tutoriales las lecciones más largas.
 </div>
 
-Si tienes una idea para una nueva lección, completa el [formulario de propuestas](/assets/forms/Formulario.Consulta.Leccion.txt) y envíalo a {% include managing-editor.html lang=page.lang %}.
+Si tienes una idea para una nueva lección, completa el [formulario de propuestas](/assets/forms/Formulario.Consulta.Leccion.txt) y [envíalo a Jefe de redacción](mailto:espanol@programminghistorian.org).
 
 Para tener una idea de lo que publicamos, consulta nuestras [lecciones ya publicadas]({{site.baseurl}}/es/lecciones), lee nuestra [guía para revisores]({{site.baseurl}}/es/guia-para-revisores) o explora [las lecciones actualmente en desarrollo](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/es/lecciones). Animamos el envío de propuestas de lecciones sobre temas ya cubiertos o en desarrollo, siempre que la lección nueva haga una contribución propia. Revisa nuestro documento de [Concordancia de Lecciones](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) para ver qué métodos ya han sido cubiertos en nuestras lecciones publicadas o por publicar en alguno de los cuatro idiomas de Programming Historian.
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -15,7 +15,7 @@ skip_validation: true
 <h2 class="noclear">Paso 3: <a href="#paso-3-enviando-una-nueva-lección">Enviar una nueva lección</a></h2>
 
 
-Estas directrices han sido desarrolladas para ayudarte a entender el proceso de creación de un tutorial para *Programming Historian* en Español. Incluyen detalles prácticos sobre el proceso de redacción de un tutorial, así como indicaciones sobre el flujo de trabajo y el proceso de revisión entre pares. Si en algún momento hay algo que no te queda claro, por favor [envía un correo electrónico a Jefe de redacción](mailto:espanol@programminghistorian.org).
+Estas directrices han sido desarrolladas para ayudarte a entender el proceso de creación de un tutorial para *Programming Historian* en Español. Incluyen detalles prácticos sobre el proceso de redacción de un tutorial, así como indicaciones sobre el flujo de trabajo y el proceso de revisión entre pares. Si en algún momento hay algo que no te queda claro, por favor [envía un correo electrónico al Jefe de redacción](mailto:espanol@programminghistorian.org).
 
 ## Paso 1: Proponer una nueva lección
 
@@ -23,7 +23,7 @@ Estas directrices han sido desarrolladas para ayudarte a entender el proceso de 
 Aceptamos tutoriales relevantes para las humanidades, dirigidos a cualquier nivel de aptitud técnica y experiencia, que se centren en un problema o proceso, que puedan ser sostenibles a largo plazo y que estén dirigidos a una audiencia global. El alcance y la longitud del tutorial han de corresponderse con la complejidad de la tarea que se enseña. Los tutoriales no deben exceder las 8.000 palabras (incluyendo el código) sin el permiso explícito del editor, el que se otorgará únicamente en circunstancias excepcionales. Esperamos que la mayoría de las lecciones tengan entre 4.000 y 6.000 palabras. Si resulta pertinente, puede que solicitemos dividir en varios tutoriales las lecciones más largas.
 </div>
 
-Si tienes una idea para una nueva lección, completa el [formulario de propuestas](/assets/forms/Formulario.Consulta.Leccion.txt) y [envíalo a Jefe de redacción](mailto:espanol@programminghistorian.org).
+Si tienes una idea para una nueva lección, completa el [formulario de propuestas](/assets/forms/Formulario.Consulta.Leccion.txt) y [envíalo al Jefe de redacción](mailto:espanol@programminghistorian.org).
 
 Para tener una idea de lo que publicamos, consulta nuestras [lecciones ya publicadas]({{site.baseurl}}/es/lecciones), lee nuestra [guía para revisores]({{site.baseurl}}/es/guia-para-revisores) o explora [las lecciones actualmente en desarrollo](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/es/lecciones). Animamos el envío de propuestas de lecciones sobre temas ya cubiertos o en desarrollo, siempre que la lección nueva haga una contribución propia. Revisa nuestro documento de [Concordancia de Lecciones](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) para ver qué métodos ya han sido cubiertos en nuestras lecciones publicadas o por publicar en alguno de los cuatro idiomas de Programming Historian.
 

--- a/fr/consignes-auteurs.md
+++ b/fr/consignes-auteurs.md
@@ -12,7 +12,7 @@ skip_validation: true
 <h2 class="noclear">Étape 2: <a href="#étape-2-rédaction-et-mise-en-forme">rédaction et mise en forme</a></h2>
 <h2 class="noclear">Étape 3: <a href="#étape-3-soumettre-une-nouvelle-leçon">soumettre une nouvelle leçon</a></h2>  
 
-Ces consignes ont été développées pour vous permettre de comprendre comment s'organise l'écriture d'un tutoriel pour le *Programming Historian en français*. Elles fournissent des détails pratiques, des informations sur la philosophie de la revue, ses workflows et l'évaluation ouverte par les pairs. Si pour quelque raison que ce soit elles nous vous paraissent pas claires, n'hésitez pas à contacter notre rédacteur/rédactrice en chef {% include managing-editor.html lang=page.lang %}.  
+Ces consignes ont été développées pour vous permettre de comprendre comment s'organise l'écriture d'un tutoriel pour le *Programming Historian en français*. Elles fournissent des détails pratiques, des informations sur la philosophie de la revue, ses workflows et l'évaluation ouverte par les pairs. Si pour quelque raison que ce soit elles nous vous paraissent pas claires, n'hésitez pas [à contacter notre rédacteur/rédactrice en chef](mailto:francais@programminghistorian.org).
 
 ## Étape 1: proposer une nouvelle leçon
 
@@ -21,7 +21,7 @@ Nous vous invitons à nous soumettre des tutoriels pertinents pour les sciences 
 La portée et la longueur du tutoriel doivent être appropriées à la complexité de la tâche qui y est expliquée. La longueur des tutoriels ne doit pas excéder 8000 mots (en incluant le code source) et nous encourageons la soumission de leçons plus courtes. Celles qui seraient plus longues sont susceptibles d'être divisées en plusieurs tutoriels.
 </div>
 
-Si vous avez une idée pour une nouvelle leçon, merci de compléter un [formulaire de proposition](/assets/forms/Formulaire.Tutoriel.txt) et contacter {% include managing-editor.html lang=page.lang %} pour discuter de votre idée.
+Si vous avez une idée pour une nouvelle leçon, merci de compléter un [formulaire de proposition](/assets/forms/Formulaire.Tutoriel.txt) et [contacter notre rédacteur/rédactrice en chef](mailto:francais@programminghistorian.org) pour discuter de votre idée.
 
 Vous pouvez avoir une meilleure idée de ce que nous publions en consultant nos [leçons en ligne](/fr/lecons/), en lisant nos [consignes aux évaluateurs et évaluatrices](/fr/consignes-evaluateurs), ou encore en parcourant les [leçons en cours de développement](https://github.com/programminghistorian/ph-submissions/issues). Merci de prendre aussi le temps de consulter notre table de [concordance des leçons](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) afin de voir quelles méthodes ont déjà été traitées dans nos tutoriels publiés ou à venir.
 

--- a/fr/contribuer.md
+++ b/fr/contribuer.md
@@ -16,7 +16,7 @@ Le _Programming Historian en français_ est porté par des volontaires. Leur én
 
 Nous sommes loin de simplement accepter ou rejeter des articles, comme le font les revues traditionnelles. Nos rédacteurs et rédactrices collaborent avec vous pour construire un texte aussi clair et utile que possible, ce qui vous permet de parfaire vos compétences et techniques d'écriture. N'hésitez pas à apprendre davantage sur notre procédure de [dépôt] [depot] de propositions.
 
-Si vous souhaitez proposer une leçon, que vous en soyez l'auteur(e) ou pas, merci d'envoyer un courriel à {% include managing-editor.html lang=page.lang %}.
+Si vous souhaitez proposer une leçon, que vous en soyez l'auteur(e) ou pas, merci [d'envoyer un courriel à notre rédacteur/rédactrice en chef](mailto:francais@programminghistorian.org).
 
 ## Assurer le suivi éditorial d'une leçon
 
@@ -59,7 +59,7 @@ L'édition anglais est aussi indexé dans le [Directory of Open Access Journals]
 
 ## Faire une suggestion
 
-Pour vous impliquer comme vous le préférez, merci de contacter {% include managing-editor.html lang=page.lang %} pour lui faire part de vos commentaires, vos questions, vos remarques ou suggestions. Nous faisons notre possible pour répondre aux courriels rapidement.
+Pour vous impliquer comme vous le préférez, merci de [contacter notre rédacteur/rédactrice en chef](mailto:francais@programminghistorian.org) pour lui faire part de vos commentaires, vos questions, vos remarques ou suggestions. Nous faisons notre possible pour répondre aux courriels rapidement.
 
 
 Merci de nous aider à améliorer le _Programming Historian en français_!

--- a/pt/contribua.md
+++ b/pt/contribua.md
@@ -16,7 +16,7 @@ Escrever um tutorial é uma das melhores formas de se ensinar competências espe
 
 Simplesmente não aceitamos ou rejeitamos artigos como periódicos tradicionais. Os nossos editores vão acompanhar o processo para ajudar a elaborar a lição, para que esta seja o mais clara e útil possível. Essa é uma excelente forma de melhorar as suas capacidades de escrita sobre temas técnicos. Por favor, leia mais sobre o nosso [processo de submissão][submissions].
 
-Se desejar propor uma lição (escrita por si ou para outra pessoa escrever), envie um email para {% include managing-editor.html lang=page.lang %}.
+Se desejar propor uma lição (escrita por si ou para outra pessoa escrever), [envie um email ao Editor-Chefe](mailto:portugues@programminghistorian.org).
 
 ## Edite lições
 
@@ -57,7 +57,7 @@ A versão em Inglês do projeto está indexada no [Directory of Open Access Jour
 
 ## Envie uma sugestão
 
-Independente da forma como gostaria de se envolver no projeto, pode sempre enviar um email para {% include managing-editor.html lang=page.lang %} com comentários, perguntas, reclamações ou sugestões. Nós iremos nos esforçar para responder prontamente a todas as mensagens de email.
+Independente da forma como gostaria de se envolver no projeto, pode sempre [enviar um email ao Editor-Chefe](mailto:portugues@programminghistorian.org)  com comentários, perguntas, reclamações ou sugestões. Nós iremos nos esforçar para responder prontamente a todas as mensagens de email.
 
 Obrigado pela sua ajuda em melhorar o _Programming Historian em português_!
 

--- a/pt/directrizes-autor.md
+++ b/pt/directrizes-autor.md
@@ -13,7 +13,7 @@ original: author-guidelines
 <h2 class="noclear">Etapa 3: <a href="#etapa-3-submeter-uma-nova-lição">Submeter uma nova lição</a></h2>
 
 
-Estas directrizes foram desenvolvidas para ajudar a entender o processo de criação de um tutorial para o *Programming Historian em português*. Estão incluídos detalhes práticos e teóricos do processo de escrita do tutorial, bem como a indicação do fluxo de trabalho e do processo de revisão por pares. Se a qualquer momento não estiver seguro, basta enviar um email ao editor {% include managing-editor.html lang=page.lang %}.
+Estas directrizes foram desenvolvidas para ajudar a entender o processo de criação de um tutorial para o *Programming Historian em português*. Estão incluídos detalhes práticos e teóricos do processo de escrita do tutorial, bem como a indicação do fluxo de trabalho e do processo de revisão por pares. Se a qualquer momento não estiver seguro, basta [enviar um email ao Editor-Chefe](mailto:portugues@programminghistorian.org).
 
 ## Etapa 1: Propor uma nova lição
 
@@ -23,7 +23,7 @@ Procuramos lições relevantes para as Humanidades sobre um problema ou processo
 O âmbito e extensão da lição devem ser adequados à  complexidade da tarefa, mas não devem ter mais de 8.000 palavras (incluindo códigos). Lições mais curtas são bem-vindas. Lições mais longas podem precisar de ser divididas.
 </div>
 
-Se tem uma ideia para uma nova lição preencha o [formulário de proposta de lição](/assets/forms/formulario.proposta.licao.txt) e envie para {% include managing-editor.html lang=page.lang %}.
+Se tem uma ideia para uma nova lição preencha o [formulário de proposta de lição](/assets/forms/formulario.proposta.licao.txt) e [enviar ao Editor-Chefe](mailto:portugues@programminghistorian.org).
 
 Para ter uma ideia do que publicamos consulte as [lições publicadas]({{site.baseurl}}/pt/licoes), leia as nossas [orientações para revisores]({{site.baseurl}}/pt/directrizes-revisor) ou navegue pelas [lições em desenvolvimento](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/pt/licoes). Por favor, reserve um momento para verificar o nosso documento de [Concordância de Lições](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) para ver quais os métodos já abordados nas nossas lições publicadas ou futuras.
 


### PR DESCRIPTION
I am updating the following pages of our website to reflect that we have set up 4 new dedicated email accounts for our Managing Editors:

 /en/contribute.md
/es/contribuciones.md
/fr/contribuer.md
/pt/contribua.md

 /en/author-guidelines.md
/es/guia-para-autores.md
/fr/consignes-auteurs.md
/pt/directrizes-autor.md

/forms/Lesson.Query.Form.txt
/forms/Formulario.Consulta.Leccion.txt
/forms/Formulaire.Tutoriel.txt
/forms/formulario.proposta.licao.txt

 _data/ph_authors.yml

Closes #2680

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
