### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1645,7 +1645,7 @@
     fr: |
       Daniel Alves est professeur adjoint au Département d'Histoire et chercheur à l'Institut d'Histoire Contemporaine, tous deux à NOVA-FCSH, Universidade Nova de Lisboa. Il coordonne le Laboratoire des Humanités Numériques au NOVA-FCSH.
   team_roles:
-    - managing
+    - editorial
     - portuguese
   status: volunteer
 
@@ -2391,7 +2391,7 @@
       Eric Brasil est professeur à l'Institut des sciences humaines et des lettres de l'Université d'intégration internationale de la lusophonie afro-brésilienne (IHLM/UNILAB) et membre du Laboratoire d'humanités numériques de l'Université fédérale de Bahia (LABHDUFBA).
   team_roles:
     - portuguese
-    - editorial
+    - managing
   status: volunteer
 
 - name: Gimena del Río Riande

--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -1619,7 +1619,7 @@
 
 - name: Daniel Alves
   twitter: danielalvesfcsh
-  email: portugues@programminghistorian.org
+  email: dra@fcsh.unl.pt
   github: DanielAlvesLABDH
   orcid: 0000-0002-3541-8197
   team: true
@@ -2363,7 +2363,7 @@
 
 - name: Eric Brasil
   twitter: ericbrasiln
-  email: profericbrasil@unilab.edu.br
+  email: portugues@programminghistorian.org
   url: "https://ericbrasiln.github.io"
   github: ericbrasiln
   orcid: 0000-0001-5067-8475


### PR DESCRIPTION
Change Daniel's role to editorial and Eric's role to managing. Eric é o novo Editor-Chefe do Programming Historian em português.

*Please summarise the reason for your Pull Request here*

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [ ] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
