### PR TITLE
Update geoparsing-text-with-edinburgh.md

### DIFF
--- a/en/lessons/geoparsing-text-with-edinburgh.md
+++ b/en/lessons/geoparsing-text-with-edinburgh.md
@@ -25,7 +25,7 @@ doi: 10.46430/phen0067
 
 <div class="alert alert-warning"> 
 Readers have reported experiencing difficulties moving through this lesson. We have learned that it is now necessary to obtain an access token to use the Mapbox API. Even if users opt for the free tier, they must provide credit card details to proceed which presents a barrier to many of our users. We are reviewing our options for updating or adaptating this lesson. (Nov. 2022)
-<\div>
+</div>
 
 ## Introduction
 

--- a/en/lessons/geoparsing-text-with-edinburgh.md
+++ b/en/lessons/geoparsing-text-with-edinburgh.md
@@ -23,6 +23,10 @@ doi: 10.46430/phen0067
 
 {% include toc.html %}
 
+<div class="alert alert-warning"> 
+Readers have reported experiencing difficulties moving through this lesson. We have learned that it is now necessary to obtain an access token to use the Mapbox API. Even if users opt for the free tier, they must provide credit card details to proceed which presents a barrier to many of our users. We are reviewing our options for updating or adaptating this lesson. (Nov. 2022)
+<\div>
+
 ## Introduction
 
 This is a lesson on how to use the [Edinburgh Geoparser](https://www.ltg.ed.ac.uk/software/geoparser/).  The Geoparser allows you to process a piece of English-language text and extract and resolve the locations contained within it. Among other uses, geo-resolution of locations makes it possible to map the data.


### PR DESCRIPTION
I am adding an alert-warning box to the lesson [Geoparsing English-Language Text with the Edinburgh Geoparser](https://programminghistorian.org/en/lessons/geoparsing-text-with-edinburgh).

In recent correspondence the author explained that a change was made to the Geoparser in early 2022 which introduced Mapbox instead of Google Maps. The team at Edinburgh think they have now found a way to utilise Mapbox without the need to supply credit card information, and so they are hoping/planning to release a new version of the Geoparser. The new release is likely to be ready at the end of December, or early in the new year. 

Closes #1953


### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
