### PR TITLE
Issue 2842

### DIFF
--- a/en/lessons/analyzing-documents-with-tfidf.md
+++ b/en/lessons/analyzing-documents-with-tfidf.md
@@ -251,7 +251,7 @@ A numpy array is list-like but not exactly a list, and I could fill an entire tu
 
 We want every term represented so that each document has the same number of values, one for each word in the corpus. Each item in `transformed_documents_as_array` is an array of its own representing one document from our corpus. As a result of all this, we essentially have a grid where each row is a document, and each column is a term. Imagine one table from a spreadsheet representing each document, like the tables above, but without column or row labels.
 
-To merge the values with their labels, we need two pieces of information: the order of the documents, and the order in which term scores are listed. The order of these documents is easy because it's the same order as the variable `all_docs list`. The full term list is stored in our `vectorizer` variable, and it's in the same order that each item in `transformed_documents_as_array` stores values. We can use the `the TFIDFVectorizer` class's `get_feature_names()` method to get that list, and each row of data (one document's __tf-idf__ scores) can be rejoined with the term list. (For more details on pandas dataframes, see the lesson ["Visualizing Data with Bokeh and Pandas"](/en/lessons/visualizing-with-bokeh).)
+To merge the values with their labels, we need two pieces of information: the order of the documents, and the order in which term scores are listed. The order of these documents is easy because it's the same order as the variable `all_docs list`. The full term list is stored in our `vectorizer` variable, and it's in the same order that each item in `transformed_documents_as_array` stores values. We can use the `the TFIDFVectorizer` class's `get_feature_names_out()` method to get that list, and each row of data (one document's __tf-idf__ scores) can be rejoined with the term list. (For more details on pandas dataframes, see the lesson ["Visualizing Data with Bokeh and Pandas"](/en/lessons/visualizing-with-bokeh).)
 
 ```python
 import pandas as pd
@@ -265,7 +265,7 @@ output_filenames = [str(txt_file).replace(".txt", ".csv").replace("txt/", "tf_id
 # loop each item in transformed_documents_as_array, using enumerate to keep track of the current position
 for counter, doc in enumerate(transformed_documents_as_array):
     # construct a dataframe
-    tf_idf_tuples = list(zip(vectorizer.get_feature_names(), doc))
+    tf_idf_tuples = list(zip(vectorizer.get_feature_names_out(), doc))
     one_doc_as_df = pd.DataFrame.from_records(tf_idf_tuples, columns=['term', 'score']).sort_values(by='score', ascending=False).reset_index(drop=True)
 
     # output to a csv using the enumerated value for the filename

--- a/fr/lecons/analyse-de-documents-avec-tfidf.md
+++ b/fr/lecons/analyse-de-documents-avec-tfidf.md
@@ -268,7 +268,7 @@ Un tableau NumPy ressemble à une liste sans y être identique. Je pourrais réd
 
 Nous voulons que toutes les valeurs soient représentées pour que chaque document soit associé au même nombre de valeurs, soit une pour chaque mot qui existe dans le corpus. Chaque ligne du tableau `documents_transformes_tableau` est elle-même un tableau qui représente un des documents du corpus. Nous disposons donc essentiellement d'une grille dans laquelle chaque ligne représente un document et chaque colonne, un mot. Imaginez un tableau semblable à ceux des sections précédentes pour chaque document, mais sans étiquettes pour identifier les lignes et les colonnes.
 
-Pour combiner les valeurs avec leurs étiquettes, il nous faut deux éléments d'information&#x202F;: l'ordre des documents et et l’ordre des tf-idf obtenu pour chaque mot. L'ordre des documents est facile à obtenir puisqu'il s'agit du même que dans la liste `tous_documents`. La liste de tous les mots du corpus, elle, est stockée dans la variable `vectoriseur` et elle suit le même ordre qu'utilise `documents_transformes_tableau` pour emmagasiner les données. Nous pouvons utiliser la méthode `get_feature_names()` de la classe `TFIDFVectorizer` pour accéder à cette liste de mots. Puis, chaque ligne de `documents_transformes_tableau` (qui contient les valeurs **tf-idf** d'un document) peut être jumelée avec la liste de mots. Pour plus de détails sur les structures de données de type DataFrame du module Pandas de Python, veuillez consulter la leçon [&laquo;&#x202F;Visualizing Data with Bokeh and Pandas&#x202F;&raquo;](/en/lessons/visualizing-with-bokeh).
+Pour combiner les valeurs avec leurs étiquettes, il nous faut deux éléments d'information&#x202F;: l'ordre des documents et et l’ordre des tf-idf obtenu pour chaque mot. L'ordre des documents est facile à obtenir puisqu'il s'agit du même que dans la liste `tous_documents`. La liste de tous les mots du corpus, elle, est stockée dans la variable `vectoriseur` et elle suit le même ordre qu'utilise `documents_transformes_tableau` pour emmagasiner les données. Nous pouvons utiliser la méthode `get_feature_names_out()` de la classe `TFIDFVectorizer` pour accéder à cette liste de mots. Puis, chaque ligne de `documents_transformes_tableau` (qui contient les valeurs **tf-idf** d'un document) peut être jumelée avec la liste de mots. Pour plus de détails sur les structures de données de type DataFrame du module Pandas de Python, veuillez consulter la leçon [&laquo;&#x202F;Visualizing Data with Bokeh and Pandas&#x202F;&raquo;](/en/lessons/visualizing-with-bokeh).
 
 ```python
 import pandas as pd
@@ -284,7 +284,7 @@ fichiers_resultats = [str(fichier_txt).replace(".txt", ".csv").replace("txt/", "
 # en utilisant enumerate() pour conserver la trace de la position courante dans le tableau
 for compteur, document in enumerate(documents_transformes_tableau):
     # construire un objet de la classe DataFrame
-    tf_idf_tuples = list(zip(vectoriseur.get_feature_names(), document))
+    tf_idf_tuples = list(zip(vectoriseur.get_feature_names_out(), document))
     un_document_format_df = pd.DataFrame.from_records(tf_idf_tuples, columns=['terme', 'pointage']).sort_values(by='pointage', ascending=False).reset_index(drop=True)
 
     # enregistrer les résultats dans un document CSV, en utilisant


### PR DESCRIPTION
I am updating /en/lessons/analyzing-documents-with-tfidf and /fr/lecons/analyse-de-documents-avec-tfidf to replace the now deprecated function `get_feature_names()` with `get_feature_names_out()`.

Closes #2842 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
