### PR TITLE
Issue 3009

### DIFF
--- a/es/lecciones/datos-tabulares-en-r.md
+++ b/es/lecciones/datos-tabulares-en-r.md
@@ -540,7 +540,7 @@ Ahora que has cargado datos en R y conoces algunas formas de trabajar con los da
 > library(xlsx)
 > write.xlsx(x= OldBailey, file= "OldBailey.xlsx", sheetName= "OldBailey", row.names= TRUE)
 ```
-En este caso, y dentro del paréntesis de esta la función [write.xlsx](https://www.rdocumentation.org/packages/xlsx/versions/0.6.1/topics/write.xlsx), estamos llamando a procesar la variable “OldBailey” con el argumento <code class="highlighter-rouge">x= </code>; a la vez, indicamos que el archivo guardado debe llamarse “OldBailey” con la extensión “.xlsx” mediante el argumento <code class="highlighter-rouge">file=</code>; además, damos el nombre "OldBailey" a la hoja de cálculo en que estarán los datos mediante <code class="highlighter-rouge">sheetName= </code>  y, finalmente, establecemos que sí queremos (TRUE o verdadero) que los nombres de la fila en nuestra variable se guarden en el nuevo archivo. [N. de la T.]
+En este caso, y dentro del paréntesis de esta la función [write.xlsx](https://www.rdocumentation.org/packages/xlsx/versions/0.6.5), estamos llamando a procesar la variable “OldBailey” con el argumento <code class="highlighter-rouge">x= </code>; a la vez, indicamos que el archivo guardado debe llamarse “OldBailey” con la extensión “.xlsx” mediante el argumento <code class="highlighter-rouge">file=</code>; además, damos el nombre "OldBailey" a la hoja de cálculo en que estarán los datos mediante <code class="highlighter-rouge">sheetName= </code>  y, finalmente, establecemos que sí queremos (TRUE o verdadero) que los nombres de la fila en nuestra variable se guarden en el nuevo archivo. [N. de la T.]
 
 ## Resumen y siguientes pasos
 

--- a/pt/licoes/nocoes-basicas-R-dados-tabulares.md
+++ b/pt/licoes/nocoes-basicas-R-dados-tabulares.md
@@ -546,7 +546,7 @@ Agora que carregamos dados em R e conhecemos algumas maneiras de trabalhar com o
 > write.xlsx(x= OldBailey, file= "OldBailey.xlsx", sheetName= "OldBailey", row.names= TRUE)
 ```
 
-Neste caso, e dentro do parêntese desta função [write.xlsx](https://www.rdocumentation.org/packages/xlsx/versions/0.6.1/topics/write.xlsx), estamos chamando para processar a variável "OldBailey" com o argumento <code class="highlighter-rouge">x= </code>. Ao mesmo tempo, indicamos que o ficheiro salvo deve ser chamado “OldBailey” com a extensão “.xlsx” com o argumento <code class="highlighter-rouge">file= </code>. Além disso, damos o nome "OldBailey" à planilha onde estarão os dados com <code class="highlighter-rouge">sheetName= </code>. Finalmente, estabelecemos que queremos (TRUE ou verdadeiro) que os nomes da linha em nossa variável sejam salvos no novo ficheiro. [N. da T.]
+Neste caso, e dentro do parêntese desta função [write.xlsx](https://www.rdocumentation.org/packages/xlsx/versions/0.6.5), estamos chamando para processar a variável "OldBailey" com o argumento <code class="highlighter-rouge">x= </code>. Ao mesmo tempo, indicamos que o ficheiro salvo deve ser chamado “OldBailey” com a extensão “.xlsx” com o argumento <code class="highlighter-rouge">file= </code>. Além disso, damos o nome "OldBailey" à planilha onde estarão os dados com <code class="highlighter-rouge">sheetName= </code>. Finalmente, estabelecemos que queremos (TRUE ou verdadeiro) que os nomes da linha em nossa variável sejam salvos no novo ficheiro. [N. da T.]
 
 ## Resumo e passos seguintes
 


### PR DESCRIPTION
I'm updating a broken link in the following ES and PT lessons:

/es/lecciones/datos-tabulares-en-r
/pt/licoes/nocoes-basicas-R-dados-tabulares

Replacing https://www.rdocumentation.org/packages/xlsx/versions/0.6.1/topics/write.xlsx with https://www.rdocumentation.org/packages/xlsx/versions/0.6.5

Closes #3009 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
