### PR TITLE
Update qgis-layers.md

### DIFF
--- a/en/lessons/qgis-layers.md
+++ b/en/lessons/qgis-layers.md
@@ -97,18 +97,16 @@ instructions on the download page.
 We will be using some government data from the Canadian province of
 Prince Edward Island. PEI is a great example because there is a lot of
 data for free online and because it is Canada's smallest province,
-making the downloads quick! Download PEI shapefiles:
+making the downloads quick!
 
--   Navigate to the links below in your web browser, read/accept the
-    license agreement, and then download the following (they will ask
-    for your name and email with each download). We created the final
-    two shapefiles, so they should download directly:
+-   Navigate to the links below in your web browser and then download
+the following PEI shapefiles. We created the final two, so they will download directly:
 
-1.  <http://www.gov.pe.ca/gis/license_agreement.php3?name=coastline&file_format=SHP>
-2.  <http://www.gov.pe.ca/gis/license_agreement.php3?name=lot_town&file_format=SHP>
-3.  <http://www.gov.pe.ca/gis/license_agreement.php3?name=hydronetwork&file_format=SHP>
-4.  <http://www.gov.pe.ca/gis/license_agreement.php3?name=forest_35&file_format=SHP>
-5.  <http://www.gov.pe.ca/gis/license_agreement.php3?name=nat_parks&file_format=SHP>
+1.  <http://www.gov.pe.ca/gis/download.php3?name=coastline&file_format=SHP>
+2.  <http://www.gov.pe.ca/gis/download.php3?name=lot_town&file_format=SHP>
+3.  <http://www.gov.pe.ca/gis/download.php3?name=hydronetwork&file_format=SHP>
+4.  <http://www.gov.pe.ca/gis/download.php3?name=forest_35&file_format=SHP>
+5.  <http://www.gov.pe.ca/gis/download.php3?name=nat_parks&file_format=SHP>
 6.  [PEI Highways][]
 7.  [PEI Places][]
 


### PR DESCRIPTION
- Update broken links, lines 105-109
- Adjust lines 102-3 to remove wording re: license agreement (no longer required for downloads)

I'm updating broken links in the EN lesson qgis-layers.

In the /qgis-layers#prince-edward-island-data section of the lesson, the links to http://www.gov.pe.ca/ have changed. The Government of Prince Edward Island no longer require users of this data to provide their name + email to download, so the URLs are slightly different. The `license_agreement` part of the path becomes `download`. 

Also updating the sentences above the links to remove the information re: license agreement.

Closes #2997 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
