### PR TITLE
Issue 3252

### DIFF
--- a/en/lessons/data-mining-the-internet-archive.md
+++ b/en/lessons/data-mining-the-internet-archive.md
@@ -662,7 +662,7 @@ from the fields, the possibilities can multiply rapidly!
   [multiple files]: http://archive.org/download/lettertowilliaml00doug
   [Dublin Core]: http://archive.org/download/lettertowilliaml00doug/lettertowilliaml00doug_dc.xml
   [MARCXML]: http://archive.org/download/lettertowilliaml00doug/lettertowilliaml00doug_marc.xml
-  [Library of Congress's MARC 21 Format for Bibliographic Data]: http://www.loc.gov/marc/bibliographic/
+  [Library of Congress's MARC 21 Format for Bibliographic Data]: https://www.librarianshipstudies.com/2017/10/marc-21.html
   [thousands of antislavery letters, manuscripts, and publications]: http://archive.org/search.php?query=collection%3Abplscas&sort=-publicdate
   [eBook and Texts]: https://archive.org/details/texts
   [the way that items and item URLs are structured]: http://blog.archive.org/2011/03/31/how-archive-org-items-are-structured/
@@ -674,8 +674,8 @@ from the fields, the possibilities can multiply rapidly!
   [remember those?]: /lessons/code-reuse-and-modularity
   [item files are named according to specific rules]: https://archive.org/about/faqs.php#140
   [handling exceptions]: http://docs.python.org/2/tutorial/errors.html#handling-exceptions
-  [rules specified for the 260 datafield]: http://www.loc.gov/marc/bibliographic/bd260.html
-  [MARC standards]: http://www.loc.gov/marc/
+  [rules specified for the 260 datafield]: https://www.oclc.org/bibformats/en/2xx/260.html
+  [MARC standards]: https://en.wikipedia.org/wiki/MARC_standards
   [1]: https://github.com/edsu/pymarc
   [functions that it provides for working with MARC XML records]: https://github.com/edsu/pymarc/blob/master/pymarc/marcxml.py
   [Counting Frequencies]: /lessons/counting-frequencies

--- a/es/lecciones/mineria-de-datos-en-internet-archive.md
+++ b/es/lecciones/mineria-de-datos-en-internet-archive.md
@@ -413,7 +413,7 @@ Desde luego, para que esta técnica sea útil se requiere hacer algo de [limpiez
 [múltiples archivos]: http://archive.org/download/lettertowilliaml00doug
 [Dublin Core]: http://archive.org/download/lettertowilliaml00doug/lettertowilliaml00doug_dc.xml
 [MARCXML]: http://archive.org/download/lettertowilliaml00doug/lettertowilliaml00doug_marc.xml
-[formato MARC 21 de la Biblioteca del Congreso para datos bibliográficos]: http://www.loc.gov/marc/bibliographic/
+[formato MARC 21 de la Biblioteca del Congreso para datos bibliográficos]: https://www.librarianshipstudies.com/2017/10/marc-21.html
 [cientos de cartas, manuscritos y  publicaciones antiesclavistas]: http://archive.org/search.php?query=collection%3Abplscas&sort=-publicdate
 [eBook and Texts]: https://archive.org/details/texts
 [elementos y sus URL están estructurados]: http://blog.archive.org/2011/03/31/how-archive-org-items-are-structured/
@@ -425,8 +425,8 @@ Desde luego, para que esta técnica sea útil se requiere hacer algo de [limpiez
 [remember those?]: /lessons/code-reuse-and-modularity
 [son nombrados de acuerdo a reglas específicas]: https://archive.org/about/faqs.php#140
 [manejo de excepciones]: http://docs.python.org/2/tutorial/errors.html#handling-exceptions
-[reglas específicas para el campo 260]: http://www.loc.gov/marc/bibliographic/bd260.html
-[estándares MARC]: http://www.loc.gov/marc/
+[reglas específicas para el campo 260]: https://www.oclc.org/bibformats/en/2xx/260.html
+[estándares MARC]: https://en.wikipedia.org/wiki/MARC_standards
 [1]: https://github.com/edsu/pymarc
 [algunas funciones que provee para trabajar con archivos MARC XML]: https://github.com/edsu/pymarc/blob/master/pymarc/marcxml.py
 [Contar frecuencias]: /es/lecciones/contar-frecuencias


### PR DESCRIPTION
I've replaced broken links in EN [Data Mining the Internet Archive Collection](https://programminghistorian.org/en/lessons/data-mining-the-internet-archive) and ES [Minería de datos en las colecciones del Internet Archive](https://programminghistorian.org/es/lecciones/mineria-de-datos-en-internet-archive).

I've set a reminder to look into the original links again to check if they have been fixed by the Library of Congress, in which case I will reinstate them in a new PR.

Closes #3252 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
