### PR TITLE
Issue 3054

### DIFF
--- a/en/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/en/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -569,7 +569,7 @@ If you run into an issue, [Jekyll has a page on troubleshooting](https://jekyllr
 
 ### Credits <a id="section9-2"></a>
 
-Thanks to *Programming Historian* Editor Fred Gibbs for editing, discussing, and reviewing this lesson; Paige Morgan and Jaime Howe for reviewing this lesson; Scott Weingart and students for testing the lesson with Windows; Tod Robbins and Matthew Lincoln for suggestions on the [DH Slack](http://tinyurl.com/DHSlack) on what to cover in this lesson; and Roxanne Shirazi for solutions to possible permission and navigation problems.
+Thanks to *Programming Historian* Editor Fred Gibbs for editing, discussing, and reviewing this lesson; Paige Morgan and Jaime Howe for reviewing this lesson; Scott Weingart and students for testing the lesson with Windows; Tod Robbins and Matthew Lincoln for suggestions on the [DH Slack](https://digitalhumanities.slack.com) on what to cover in this lesson; and Roxanne Shirazi for solutions to possible permission and navigation problems.
 
 The Editorial Board would like to thank [spswanz](https://github.com/spswanz) for pointing out to a bug in the [Ruby & Ruby Gems](#section2-3) section. 
 
@@ -585,4 +585,4 @@ Check out the following links for documentation, inspiration, and further readin
 * Eduardo Bouças, ["An Introduction to Static Site Generators"](https://davidwalsh.name/introduction-static-site-generators)
 * [Jekyll Style Guide](http://ben.balter.com/jekyll-style-guide/)
 * The [Prose](http://prose.io/) content editor (built on Jekyll)
-* [Join the Digital Humanities Slack](http://tinyurl.com/DHslack) (anyone can join, even if you have no DH experience) and check out the #publishing channel for discussions of Jekyll and other DH publishing platforms
+* [Join the Digital Humanities Slack](https://digitalhumanities.slack.com) (anyone can join, even if you have no DH experience) and check out the #publishing channel for discussions of Jekyll and other DH publishing platforms

--- a/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
+++ b/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
@@ -643,7 +643,7 @@ Si encuentras algún problema, [Jekyll tiene una página para problemas, conocid
 
 ### Creditos <a id="section9-2"></a>
 
-Gracias a Fred Gibbs, editor del *Programming Historian* por editar, debatir y revisar la lección original. A Paige Morgan por revisar la lección; a Scott Weingart y sus estudiantes por poner en práctica y testear esta lección en Windows; a Tod Robbins y Matthew Lincoln por sugerencias en [DH Slack](http://tinyurl.com/DHSlack) sobre lo que debería enseñar esta lección. Asimismo, agradecemos a Marc Bria por su revisión y sugerencias con respecto a la traducción de esta lección al español.
+Gracias a Fred Gibbs, editor del *Programming Historian* por editar, debatir y revisar la lección original. A Paige Morgan por revisar la lección; a Scott Weingart y sus estudiantes por poner en práctica y testear esta lección en Windows; a Tod Robbins y Matthew Lincoln por sugerencias en [DH Slack](https://digitalhumanities.slack.com) sobre lo que debería enseñar esta lección. Asimismo, agradecemos a Marc Bria por su revisión y sugerencias con respecto a la traducción de esta lección al español.
 
 ### Lecturas <a id="section9-3"></a>
 
@@ -657,4 +657,4 @@ Puedes visitar estos sitios para más documentación, inspiración y para aprend
 * Eduardo Bouças, ["An Introduction to Static Site Generators"](https://davidwalsh.name/introduction-static-site-generators)
 * [Guía de estilo de Jekyll](https://ben.balter.com/jekyll-style-guide/)
 * [Prose](https://prose.io/): editor de contenido (creado en Jekyll)
-* [Únete al Slack sobre humanidades digitales](https://tinyurl.com/DHslack) (cualquiera puede sumarse; no se necesita saber sobre humanidades digitales) y súmate a los debates acerca de Jekyll y otras plataformas de publicación en el canal #publishing.
+* [Únete al Slack sobre humanidades digitales](https://digitalhumanities.slack.com) (cualquiera puede sumarse; no se necesita saber sobre humanidades digitales) y súmate a los debates acerca de Jekyll y otras plataformas de publicación en el canal #publishing.


### PR DESCRIPTION
I'm replacing a broken link in /en/lessons/building-static-sites-with-jekyll-github-pages and /es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.

This TinyURL link is broken https://tinyurl.com/DHslack. Replacing it with the full link:
https://digitalhumanities.slack.com/.

Closes #3054 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
