### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2366,7 +2366,7 @@
   email: profericbrasil@unilab.edu.br
   url: "https://ericbrasiln.github.io"
   github: ericbrasiln
-  orcid: 0000-0001-5067-847
+  orcid: 0000-0001-5067-8475
   team: true
   team_start: 2021
   institution: Universidade da Integração Internacional da Lusofonia Afro-brasileira


### PR DESCRIPTION
I've now fixed Eric Brasil's ORCID from `0000-0001-5067-847` to `0000-0001-5067-8475`.

Closes #3130 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
