### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2864,11 +2864,11 @@
   affiliation:
     en: |
       Humathèque, Campus Condorcet-CNRS, France
-    pt: |
-      Humathèque, Campus Condorcet-CNRS, Francia
     es: |
-      Humathèque, Campus Condorcet-CNRS, France
+      Humathèque, Campus Condorcet-CNRS, Francia
     fr: |
+      Humathèque, Campus Condorcet-CNRS, France
+    pt: |
       Humathèque, Campus Condorcet-CNRS, França
   team_roles:
     - french


### PR DESCRIPTION
I'm correcting a small error in the translations of Alexandre's affiliation, as they appear on the following pages:
- /en/project-team
- /es/equipo-de-proyecto
- /fr/equipe-projet
- /pt/equipe

(This is an update to lines 2866-2872 of `ph_authors.yml`)

Closes #3074 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Assistant @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
