### PR TITLE
Issue 3140

### DIFF
--- a/_posts/2023-11-15-en-call-for-lessons.md
+++ b/_posts/2023-11-15-en-call-for-lessons.md
@@ -11,7 +11,7 @@ categories: posts
 The [English edition of Programming Historian](/en/lessons/) seeks proposals for new original lessons or translations to be considered for publication in 2024.
 
 **Submissions Open**: 15 November 2023  
-**Submissions Close**: 12 January 2024
+**Submissions Close**: 31 January 2024 (**deadline extended**)
 
 ## What is a _Programming Historian_ lesson?
 

--- a/_posts/2023-11-15-en-call-for-lessons.md
+++ b/_posts/2023-11-15-en-call-for-lessons.md
@@ -49,7 +49,7 @@ Remember, you can either:
 - Propose an original English-language lesson
 - Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions. Please review our [Translation Concordance](/translation-concordance) map to identify options for your translation.
 
-**If you have an idea, please send us a proposal by January 31th, 2024 (extended deadline).**
+**If you have an idea, please send us a proposal by January 31st, 2024 (extended deadline).**
 
 We've set up [a Google Form](https://tinyurl.com/ph-en-proposals) which you can submit directly online. There's also [a plain-text version](/assets/forms/Lesson.Query.Form.txt) which you can [send to us by email](mailto:english@programminghistorian.org), if you prefer. The form has twelve questions. Please answer all those which apply.
 

--- a/_posts/2023-11-15-en-call-for-lessons.md
+++ b/_posts/2023-11-15-en-call-for-lessons.md
@@ -11,7 +11,7 @@ categories: posts
 The [English edition of Programming Historian](/en/lessons/) seeks proposals for new original lessons or translations to be considered for publication in 2024.
 
 **Submissions Open**: 15 November 2023  
-**Submissions Close**: 31 January 2024 (**deadline extended**)
+**Submissions Close**: 31 January 2024 (**extended deadline**)
 
 ## What is a _Programming Historian_ lesson?
 
@@ -49,7 +49,7 @@ Remember, you can either:
 - Propose an original English-language lesson
 - Propose a translation into English of an existing, original [Spanish](/es/lecciones/), [French](/fr/lecons/), or [Portuguese](/pt/licoes/) lesson published in one of the other _Programming Historian_ editions. Please review our [Translation Concordance](/translation-concordance) map to identify options for your translation.
 
-**If you have an idea, please send us a proposal by January 12th, 2024.**
+**If you have an idea, please send us a proposal by January 31th, 2024 (extended deadline).**
 
 We've set up [a Google Form](https://tinyurl.com/ph-en-proposals) which you can submit directly online. There's also [a plain-text version](/assets/forms/Lesson.Query.Form.txt) which you can [send to us by email](mailto:english@programminghistorian.org), if you prefer. The form has twelve questions. Please answer all those which apply.
 


### PR DESCRIPTION
I have updated the EN Call for Lessons to make note of the deadline extension to January 31st.

Closes #3140 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
