### PR TITLE
Issue 2928

### DIFF
--- a/en/about.md
+++ b/en/about.md
@@ -18,7 +18,7 @@ The _Programming Historian_ team is committed to open source values. All contrib
 
 
 ## Diamond Open Access
-All submissions to _Programming Historian_ are published under a [Creative Commons 'CC-BY' license](https://creativecommons.org/licenses/by/4.0/deed.en). This adheres to a '[Diamond](https://doi.org/10.6084/m9.figshare.6900566.v1)' open access model of publishing. The version of record is made freely available without subscription fee or restrictions on access. Authors are permitted to republish their tutorials anywhere. And so can anyone, as long as they cite the original author and respect his or her moral rights.
+All submissions to _Programming Historian_ are published under a [Creative Commons 'CC-BY' license](https://creativecommons.org/licenses/by/4.0/deed.en). This adheres to a '[Diamond](https://commons.wikimedia.org/wiki/File:Open_Access_colours_Venn.svg)' open access model of publishing. The version of record is made freely available without subscription fee or restrictions on access. Authors are permitted to republish their tutorials anywhere. And so can anyone, as long as they cite the original author and respect his or her moral rights.
 
 We do not charge Article Processing Charges (APCs), nor do we charge library subscriptions.
 

--- a/pt/sobre.md
+++ b/pt/sobre.md
@@ -18,7 +18,7 @@ A equipe do _Programming Historian em Português_ está comprometida com os prin
 
 
 ## Acesso Aberto _Diamante_
-Todas as lições para o _Programming Historian em Português_ são publicadas sob uma licença [Creative Commons 'CC-BY'](https://creativecommons.org/licenses/by/4.0/deed.pt). Isto significa um modelo de publicação de acesso aberto '[Diamante](https://figshare.com/articles/dataset/Diamond_open_access_venn/6900566/1)'. Todas as lições são disponibilizadas gratuitamente, sem subscrição paga e sem restrições de acesso. Os autores podem republicar os seus tutoriais em outros locais. Da mesma forma, qualquer um pode fazer o mesmo, desde que cite o autor original e respeite os seus direitos.
+Todas as lições para o _Programming Historian em Português_ são publicadas sob uma licença [Creative Commons 'CC-BY'](https://creativecommons.org/licenses/by/4.0/deed.pt). Isto significa um modelo de publicação de acesso aberto '[Diamante](https://commons.wikimedia.org/wiki/File:Open_Access_colours_Venn.svg)'. Todas as lições são disponibilizadas gratuitamente, sem subscrição paga e sem restrições de acesso. Os autores podem republicar os seus tutoriais em outros locais. Da mesma forma, qualquer um pode fazer o mesmo, desde que cite o autor original e respeite os seus direitos.
 
 Não cobramos taxas de processamento de artigos (APCs) ou assinaturas para bibliotecas.
 


### PR DESCRIPTION
I'm updating a link to a Venn diagram which highlights Diamond Open Access in relation to the different levels of open access in scholarly publishing.

This is included in the following pages:

en/about
pt/sobre

(N.B. does not feature in the /es or /fr equivalent pages)

Closes #2928 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
