### PR TITLE
Issue 2800

### DIFF
--- a/assets/forms/Formulaire.Tutoriel.txt
+++ b/assets/forms/Formulaire.Tutoriel.txt
@@ -4,7 +4,7 @@ Si vous souhaitez écrire un tutoriel et le soumettre au Programming Historian, 
 
 Anglais: Alex Wermer-Colan (english@programminghistorian.org)
 Espagnol: Riva Quiroga (espanol@programminghistorian.org)
-Français: Sofia Papastamkou (francais@programminghistorian.org)
+Français: Marie Flesch (francais@programminghistorian.org)
 Portugais: Daniel Alves (portugues@programminghistorian.org)
 
 

--- a/assets/forms/Formulario.Consulta.Leccion.txt
+++ b/assets/forms/Formulario.Consulta.Leccion.txt
@@ -4,7 +4,7 @@ Si estás interesado en escribir un tutorial y enviarlo a Programming Historian,
 
 Inglés: Alex Wermer-Colan (english@programminghistorian.org)
 Español: Riva Quiroga (espanol@programminghistorian.org)
-Francés: Sofia Papastamkou (francais@programminghistorian.org)
+Francés: Marie Flesch (francais@programminghistorian.org)
 Portugués: Daniel Alves (portugues@programminghistorian.org)
 
 ## Acerca de ti

--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -4,7 +4,7 @@ If you are interested in writing a lesson and submitting it to the Programming H
 
 English: Alex Wermer-Colan (english@programminghistorian.org)
 Spanish: Riva Quiroga (espanol@programminghistorian.org)
-French: Sofia Papastamkou (francais@programminghistorian.org)
+French: Marie Flesch (francais@programminghistorian.org)
 Portuguese: Daniel Alves (portugues@programminghistorian.org)
 
 

--- a/assets/forms/formulario.proposta.licao.txt
+++ b/assets/forms/formulario.proposta.licao.txt
@@ -4,7 +4,7 @@ Se estiver interessado em escrever uma lição e enviá-la ao Programming Histor
 
 Inglês: Alex Wermer-Colan (english@programminghistorian.org)
 Espanhol: Riva Quiroga (espanol@programminghistorian.org)
-Francês: Marie Flesh (francais@programminghistorian.org)
+Francês: Marie Flesch (francais@programminghistorian.org)
 Português: Daniel Alves (portugues@programminghistorian.org)
 
 ## Sobre o autor

--- a/assets/forms/formulario.proposta.licao.txt
+++ b/assets/forms/formulario.proposta.licao.txt
@@ -4,7 +4,7 @@ Se estiver interessado em escrever uma lição e enviá-la ao Programming Histor
 
 Inglês: Alex Wermer-Colan (english@programminghistorian.org)
 Espanhol: Riva Quiroga (espanol@programminghistorian.org)
-Francês: Sofia Papastamkou (francais@programminghistorian.org)
+Francês: Marie Flesh (francais@programminghistorian.org)
 Português: Daniel Alves (portugues@programminghistorian.org)
 
 ## Sobre o autor


### PR DESCRIPTION
I am updating the FR Managing Editor's name from Sofia Papastamkou to Marie Flesch on our Lesson Query forms (across EN, ES, FR and PT)

 EN https://programminghistorian.org/assets/forms/Lesson.Query.Form.txt
 ES https://programminghistorian.org/assets/forms/Formulario.Consulta.Leccion.txt
 FR https://programminghistorian.org/assets/forms/Formulaire.Tutoriel.txt
 PT https://programminghistorian.org/assets/forms/formulario.proposta.licao.txt

Closes #2800 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
