### PR TITLE
Update transcription-automatisee-graphies-non-latines.md

### DIFF
--- a/fr/lecons/transcription-automatisee-graphies-non-latines.md
+++ b/fr/lecons/transcription-automatisee-graphies-non-latines.md
@@ -19,7 +19,7 @@ abstract: Ce tutoriel a pour but de décrire les bonnes pratiques pour la créat
 avatar_alt: Une initiale d'imprimerie représentant en son centre une figure écrivant à la main
 mathjax: true
 lesson-partners: [Jisc, The National Archives]
-partnership-url: /jisc-tna-partnership
+partnership-url: /jisc-tna-partenariat
 doi: 10.46430/phfr0023
 ---
 

--- a/fr/lecons/transcription-automatisee-graphies-non-latines.md
+++ b/fr/lecons/transcription-automatisee-graphies-non-latines.md
@@ -19,7 +19,7 @@ abstract: Ce tutoriel a pour but de décrire les bonnes pratiques pour la créat
 avatar_alt: Une initiale d'imprimerie représentant en son centre une figure écrivant à la main
 mathjax: true
 lesson-partners: [Jisc, The National Archives]
-partnership-url: /jisc-tna-partenariat
+partnership-url: /fr/jisc-tna-partenariat
 doi: 10.46430/phfr0023
 ---
 


### PR DESCRIPTION
I am adjusting the partnership logic in /transcription-automatisee-graphies-non-latines (`partnership-url:`, line 22) so that cliquez ici in the partnership banner leads directly to the FR partnership page.

Closes #2855 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
