### PR TITLE
Issue 2696

### DIFF
--- a/en/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/en/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -524,7 +524,7 @@ You can customize the current theme of your website by making changes to the fil
 
 Or, you can add in (and further customize, if desired) a theme already created by someone else by searching for "Jekyll themes" or trying one of these resources:
 
-- [Alex Gil's "Ed" theme for minimal digital editions](https://elotroalex.github.io/ed/) and [its documentation](https://elotroalex.github.io/ed/documentation) (free)
+- [Alex Gil's "Ed" theme for minimal digital editions](https://github.com/minicomp/ed/) and [its documentation](https://github.com/minicomp/ed/blob/main/documentation.md) (free)
 - [Rebecca Sutton Koeser's "Digital Edition" theme](https://github.com/emory-libraries-ecds/digitaledition-jekylltheme) (free)
 - The [Jekyll Themes](http://jekyllthemes.org/) directory (free)
 - [JekyllThemes.io](http://jekyllthemes.io/) (free and paid)

--- a/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
+++ b/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
@@ -598,7 +598,7 @@ El diseño visual de un sitio web es referido usualmente como el *tema* (aunque 
 
 Puedes personalizar el tema de tu sitio realizando cambios en los archivos que se encuentran en las carpetas `_sass` y `css`. (lamentablemente, en sus versiones más recientes, Jekyll comenzó a usar SASS en lugar de CSS, lo que hace que sea más difícil aprender a personalizarlas para los no-diseñadores). También puedes añadir (y luego personalizar, si lo deseas) un tema creado por alguien más, a los que puedes acceder realizando una búsqueda con el término "Jekyll themes" en alguno de los siguientes recursos:  
 
-- Tema ["Ed" para ediciones digitales mínimas](https://elotroalex.github.io/ed/), de Alex Gil  (gratis)
+- Tema ["Ed" para ediciones digitales mínimas](https://github.com/minicomp/ed/), de Alex Gil  (gratis)
 - Tema ["Digital Edition"](https://github.com/emory-libraries-ecds/digitaledition-jekylltheme), de Rebecca Sutton Koese (gratis)
 - El directorio de [Jekyll Themes](http://jekyllthemes.org/) (gratis)
 - [JekyllThemes.io](http://jekyllthemes.io/) (gratis y pago)


### PR DESCRIPTION
I'm fixing a broken link in the following lessons:

/en/lessons/building-static-sites-with-jekyll-github-pages
/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages

I am replacing https://elotroalex.github.io/ed/ with the updated link https://github.com/minicomp/ed/. 

In the EN lesson, I'm also replacing https://elotroalex.github.io/ed/documentation
with https://github.com/minicomp/ed/blob/main/documentation.md (this doesn't appear in the ES lesson.

(With the release of the 1.0 gem, Alex Gil's "Ed" theme for minimal digital editions was moved to a new repo).

Closes #2696 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
