### PR TITLE
Issue 3136

### DIFF
--- a/en/lessons/intro-to-twitterbots.md
+++ b/en/lessons/intro-to-twitterbots.md
@@ -134,7 +134,7 @@ With tweaking, and breaking the units of expression into smaller symbols, we can
 
 ## Prototyping with a Tracery editor
 
-There is a Tracery editor at [www.brightspiral.com/tracery/](http://www.brightspiral.com/tracery). We will use that to work out the kinks in _plantpotbot_. The editor visualizes the way the symbols and rules of the grammar interact (how they are nested, and the kinds of output your grammar will generate). Open the editor in a new window. You should see this:
+In order to work out the kinks in _plantpotbot_, we used the Tracery editor at Brightspiral, which unfortunately no longer exists. Now, you might want to try the following alternative at [https://tracery.io/editor/](https://tracery.io/editor/). The editor visualizes the way the symbols and rules of the grammar interact (how they are nested, and the kinds of output your grammar will generate). Open the editor in a new window. You should see this:
 
 {% include figure.html filename="bot-lesson-editor.png" caption="The Tracery Editor at Brightspiral.com" %}
 

--- a/fr/lecons/intro-aux-bots-twitter.md
+++ b/fr/lecons/intro-aux-bots-twitter.md
@@ -142,7 +142,7 @@ Les résultats possibles seront :
 En bricolant, et en décomposant les unités d'expression en symboles plus petits et précis, on peut corriger toute maladresse d'expression - ou alors décider de les laisser pour rendre la voix du bot plus &laquo; authentique &raquo;.
 
 ## Prototypage à l’aide d’un éditeur Tracery
-Un éditeur Tracery est disponible ici : [www.brightspiral.com/tracery/](http://www.brightspiral.com/tracery). Nous l'utiliserons pour rectifier les imperfections du bot _PlanteEnPot_. L'éditeur visualise la façon dont les symboles et les règles de la grammaire interagissent, à savoir la manière dont ils sont imbriqués et le type de résultats que votre grammaire va générer. Si vous ouvrez l'éditeur dans une nouvelle fenêtre, vous devriez voir ça :
+Pour rectifier les imperfections du bot _PlanteEnPot_, nous avons utilisé l'éditeur Tracery de Brightspiral, qui n'existe malheureusement plus. Vous pouvez pourtant essayer un éditeur alternatif, tel que [https://tracery.io/editor/](https://tracery.io/editor/). L'éditeur visualise la façon dont les symboles et les règles de la grammaire interagissent, à savoir la manière dont ils sont imbriqués et le type de résultats que votre grammaire va générer. Si vous ouvrez l'éditeur dans une nouvelle fenêtre, vous devriez voir ça :
 
 {% include figure.html filename="bot-lesson-editor.png" caption="L'éditeur Tracery sur Brightspiral.com" %}
 


### PR DESCRIPTION
The links to the Brightspiral editor were broken in /fr/lecons/intro-aux-bots-twitter + /en/lessons/intro-to-twitterbots, because Brightspiral no longer exists.

I have removed them and pointed readers to an alternative online Tracery editor, [https://tracery.io/editor/](https://tracery.io/editor/.)

Closes #3136 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
