### PR TITLE
Issue 3127

### DIFF
--- a/_posts/2023-11-15-en-call-for-lessons.md
+++ b/_posts/2023-11-15-en-call-for-lessons.md
@@ -29,7 +29,7 @@ Our lessons support readers who want to learn new skills, but the act of writing
 
 _Programming Historian_'s English edition is inviting proposals to fill gaps in our lesson directory. Please explore [our journal](/en/lessons/) to discover what’s already available, and consider what you might be able to add.
 
-If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. In this call, **proposals for translations will be prioritised for publication**.
+If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation. In this call, **proposals for translations will be prioritised for publication**.
 
 We’re also keen to extend our offer to learners, and invite proposals which focus on methodological approaches, digital techniques and tools including, but not limited to:
 - Text encoding, Natural Language Processing, especially for multilingual corpora
@@ -47,7 +47,7 @@ We’re also keen to extend our offer to learners, and invite proposals which fo
 Remember, you can either:
 
 - Propose an original English-language lesson
-- Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions.
+- Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation.
 
 **If you have an idea, please send us a proposal by January 12th, 2024.**
 

--- a/_posts/2023-11-15-en-call-for-lessons.md
+++ b/_posts/2023-11-15-en-call-for-lessons.md
@@ -29,7 +29,7 @@ Our lessons support readers who want to learn new skills, but the act of writing
 
 _Programming Historian_'s English edition is inviting proposals to fill gaps in our lesson directory. Please explore [our journal](/en/lessons/) to discover what’s already available, and consider what you might be able to add.
 
-If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation. In this call, **proposals for translations will be prioritised for publication**.
+If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Concordance](/translation-concordance) map to identify options for your translation. In this call, **proposals for translations will be prioritised for publication**.
 
 We’re also keen to extend our offer to learners, and invite proposals which focus on methodological approaches, digital techniques and tools including, but not limited to:
 - Text encoding, Natural Language Processing, especially for multilingual corpora
@@ -47,7 +47,7 @@ We’re also keen to extend our offer to learners, and invite proposals which fo
 Remember, you can either:
 
 - Propose an original English-language lesson
-- Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation.
+- Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions. Please review our [Translation Concordance](/translation-concordance) map to identify options for your translation.
 
 **If you have an idea, please send us a proposal by January 12th, 2024.**
 

--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -6,7 +6,7 @@ We encourage prospective authors to think carefully about how their proposal cou
 
 You can [explore our journal](https://programminghistorian.org/en/lessons/) to discover what’s already available and consider what you might be able to add.
 
-If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](https://programminghistorian.org/es/lecciones/), [French](https://programminghistorian.org/fr/lecons/), or [Portuguese](https://programminghistorian.org/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation.
+If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](https://programminghistorian.org/es/lecciones/), [French](https://programminghistorian.org/fr/lecons/), or [Portuguese](https://programminghistorian.org/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Concordance](/translation-concordance) map to identify options for your translation.
 
 ---
 

--- a/assets/forms/Lesson.Query.Form.txt
+++ b/assets/forms/Lesson.Query.Form.txt
@@ -6,7 +6,7 @@ We encourage prospective authors to think carefully about how their proposal cou
 
 You can [explore our journal](https://programminghistorian.org/en/lessons/) to discover what’s already available and consider what you might be able to add.
 
-If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](https://programminghistorian.org/es/lecciones/), [French](https://programminghistorian.org/fr/lecons/), or [Portuguese](https://programminghistorian.org/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English.
+If the method or approach you’re interested in writing a lesson about is already represented by the [Spanish](https://programminghistorian.org/es/lecciones/), [French](https://programminghistorian.org/fr/lecons/), or [Portuguese](https://programminghistorian.org/pt/licoes/) editions of _Programming Historian_, we welcome proposals to translate those existing, original lessons into English. Please review our [Translation Corcordance](/translation-concordance) map to identify options for your translation.
 
 ---
 


### PR DESCRIPTION
I'm updating `/posts/en-call-for-lessons` + `Lesson.Query.Form.txt` to add a sentence + link to our /translation-concordance document, which will support prospective translators to find original lessons published by the ES, FR, PT editions.

Closes #3127 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
