### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2071,9 +2071,10 @@
   twitter: ringwald_c
   email: celian.ringwald@hotmail.fr
   github: datalogism
-  team: true
+  team: false
   orcid: 0000-0002-7302-9037
   team_start: 2021
+  team_end: 2024
   institution: Inria Sophia-Antipolis, France
   sortname: Ringwald
   affiliation:


### PR DESCRIPTION
I am updating ph_authors.yml to reflect that Célian Ringwald is stepping down from the French editorial team.

To do this, I've changed their `team:` status to `false`, and added a new line that reads `team_end:` 2024

Closes #3231 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
