### PR TITLE
Issue 2849

### DIFF
--- a/en/vacancies.md
+++ b/en/vacancies.md
@@ -4,36 +4,4 @@ layout: blank
 redirect_from: /vacancies
 ---
 
-# Appel à candidatures : le Programming Historian en français recrute des rédacteurs et des rédactrices
-
-Le Programming Historian en français recrute de nouveaux membres ! Rejoignez une équipe internationale aux compétences multiples, qui met son expertise des méthodes numériques et quantitatives au service des spécialistes des sciences humaines et sociales.
-
-- Salaire : Volontaire
-- Horaires : ~0,5 jour par quinzaine
-- Lieu : Travail à domicile à distance
-- Date limite de candidature : 31 janvier 2023
-
-__Le Programming Historian, qu'est-ce que c'est ?__
-
-Le _Programming Historian_ publie des tutoriels sur un large éventail de méthodes numériques, de techniques et de flux de travail appliqués à la recherche et à l'enseignement en sciences humaines et sociales. Il s'agit d'une revue qui suit le modèle de diamond open access et dont les contenus sont en accès libre intégral. Elle est disponible en quatre lanques: en anglais, en espagnol, en français et en portugais. Le fonctionnement de chaque version repose sur une équipe de chercheurs et chercheuses en SHS qui la gèrent à titre de volontaires, sans rémunération. Les articles publiés dans chaque langue sont soit des traductions soit des leçons originales ; dans les deux cas, ils ont été soumis à l'évaluation ouverte par les pairs avant d'être publiés.    
-
-Le [_Programming Historian en français_](/fr), en ligne depuis 2019, propose des leçons traduites depuis l'anglais et des leçons initialement écrites en français. D'autres sont en cours de préparation et, afin d'organiser leur évaluation et publication, nous cherchons à renforcer les rangs de notre équipe avec des nouveaux membres. Nous recherchons des personnes ayant une bonne connaissance des méthodes numériques appliquées aux sciences humaines et sociales et [prêtes à s'investir au sein d'une équipe internationale](https://github.com/programminghistorian/jekyll/wiki/Privileges-and-Responsibilities-of-Membership). Nos [consignes aux rédacteurs et aux rédactrices](/fr/consignes-redacteurs) détaillent les tâches pratiques des membres de notre équipe. Les membres du _Programming Historian en français_ peuvent aussi fournir davantage de précisions sur les [valeurs de la revue](/fr/apropos), ainsi que sur l'organisation d'une équipe distribuée dans différentes parties du globe. Le projet étant hébergé sur GitHub, une formation sera assurée en cas de besoin. Merci de noter qu'appartenir à l'équipe se fait à titre volontaire, il n'y a donc pas de rémunération. En échange, il s'agit de gagner une expérience appréciée au sein d'une équipe à compétences multiples, motivée et internationale. 
-
-__Principales missions des rédacteurs et rédactrices :__
-- [assurer le suivi éditorial](/fr/consignes-redacteurs) de leçons originales ou traduites, pour notamment organiser l'évaluation ouverte par les pairs et leur mise en ligne
-- contribuer aux activités de mise à jour du projet qui peuvent nécessiter des opérations ponctuelles de traduction sur les pages du site web
-- participer et contribuer dans la mesure du possible aux activités collectives autour du projet (participation à des manifestations scientifiques et pédagogiques: colloques, ateliers...)
-
-__Connaissances et compétences principalement recherchées :__
-- connaissance et pratique des méthodes numériques/quantitatives appliquées aux sciences humaines et sociales et aux métiers du patrimoine
-- connaissance de l'anglais et capacité de travailler dans une équipe internationale
-- autonomie et disponibilité  
-- engagement [en faveur du libre accès et du logiciel open source](/fr/apropos)   
- 
-__Connaissances et compétences appréciées :__
-- connaissance de l'espagnol ou du portugais pour faciliter la collaboration entre les différentes équipes du _Programming Historian_
-- connaissance ou expérience de l'édition électronique scientifique 
-
-Idéalement, les nouveaux membres doivent s'engager pour une durée de deux ans minimum.
-
-Merci d'envoyer un CV d'une page et un texte d'environ 200 mots expliquant les raisons pour lesquelles vous souhaitez rejoindre le projet à <a href="mailto:francais@programminghistorian.org ">notre rédactrice en chef</a> jusqu'au 31 janvier 2023. 
+Thank you for your interest in working with _Programming Historian_. There are currently no vacancies.

--- a/es/vacantes.md
+++ b/es/vacantes.md
@@ -4,5 +4,5 @@ layout: blank
 original: vacancies
 ---
 
-Gracias por su interés en trabajar con _Programming Historian_. Actualmente no hay vacantes.
+Gracias por tu interés en trabajar en _Programming Historian_. Actualmente no hay vacantes.
 

--- a/es/vacantes.md
+++ b/es/vacantes.md
@@ -4,37 +4,5 @@ layout: blank
 original: vacancies
 ---
 
-# Appel à candidatures : le Programming Historian en français recrute des rédacteurs et des rédactrices
-
-Le Programming Historian en français recrute de nouveaux membres ! Rejoignez une équipe internationale aux compétences multiples, qui met son expertise des méthodes numériques et quantitatives au service des spécialistes des sciences humaines et sociales.
-
-- Salaire : Volontaire
-- Horaires : ~0,5 jour par quinzaine
-- Lieu : Travail à domicile à distance
-- Date limite de candidature : 31 janvier 2023
-
-__Le Programming Historian, qu'est-ce que c'est ?__
-
-Le _Programming Historian_ publie des tutoriels sur un large éventail de méthodes numériques, de techniques et de flux de travail appliqués à la recherche et à l'enseignement en sciences humaines et sociales. Il s'agit d'une revue qui suit le modèle de diamond open access et dont les contenus sont en accès libre intégral. Elle est disponible en quatre lanques: en anglais, en espagnol, en français et en portugais. Le fonctionnement de chaque version repose sur une équipe de chercheurs et chercheuses en SHS qui la gèrent à titre de volontaires, sans rémunération. Les articles publiés dans chaque langue sont soit des traductions soit des leçons originales ; dans les deux cas, ils ont été soumis à l'évaluation ouverte par les pairs avant d'être publiés.    
-
-Le [_Programming Historian en français_](/fr), en ligne depuis 2019, propose des leçons traduites depuis l'anglais et des leçons initialement écrites en français. D'autres sont en cours de préparation et, afin d'organiser leur évaluation et publication, nous cherchons à renforcer les rangs de notre équipe avec des nouveaux membres. Nous recherchons des personnes ayant une bonne connaissance des méthodes numériques appliquées aux sciences humaines et sociales et [prêtes à s'investir au sein d'une équipe internationale](https://github.com/programminghistorian/jekyll/wiki/Privileges-and-Responsibilities-of-Membership). Nos [consignes aux rédacteurs et aux rédactrices](/fr/consignes-redacteurs) détaillent les tâches pratiques des membres de notre équipe. Les membres du _Programming Historian en français_ peuvent aussi fournir davantage de précisions sur les [valeurs de la revue](/fr/apropos), ainsi que sur l'organisation d'une équipe distribuée dans différentes parties du globe. Le projet étant hébergé sur GitHub, une formation sera assurée en cas de besoin. Merci de noter qu'appartenir à l'équipe se fait à titre volontaire, il n'y a donc pas de rémunération. En échange, il s'agit de gagner une expérience appréciée au sein d'une équipe à compétences multiples, motivée et internationale. 
-
-__Principales missions des rédacteurs et rédactrices :__
-- [assurer le suivi éditorial](/fr/consignes-redacteurs) de leçons originales ou traduites, pour notamment organiser l'évaluation ouverte par les pairs et leur mise en ligne
-- contribuer aux activités de mise à jour du projet qui peuvent nécessiter des opérations ponctuelles de traduction sur les pages du site web
-- participer et contribuer dans la mesure du possible aux activités collectives autour du projet (participation à des manifestations scientifiques et pédagogiques: colloques, ateliers...)
-
-__Connaissances et compétences principalement recherchées :__
-- connaissance et pratique des méthodes numériques/quantitatives appliquées aux sciences humaines et sociales et aux métiers du patrimoine
-- connaissance de l'anglais et capacité de travailler dans une équipe internationale
-- autonomie et disponibilité  
-- engagement [en faveur du libre accès et du logiciel open source](/fr/apropos)   
- 
-__Connaissances et compétences appréciées :__
-- connaissance de l'espagnol ou du portugais pour faciliter la collaboration entre les différentes équipes du _Programming Historian_
-- connaissance ou expérience de l'édition électronique scientifique 
-
-Idéalement, les nouveaux membres doivent s'engager pour une durée de deux ans minimum.
-
-Merci d'envoyer un CV d'une page et un texte d'environ 200 mots expliquant les raisons pour lesquelles vous souhaitez rejoindre le projet à <a href="mailto:francais@programminghistorian.org ">notre rédactrice en chef</a> jusqu'au 31 janvier 2023. 
+Gracias por su interés en trabajar con _Programming Historian_. Actualmente no hay vacantes.
 

--- a/fr/postes-vacants.md
+++ b/fr/postes-vacants.md
@@ -4,37 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-# Appel à candidatures : le Programming Historian en français recrute des rédacteurs et des rédactrices
-
-Le Programming Historian en français recrute de nouveaux membres ! Rejoignez une équipe internationale aux compétences multiples, qui met son expertise des méthodes numériques et quantitatives au service des spécialistes des sciences humaines et sociales.
-
-- Salaire : Volontaire
-- Horaires : ~0,5 jour par quinzaine
-- Lieu : Travail à domicile à distance
-- Date limite de candidature : 31 janvier 2023
-
-__Le Programming Historian, qu'est-ce que c'est ?__
-
-Le _Programming Historian_ publie des tutoriels sur un large éventail de méthodes numériques, de techniques et de flux de travail appliqués à la recherche et à l'enseignement en sciences humaines et sociales. Il s'agit d'une revue qui suit le modèle de diamond open access et dont les contenus sont en accès libre intégral. Elle est disponible en quatre lanques: en anglais, en espagnol, en français et en portugais. Le fonctionnement de chaque version repose sur une équipe de chercheurs et chercheuses en SHS qui la gèrent à titre de volontaires, sans rémunération. Les articles publiés dans chaque langue sont soit des traductions soit des leçons originales ; dans les deux cas, ils ont été soumis à l'évaluation ouverte par les pairs avant d'être publiés.    
-
-Le [_Programming Historian en français_](/fr), en ligne depuis 2019, propose des leçons traduites depuis l'anglais et des leçons initialement écrites en français. D'autres sont en cours de préparation et, afin d'organiser leur évaluation et publication, nous cherchons à renforcer les rangs de notre équipe avec des nouveaux membres. Nous recherchons des personnes ayant une bonne connaissance des méthodes numériques appliquées aux sciences humaines et sociales et [prêtes à s'investir au sein d'une équipe internationale](https://github.com/programminghistorian/jekyll/wiki/Privileges-and-Responsibilities-of-Membership). Nos [consignes aux rédacteurs et aux rédactrices](/fr/consignes-redacteurs) détaillent les tâches pratiques des membres de notre équipe. Les membres du _Programming Historian en français_ peuvent aussi fournir davantage de précisions sur les [valeurs de la revue](/fr/apropos), ainsi que sur l'organisation d'une équipe distribuée dans différentes parties du globe. Le projet étant hébergé sur GitHub, une formation sera assurée en cas de besoin. Merci de noter qu'appartenir à l'équipe se fait à titre volontaire, il n'y a donc pas de rémunération. En échange, il s'agit de gagner une expérience appréciée au sein d'une équipe à compétences multiples, motivée et internationale. 
-
-__Principales missions des rédacteurs et rédactrices :__
-- [assurer le suivi éditorial](/fr/consignes-redacteurs) de leçons originales ou traduites, pour notamment organiser l'évaluation ouverte par les pairs et leur mise en ligne
-- contribuer aux activités de mise à jour du projet qui peuvent nécessiter des opérations ponctuelles de traduction sur les pages du site web
-- participer et contribuer dans la mesure du possible aux activités collectives autour du projet (participation à des manifestations scientifiques et pédagogiques: colloques, ateliers...)
-
-__Connaissances et compétences principalement recherchées :__
-- connaissance et pratique des méthodes numériques/quantitatives appliquées aux sciences humaines et sociales et aux métiers du patrimoine
-- connaissance de l'anglais et capacité de travailler dans une équipe internationale
-- autonomie et disponibilité  
-- engagement [en faveur du libre accès et du logiciel open source](/fr/apropos)   
- 
-__Connaissances et compétences appréciées :__
-- connaissance de l'espagnol ou du portugais pour faciliter la collaboration entre les différentes équipes du _Programming Historian_
-- connaissance ou expérience de l'édition électronique scientifique 
-
-Idéalement, les nouveaux membres doivent s'engager pour une durée de deux ans minimum.
-
-Merci d'envoyer un CV d'une page et un texte d'environ 200 mots expliquant les raisons pour lesquelles vous souhaitez rejoindre le projet à <a href="mailto:francais@programminghistorian.org ">notre rédactrice en chef</a> jusqu'au 31 janvier 2023. 
-
+Merci de l'intérêt que vous portez au _Programming Historian_. Il n'y a actuellement aucun poste vacant.

--- a/pt/vagas.md
+++ b/pt/vagas.md
@@ -4,4 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-Obrigado pelo seu interesse em trabalhar com _Programming Historian_. Actualmente não há vagas.
+Obrigado pelo seu interesse em trabalhar com o _Programming Historian_. Actualmente não há vagas.

--- a/pt/vagas.md
+++ b/pt/vagas.md
@@ -4,36 +4,4 @@ layout: blank
 original: vacancies
 ---
 
-# Appel à candidatures : le Programming Historian en français recrute des rédacteurs et des rédactrices
-
-Le Programming Historian en français recrute de nouveaux membres ! Rejoignez une équipe internationale aux compétences multiples, qui met son expertise des méthodes numériques et quantitatives au service des spécialistes des sciences humaines et sociales.
-
-- Salaire : Volontaire
-- Horaires : ~0,5 jour par quinzaine
-- Lieu : Travail à domicile à distance
-- Date limite de candidature : 31 janvier 2023
-
-__Le Programming Historian, qu'est-ce que c'est ?__
-
-Le _Programming Historian_ publie des tutoriels sur un large éventail de méthodes numériques, de techniques et de flux de travail appliqués à la recherche et à l'enseignement en sciences humaines et sociales. Il s'agit d'une revue qui suit le modèle de diamond open access et dont les contenus sont en accès libre intégral. Elle est disponible en quatre lanques: en anglais, en espagnol, en français et en portugais. Le fonctionnement de chaque version repose sur une équipe de chercheurs et chercheuses en SHS qui la gèrent à titre de volontaires, sans rémunération. Les articles publiés dans chaque langue sont soit des traductions soit des leçons originales ; dans les deux cas, ils ont été soumis à l'évaluation ouverte par les pairs avant d'être publiés.    
-
-Le [_Programming Historian en français_](/fr), en ligne depuis 2019, propose des leçons traduites depuis l'anglais et des leçons initialement écrites en français. D'autres sont en cours de préparation et, afin d'organiser leur évaluation et publication, nous cherchons à renforcer les rangs de notre équipe avec des nouveaux membres. Nous recherchons des personnes ayant une bonne connaissance des méthodes numériques appliquées aux sciences humaines et sociales et [prêtes à s'investir au sein d'une équipe internationale](https://github.com/programminghistorian/jekyll/wiki/Privileges-and-Responsibilities-of-Membership). Nos [consignes aux rédacteurs et aux rédactrices](/fr/consignes-redacteurs) détaillent les tâches pratiques des membres de notre équipe. Les membres du _Programming Historian en français_ peuvent aussi fournir davantage de précisions sur les [valeurs de la revue](/fr/apropos), ainsi que sur l'organisation d'une équipe distribuée dans différentes parties du globe. Le projet étant hébergé sur GitHub, une formation sera assurée en cas de besoin. Merci de noter qu'appartenir à l'équipe se fait à titre volontaire, il n'y a donc pas de rémunération. En échange, il s'agit de gagner une expérience appréciée au sein d'une équipe à compétences multiples, motivée et internationale. 
-
-__Principales missions des rédacteurs et rédactrices :__
-- [assurer le suivi éditorial](/fr/consignes-redacteurs) de leçons originales ou traduites, pour notamment organiser l'évaluation ouverte par les pairs et leur mise en ligne
-- contribuer aux activités de mise à jour du projet qui peuvent nécessiter des opérations ponctuelles de traduction sur les pages du site web
-- participer et contribuer dans la mesure du possible aux activités collectives autour du projet (participation à des manifestations scientifiques et pédagogiques: colloques, ateliers...)
-
-__Connaissances et compétences principalement recherchées :__
-- connaissance et pratique des méthodes numériques/quantitatives appliquées aux sciences humaines et sociales et aux métiers du patrimoine
-- connaissance de l'anglais et capacité de travailler dans une équipe internationale
-- autonomie et disponibilité  
-- engagement [en faveur du libre accès et du logiciel open source](/fr/apropos)   
- 
-__Connaissances et compétences appréciées :__
-- connaissance de l'espagnol ou du portugais pour faciliter la collaboration entre les différentes équipes du _Programming Historian_
-- connaissance ou expérience de l'édition électronique scientifique 
-
-Idéalement, les nouveaux membres doivent s'engager pour une durée de deux ans minimum.
-
-Merci d'envoyer un CV d'une page et un texte d'environ 200 mots expliquant les raisons pour lesquelles vous souhaitez rejoindre le projet à <a href="mailto:francais@programminghistorian.org ">notre rédactrice en chef</a> jusqu'au 31 janvier 2023. 
+Obrigado pelo seu interesse em trabalhar com _Programming Historian_. Actualmente não há vagas.


### PR DESCRIPTION
I'm removing the vacancy for new FR editors from our /en/vacancies, /es/vacantes, /fr/postes-vacants, and /pt/vagas pages.

I'm replacing the advertisement text with a holding message on each page, (as before, so these translations have been checked).

EN: Thank you for your interest in working with _Programming Historian_. There are currently no vacancies.
ES: Gracias por su interés en trabajar con _Programming Historian_. Actualmente no hay vacantes.
FR: Merci de l'intérêt que vous portez au _Programming Historian_. Il n'y a actuellement aucun poste vacant.
PT: Obrigado pelo seu interesse em trabalhar com _Programming Historian_. Actualmente não há vagas.

Closes #2849

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
  - [x] **These translations have been checked previously**
