### PR TITLE
Issue-2836

### DIFF
--- a/en/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/en/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -23,7 +23,7 @@ doi: 10.46430/phen0048
 
 **At the end of this lesson**, you'll have a basic live website where you can publish content that other people can visit—it will look like [this](http://amandavisconti.github.io/JekyllDemo/)!—and you'll also have some resources to explore if you want to further customize the site.
 
-**Requirements:** A computer (Mac/Windows/Linux are all okay, but this lesson doesn't cover some aspects of Linux use, and you may encounter some issues if you are using a Mac with an M-series (silicone) chip), the ability to download and install software on the computer, an internet connection that can support downloading software. Users have reported needing between 1-3 hours to complete the entire lesson.
+**Requirements:** A computer (Mac/Windows/Linux are all okay, but this lesson doesn't cover some aspects of Linux use, and you may encounter some issues if you are using a Mac with an M-series (silicon) chip), the ability to download and install software on the computer, an internet connection that can support downloading software. Users have reported needing between 1-3 hours to complete the entire lesson.
 
 {% include toc.html %}
 
@@ -153,7 +153,7 @@ Starting with macOS Catalina, zsh has replaced bash as the default shell for Mac
 *If you're using a Mac computer, follow the instructions below until you hit a line that says the Windows-specific instructions are beginning.*
 
 <div class="alert alert-warning">
-Please note that if you are using a Mac with an M-series (silicone) chip, you may encounter some compatibility issues when installing Jekyll or its dependencies. If that’s the case, we advise you to follow additional installation instructions for the relevant package, either from the official documentation, or online help forums.
+Please note that if you are using a Mac with an M-series (silicon) chip, you may encounter some compatibility issues when installing Jekyll or its dependencies. If that’s the case, we advise you to follow additional installation instructions for the relevant package, either from the official documentation, or online help forums.
 </div>
 
 Open a command line window (Applications > Utilities > Terminal) and enter the code shown in the steps below (*`code is formatted like this`*), keeping [the command line tips from above](#section1-4) in mind.

--- a/en/lessons/building-static-sites-with-jekyll-github-pages.md
+++ b/en/lessons/building-static-sites-with-jekyll-github-pages.md
@@ -23,7 +23,7 @@ doi: 10.46430/phen0048
 
 **At the end of this lesson**, you'll have a basic live website where you can publish content that other people can visit—it will look like [this](http://amandavisconti.github.io/JekyllDemo/)!—and you'll also have some resources to explore if you want to further customize the site.
 
-**Requirements:** A computer (Mac/Windows/Linux are all okay, but this lesson doesn't cover some aspects of Linux use), the ability to download and install software on the computer, an internet connection that can support downloading software. Users have reported needing between 1-3 hours to complete the entire lesson.
+**Requirements:** A computer (Mac/Windows/Linux are all okay, but this lesson doesn't cover some aspects of Linux use, and you may encounter some issues if you are using a Mac with an M-series (silicone) chip), the ability to download and install software on the computer, an internet connection that can support downloading software. Users have reported needing between 1-3 hours to complete the entire lesson.
 
 {% include toc.html %}
 
@@ -151,6 +151,10 @@ Starting with macOS Catalina, zsh has replaced bash as the default shell for Mac
 ### On a Mac <a id="sectionMac"></a>
 
 *If you're using a Mac computer, follow the instructions below until you hit a line that says the Windows-specific instructions are beginning.*
+
+<div class="alert alert-warning">
+Please note that if you are using a Mac with an M-series (silicone) chip, you may encounter some compatibility issues when installing Jekyll or its dependencies. If that’s the case, we advise you to follow additional installation instructions for the relevant package, either from the official documentation, or online help forums.
+</div>
 
 Open a command line window (Applications > Utilities > Terminal) and enter the code shown in the steps below (*`code is formatted like this`*), keeping [the command line tips from above](#section1-4) in mind.
 

--- a/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
+++ b/es/lecciones/sitios-estaticos-con-jekyll-y-github-pages.md
@@ -40,7 +40,7 @@ doi: 10.46430/phes0050
 
 **Al final de esta lección**, tendrás un sitio web básico en funcionamiento donde podrás publicar contenido que otras personas podrán visitar -¡se verá [así](https://amandavisconti.github.io/JekyllDemo/)!- y también tendrás algunos recursos para explorar, si deseas personalizar aún más el sitio.
 
-**Requisitos:** una computadora (Mac/Windows/Linux funcionan, aunque esta lección no cubre algunos aspectos del uso de Linux), que permita la descarga e instalación de software y conexión a Internet que soporte la descarga de software. Según los usuarios, se necesitan entre 1 y 3 horas para completar toda la lección.
+**Requisitos:** una computadora (Mac/Windows/Linux funcionan, aunque esta lección no cubre algunos aspectos del uso de Linux y puede que tengas algunos problemas si estás utilizando una Mac con un chip de la serie-M), que permita la descarga e instalación de software y conexión a Internet que soporte la descarga de software. Según los usuarios, se necesitan entre 1 y 3 horas para completar toda la lección.
 
 **Nivel de dificultad:** Intermedio (esta lección no incluye el uso de línea de comandos y git, pero te ofrece todo lo necesario para que la completes).
 
@@ -191,6 +191,10 @@ A continuación, vamos a instalar algunas dependencias de software (es decir, pr
 ### En Mac <a id="sectionMac"></a>
 
 Si estás utilizando una computadora Mac, sigue las instrucciones que se encuentran a continuación.
+
+<div class="alert alert-warning">
+Ten en cuenta que si estás utilizando una Mac con un chip de la serie M puede que encuentres problemas de compatibilidad al instalar Jekyll o sus dependencias. Si ese es el caso, te recomendamos que sigas las instrucciones de instalación adicionales para el paquete correspondiente, tanto de la documentación original como de foros online.
+</div>
 
 Abre una ventana de línea de comandos (*Aplicaciones > Utilidades > Terminal*) e ingresa el código que se muestra en los pasos a continuación (`el código es el texto que aparece formateado así`) siguiendo [las sugerencias de uso de la línea de comandos detalladas más arriba](#section1-4).
 


### PR DESCRIPTION
Following the advice on the issue thread, I've prepared some changes to /en/lessons/building-static-sites-with-jekyll-github-pages, to warn users using a Mac with a M-series chip that they may have to follow additional installation instructions at certain steps. 

Closes #2836 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [x] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.
