### PR TITLE
Spanish Managing Editor Handover (#2890)

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1453,7 +1453,7 @@
     pt: |
       Riva Quiroga é pesquisadora doutoral em Linguística na Universidad Católica de Chile.
   team_roles:
-    - editor
+    - editorial
     - spanish
     - proghist
   status: volunteer

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1123,7 +1123,7 @@
 - name: Jennifer Isasi
   url: "https://jenniferisasi.github.io/"
   twitter: jenniferisve
-  email: jenniferbibat@gmail.com
+  email: espanol@programminghistorian.org
   github: jenniferisasi
   team: true
   team_start: 2018
@@ -1152,6 +1152,7 @@
     - spanish
     - editorial
     - technical
+    - managing
   status: institutionally-supported
 
 - name: Jon MacKay
@@ -1425,7 +1426,7 @@
 
 - name: Riva Quiroga
   twitter: rivaquiroga
-  email: espanol@programminghistorian.org
+  email: riva.quiroga@uc.cl
   github: rivaquiroga
   url: "https://rivaquiroga.cl/"
   orcid: 0000-0002-1147-4135
@@ -1452,7 +1453,7 @@
     pt: |
       Riva Quiroga é pesquisadora doutoral em Linguística na Universidad Católica de Chile.
   team_roles:
-    - managing
+    - editor
     - spanish
     - proghist
   status: volunteer

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1796,7 +1796,6 @@
       Alex Wermer-Colan é responsável pelos Estudos Digitais na Biblioteca Loretta C. Duckworth Scholars Studio da Temple University.
   team_roles:
       - english
-      - editorial
       - technical
       - managing
   status: volunteer

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1150,7 +1150,6 @@
       Jennifer Isasi é professora assistente e pesquisadora digital, diretora da Digital Liberal Arts Research Initiative na Penn State e doutorada em Estudos Hispânicos.
   team_roles:
     - spanish
-    - editorial
     - technical
     - managing
   status: institutionally-supported

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -806,7 +806,7 @@ background_color:
 
 managing_editor:
   en: Alex Wermer-Colan
-  es: Riva Quiroga
+  es: Jennifer Isasi
   fr: Marie Flesch
   pt: Daniel Alves
 

--- a/assets/forms/Formulaire.Tutoriel.txt
+++ b/assets/forms/Formulaire.Tutoriel.txt
@@ -3,7 +3,7 @@
 Si vous souhaitez écrire un tutoriel et le soumettre au Programming Historian, merci de remplir cette fiche en fournissant toutes les informations qui permettront au comité éditorial de discuter de votre idée. Pour toute question sur ce formulaire, merci de contacter directement notre rédacteur ou rédactrice en chef:
 
 Anglais: Alex Wermer-Colan (english@programminghistorian.org)
-Espagnol: Riva Quiroga (espanol@programminghistorian.org)
+Espagnol: Jennifer Isasi (espanol@programminghistorian.org)
 Français: Marie Flesch (francais@programminghistorian.org)
 Portugais: Daniel Alves (portugues@programminghistorian.org)
 

--- a/assets/forms/Formulario.Consulta.Leccion.txt
+++ b/assets/forms/Formulario.Consulta.Leccion.txt
@@ -3,7 +3,7 @@
 Si estás interesado en escribir un tutorial y enviarlo a Programming Historian, por favor llena este formulario para darle al Consejo Editorial suficientes detalles para valorar tu idea. Si estás teniendo problemas con el formulario puedes contactar al Jefe de Redacción directamente:
 
 Inglés: Alex Wermer-Colan (english@programminghistorian.org)
-Español: Riva Quiroga (espanol@programminghistorian.org)
+Español: Jennifer Isasi (espanol@programminghistorian.org)
 Francés: Marie Flesch (francais@programminghistorian.org)
 Portugués: Daniel Alves (portugues@programminghistorian.org)
 

--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -3,7 +3,7 @@
 If you are interested in writing a lesson and submitting it to the Programming Historian, please fill in this form to give the Editorial Board enough detail to comment on your idea. If you are experiencing difficulty with the form you can contact our Managing Editor directly:
 
 English: Alex Wermer-Colan (english@programminghistorian.org)
-Spanish: Riva Quiroga (espanol@programminghistorian.org)
+Spanish: Jennifer Isasi (espanol@programminghistorian.org)
 French: Marie Flesch (francais@programminghistorian.org)
 Portuguese: Daniel Alves (portugues@programminghistorian.org)
 

--- a/assets/forms/formulario.proposta.licao.txt
+++ b/assets/forms/formulario.proposta.licao.txt
@@ -1,9 +1,9 @@
 # Proposta de nova lição para o Programming Historian
 
-Se estiver interessado em escrever uma lição e enviá-la ao Programming Historian, preencha este formulário para fornecer ao Conselho Editorial detalhes suficientes para comentar a sua ideia. Se tiver dificuldades com o formulário, pode entrar em contato com o nosso Editor-chefe diretamente: 
+Se estiver interessado em escrever uma lição e enviá-la ao Programming Historian, preencha este formulário para fornecer ao Conselho Editorial detalhes suficientes para comentar a sua ideia. Se tiver dificuldades com o formulário, pode entrar em contato com o nosso Editor-chefe diretamente:
 
 Inglês: Alex Wermer-Colan (english@programminghistorian.org)
-Espanhol: Riva Quiroga (espanol@programminghistorian.org)
+Espanhol: Jennifer Isasi (espanol@programminghistorian.org)
 Francês: Marie Flesch (francais@programminghistorian.org)
 Português: Daniel Alves (portugues@programminghistorian.org)
 


### PR DESCRIPTION
I'm updating `snippets.yml`, `ph_authors.yml`, and all our lesson query forms.

Closes #2890

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- ~~[ ] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
