### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2042,8 +2042,9 @@
   url: "https://pro.univ-lille.fr/antoine-henry/"
   orcid: 0000-0003-4722-4610
   github: icolab
-  team: true
+  team: false
   team_start: 2021
+  team_end: 2022
   institution: Université de Lille
   sortname: Henry
   affiliation:


### PR DESCRIPTION
I am updating `ph_authors.yml` to reflect that Antoine Henry is stepping down from the French team.

To do this, I've changed their team status to `false`, and added a new line that reads `team_end: 2022`

Closes #2767

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
