### PR TITLE
Issue 3156

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -808,7 +808,7 @@ managing_editor:
   en: Alex Wermer-Colan
   es: Jennifer Isasi
   fr: Marie Flesch
-  pt: Daniel Alves
+  pt: Eric Brasil
 
 front-image-alt:
   en: Image from Scientific American of a woman at an Electrical Counting Machine.

--- a/assets/forms/Formulaire.Tutoriel.txt
+++ b/assets/forms/Formulaire.Tutoriel.txt
@@ -5,7 +5,7 @@ Si vous souhaitez écrire un tutoriel et le soumettre au Programming Historian, 
 Anglais: Alex Wermer-Colan (english@programminghistorian.org)
 Espagnol: Jennifer Isasi (espanol@programminghistorian.org)
 Français: Marie Flesch (francais@programminghistorian.org)
-Portugais: Daniel Alves (portugues@programminghistorian.org)
+Portugais: Eric Brasil (portugues@programminghistorian.org)
 
 
 ## Vous

--- a/assets/forms/Formulario.Consulta.Leccion.txt
+++ b/assets/forms/Formulario.Consulta.Leccion.txt
@@ -5,7 +5,7 @@ Si estás interesado en escribir un tutorial y enviarlo a Programming Historian,
 Inglés: Alex Wermer-Colan (english@programminghistorian.org)
 Español: Jennifer Isasi (espanol@programminghistorian.org)
 Francés: Marie Flesch (francais@programminghistorian.org)
-Portugués: Daniel Alves (portugues@programminghistorian.org)
+Portugués: Eric Brasil (portugues@programminghistorian.org)
 
 ## Acerca de ti
 1. Nombre

--- a/assets/forms/formulario.proposta.licao.txt
+++ b/assets/forms/formulario.proposta.licao.txt
@@ -5,7 +5,7 @@ Se estiver interessado em escrever uma lição e enviá-la ao Programming Histor
 Inglês: Alex Wermer-Colan (english@programminghistorian.org)
 Espanhol: Jennifer Isasi (espanol@programminghistorian.org)
 Francês: Marie Flesch (francais@programminghistorian.org)
-Português: Daniel Alves (portugues@programminghistorian.org)
+Português: Eric Brasil (portugues@programminghistorian.org)
 
 ## Sobre o autor
 1. Nome


### PR DESCRIPTION
I have updated the PT Managing Editor from Daniel Alves to Eric Brasil in `_data/snippets` and the Lesson Query Forms in FR, ES, PT.

Closes #3156 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- ~[ ] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
