### PR TITLE
Issue 2832

### DIFF
--- a/en/editor-guidelines.md
+++ b/en/editor-guidelines.md
@@ -289,6 +289,7 @@ We represent our lessons using an old image that we feel captures some element o
 Here are a few places to look for lesson images:
 
  - The [British Library](https://www.flickr.com/photos/britishlibrary)
+ - The [Internet Archive Book Images](https://archive.org/details/bookimages)
  - The [Virtual Manuscript Library of Switzerland](https://www.flickr.com/photos/e-codices)
  - The [Library of Congress Maps](http://www.loc.gov/maps/collections)
 

--- a/es/guia-editor.md
+++ b/es/guia-editor.md
@@ -321,6 +321,7 @@ Puedes buscar imágenes en los recursos siguientes:
 
  - [Europeana](http://www.europeana.eu/portal/en)
  - [British Library](https://www.flickr.com/photos/britishlibrary)
+ - [Internet Archive Book Images](https://archive.org/details/bookimages)
  - [Virtual Manuscript Library of Switzerland](https://www.flickr.com/photos/e-codices)
  - [Library of Congress Maps](http://www.loc.gov/maps/collections)
 

--- a/fr/consignes-redacteurs.md
+++ b/fr/consignes-redacteurs.md
@@ -278,6 +278,7 @@ Ci-dessous quelques sites pour chercher des images:
  - [Europeana](https://www.europeana.eu)
  - The [Virtual Manuscript Library of Switzerland](https://www.flickr.com/photos/e-codices)
  - The [British Library](https://www.flickr.com/photos/britishlibrary)
+ - The [Internet Archive Book Images](https://archive.org/details/bookimages)
  - The [Library of Congress Maps](http://www.loc.gov/maps/collections)
 
 

--- a/pt/directrizes-editor.md
+++ b/pt/directrizes-editor.md
@@ -291,6 +291,7 @@ Representamos as lições usando uma imagem antiga que consideramos capturar alg
 Aqui estão alguns locais para procurar imagens para a lição:
 
  - [British Library](https://www.flickr.com/photos/britishlibrary)
+ - [Internet Archive Book Images](https://archive.org/details/bookimages)
  - [Virtual Manuscript Library of Switzerland](https://www.flickr.com/photos/e-codices)
  - [Library of Congress Maps](http://www.loc.gov/maps/collections)
 


### PR DESCRIPTION
I am reinstating the link to Internet Archive Book Images Flickr across /en/editor-guidelines, /es/guia-editor, /fr/consignes-redacteurs and /pt/directrizes-editor.

Closes #2832 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing edtor in your PR. Please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines) when writing your PR description~~
- [x] Add the appropriate "Label"
- [x] [Ensure the status checks pass](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#4-check-your-pr-status)
- [x] [Check the live preview of your PR on Netlify](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#5-preview-how-your-pr-looks-when-built-into-html)
- [x] If this PR closes an open issue, add the phrase `Closes #ISSUENUMBER` to the description above

*If you are having difficulty fixing build errors, first consult <https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions> carefully, especially ["Common Build Errors"](https://github.com/programminghistorian/jekyll/wiki/Making-Technical-Contributions#common-build-errors). Then contact the technical team if you need further help.*
