### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2413,8 +2413,9 @@
         Gabriel Calarco es Licenciado en Letras por la Universidad de Buenos Aires (UBA) y se encuentra cursando el doctorado en Literatura en la misma universidad como becario del Instituto de Investigaciones Bibliográficas y Crítica Textual (IIBICRIT-CONICET). También se desempeña como docente en la Diplomatura de Humanidades Digitales (UCES) y como profesor de Literatura en el Nivel Medio.
 
 - name: Liz Fischer
-  team: true
+  team: false
   team_start: 2022
+  team_end: 2023
   institution: University of Texas at Austin
   github: lizfischer
   email: lizzy.m.fischer@gmail.com


### PR DESCRIPTION
I am updating ph_authors.yml to reflect that Liz Fischer is stepping down from the French team.

To do this, I've changed their status to `team: false`, and added a new line that reads `team_end: 2023`

One action from #2934

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [ ] ~~If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
