### PR TITLE
Issue 2612

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -255,7 +255,7 @@ If you want to include an aside or a warning to readers, you can set it apart fr
 ```
 
 ### Figures and Images
-Images can help readers understand your lesson steps, but should not be used for decoration. If you wish to use images in your lesson, label them sequentially LESSON-NAME1.jpg, LESSON-NAME2.jpg, etc. Refer to them in the text as "Figure 1", "Figure 2", and so on. All figures must come with a concise figure caption and endnotes where appropriate. You must have the legal right to post any images.
+Images can help readers understand your lesson steps, but should not be used for decoration. If you wish to use images in your lesson, label them sequentially LESSON-NAME1.jpg, LESSON-NAME2.jpg, etc. Refer to them in the text as "Figure 1", "Figure 2", and so on. All figures must come with a concise figure caption, descriptive alt-text, and endnotes where appropriate. You must have the legal right to post any images.
 
 Use web-friendly file formats such as .png or .jpg and reduce large images to a maximum of 840px on the longest side. This is important for readers in countries with slower internet speeds.
 
@@ -265,7 +265,7 @@ To insert an image in your text, use the following format:
 
 {% raw %}
 ``` markdown
-{% include figure.html filename="IMAGE-FILENAME" caption="YOUR CAPTION USING \"ESCAPED\" QUOTES" %}
+{% include figure.html filename="IMAGE-FILENAME" alt="Visual description of figure image" caption="YOUR CAPTION USING \"ESCAPED\" QUOTES" %}
 ```
 {% endraw %}
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -251,7 +251,7 @@ Si quieres incluir un aparte o una advertencia, puedes utilizar el siguiente blo
 ```
 
 ### Figuras e imágenes
-Las imágenes pueden ayudar a tu audiencia a entender los pasos de la lección, pero no deben ser usadas como decoración. Si deseas utilizar imágenes en tu lección, etiquétalas secuencialmente siguiendo el patrón: `nombre-leccion1.jpg`, `nombre.leccion2.jpg`, etc. Refiérete a ellas en el texto como "Figura 1", "Figura 2" y así sucesivamente. Todas las figuras deben venir con una leyenda concisa, texto descriptivo 'alt-text', y notas finales cuando sea apropiado. Debes tener el derecho legal para publicar cualquier imagen que incluyas en tu lección.
+Las imágenes pueden ayudar a tu audiencia a entender los pasos de la lección, pero no deben ser usadas como decoración. Si deseas utilizar imágenes en tu lección, etiquétalas secuencialmente siguiendo el patrón: `nombre-leccion1.jpg`, `nombre.leccion2.jpg`, etc. Refiérete a ellas en el texto como "Figura 1", "Figura 2" y así sucesivamente. Todas las figuras deben venir con una leyenda concisa, texto descriptivo 'alt-text' y notas finales cuando sea apropiado. Debes tener el derecho legal para publicar cualquier imagen que incluyas en tu lección.
 
 Utiliza formatos de archivos amigables para la web, como .png o .jpg, y reduce las imágenes grandes a un máximo de 840 px en el lado más largo. Esto es importante para lectores en países con velocidades de Internet más lentas.
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -251,7 +251,7 @@ Si quieres incluir un aparte o una advertencia, puedes utilizar el siguiente blo
 ```
 
 ### Figuras e imágenes
-Las imágenes pueden ayudar a tu audiencia a entender los pasos de la lección, pero no deben ser usadas como decoración. Si deseas utilizar imágenes en tu lección, etiquétalas secuencialmente siguiendo el patrón: `nombre-leccion1.jpg`, `nombre.leccion2.jpg`, etc. Refiérete a ellas en el texto como "Figura 1", "Figura 2" y así sucesivamente. Todas las figuras deben venir con una leyenda concisa y notas finales cuando sea apropiado. Debes tener el derecho legal para publicar cualquier imagen que incluyas en tu lección.
+Las imágenes pueden ayudar a tu audiencia a entender los pasos de la lección, pero no deben ser usadas como decoración. Si deseas utilizar imágenes en tu lección, etiquétalas secuencialmente siguiendo el patrón: `nombre-leccion1.jpg`, `nombre.leccion2.jpg`, etc. Refiérete a ellas en el texto como "Figura 1", "Figura 2" y así sucesivamente. Todas las figuras deben venir con una leyenda concisa, texto descriptivo 'alt-text', y notas finales cuando sea apropiado. Debes tener el derecho legal para publicar cualquier imagen que incluyas en tu lección.
 
 Utiliza formatos de archivos amigables para la web, como .png o .jpg, y reduce las imágenes grandes a un máximo de 840 px en el lado más largo. Esto es importante para lectores en países con velocidades de Internet más lentas.
 
@@ -261,7 +261,7 @@ Para insertar una imagen en tu texto, utiliza el siguiente formato:
 
 {% raw %}
 ``` markdown
-{% include figure.html filename="NOMBRE-ARCHIVO-IMAGEN" caption="PIE DE FOTO UTILIZANDO \"ESCAPED\" QUOTES" %}
+{% include figure.html filename="NOMBRE-ARCHIVO-IMAGEN" alt="DESCRIPCIÓN-VISUAL-DE-LA-IMAGEN" caption="PIE DE FOTO UTILIZANDO \"ESCAPED\" QUOTES" %}
 ```
 {% endraw %}
 

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -261,7 +261,7 @@ Para insertar una imagen en tu texto, utiliza el siguiente formato:
 
 {% raw %}
 ``` markdown
-{% include figure.html filename="NOMBRE-ARCHIVO-IMAGEN" alt="DESCRIPCIÓN-VISUAL-DE-LA-IMAGEN" caption="PIE DE FOTO UTILIZANDO \"ESCAPED\" QUOTES" %}
+{% include figure.html filename="NOMBRE-ARCHIVO-IMAGEN" alt="DESCRIPCIÓN VISUAL DE LA IMAGEN" caption="PIE DE FOTO UTILIZANDO \"ESCAPED\" QUOTES" %}
 ```
 {% endraw %}
 

--- a/fr/consignes-auteurs.md
+++ b/fr/consignes-auteurs.md
@@ -295,7 +295,7 @@ Si vous souhaitez attirer l'attention des lecteurs, vous pouvez ajouter un bloc 
 </div>
 ```
 ### Figures et images
-Les images doivent pouvoir aider votre lectorat à mieux comprendre les étapes de votre leçon, elles ne doivent pas être purement illustratives. Si vous souhaitez en fournir avec votre leçon, nommez-les de manière ordonnée NOM-DE-LEÇON1.jpg, NOM-DE-LEÇON2.jpg, etc. puis, dans le texte, rappelez-les en tant que figure 1, figure 2... Toutes les figures doivent être accompagnées d'une brève légende et, le cas échéant, de notes. Vous devez disposer du droit de publier toute image que vous fournissez. 
+Les images doivent pouvoir aider votre lectorat à mieux comprendre les étapes de votre leçon, elles ne doivent pas être purement illustratives. Si vous souhaitez en fournir avec votre leçon, nommez-les de manière ordonnée NOM-DE-LEÇON1.jpg, NOM-DE-LEÇON2.jpg, etc. puis, dans le texte, rappelez-les en tant que figure 1, figure 2... Toutes les figures doivent être accompagnées d'une brève légende, 'alt-text' texte descriptif et, le cas échéant, de notes. Vous devez disposer du droit de publier toute image que vous fournissez. 
 
 Veillez à utiliser un format adapté à la publication web tel .png or .jpg et à réduire les grandes images à un maximum de 840px sur la longueur. Cela est important pour les lecteurs et les lectrices qui disposent des connexions internet à bas débit. 
 
@@ -305,7 +305,7 @@ Vous pouvez insérer une image dans votre texte à l'aide de cette syntaxe&#x202
 
 {% raw %}
 ``` markdown
-{% include figure.html filename="IMAGE-FILENAME" caption="VOTRE TITRE, AVEC \"CODE D'ÉCHAPPEMENT\" POUR LES GUILLEMETS" %}
+{% include figure.html filename="IMAGE-FILENAME" alt="DESCRIPTION VISUELLE DE L'IMAGE" caption="VOTRE TITRE, AVEC \"CODE D'ÉCHAPPEMENT\" POUR LES GUILLEMETS" %}
 ```
 {% endraw %}
 

--- a/pt/directrizes-autor.md
+++ b/pt/directrizes-autor.md
@@ -222,7 +222,7 @@ Se deseja incluir uma nota ou um aviso para os leitores, é possível separá-lo
 ```
 
 ### Figuras e imagens
-As imagens podem ajudar os leitores a entender os passos da lição, mas não devem ser usadas como decoração. Se desejar usar imagens na sua lição, identifique-as sequencialmente como LESSON-NAME1.jpg, LESSON-NAME2.jpg, etc. Refira as imagens no texto como "Figura 1", "Figura 2", e assim por diante. Todas as figuras devem vir com uma legenda concisa e notas finais, quando apropriado. A licença legal para publicar qualquer imagem tem de estar assegurada.
+As imagens podem ajudar os leitores a entender os passos da lição, mas não devem ser usadas como decoração. Se desejar usar imagens na sua lição, identifique-as sequencialmente como LESSON-NAME1.jpg, LESSON-NAME2.jpg, etc. Refira as imagens no texto como "Figura 1", "Figura 2", e assim por diante. Todas as figuras devem vir com uma legenda concisa, texto alternativo descritivo 'alt-text' e notas finais, quando apropriado. A licença legal para publicar qualquer imagem tem de estar assegurada.
 
 Os ficheiros devem ser compatíveis com a web, preferencialmente .png ou .jpg, e devem ter um máximo de 840px no lado mais longo. Isso é especialmente importante para leitores de países com velocidades mais lentas de Internet.
 
@@ -232,7 +232,7 @@ Para inserir uma imagem no seu texto, use o seguinte formato:
 
 {% raw %}
 ``` markdown
-{% include figure.html filename="NOME-DO-FICHEIRO-DE-IMAGEM" caption="A LEGENDA USANDO \"BARRAS\" PARA SALTAR ASPAS INTERNAS" %}
+{% include figure.html filename="NOME-DO-FICHEIRO-DE-IMAGEM" alt="DESCRIÇÃO VISUAL DA IMAGEM" caption="A LEGENDA USANDO \"BARRAS\" PARA SALTAR ASPAS INTERNAS" %}
 ```
 {% endraw %}
 


### PR DESCRIPTION
I am updating the following pages of our website:

/en/author-guidelines  
/es/guia-para-autores  
/fr/consignes-auteurs  
/pt/directrizes-autor  

I am adding an alt-text template to our liquid syntax examples:

`alt="Visual description of figure image"`
`alt="DESCRIPCIÓN VISUAL DE LA IMAGEN"`
`alt="DESCRIPTION VISUELLE DE L'IMAGE"`
`alt="DESCRIÇÃO VISUAL DA IMAGEM"`

And I have adjusted the introductory sentences:

EN: All figures must come with a concise figure caption, descriptive alt-text, and endnotes where appropriate.
ES: Todas las figuras deben venir con una leyenda concisa, texto descriptivo 'alt-text', y notas finales cuando sea apropiado.
FR: Toutes les figures doivent être accompagnées d’une brève légende, 'alt-text' texte descriptif et, le cas échéant, de notes.
PT: Todas as figuras devem vir com uma legenda concisa, texto alternativo descritivo 'alt-text' e notas finais, quando apropriado.

reference #2612 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.
