### PR TITLE
Create TEST-colab-notebook.md

### DIFF
--- a/en/lessons/TEST-colab-notebook.md
+++ b/en/lessons/TEST-colab-notebook.md
@@ -1,0 +1,29 @@
+---
+title: "Lesson Title"
+slug: TEST-colab-notebook
+layout: lesson
+collection: lessons
+date: 2024-07-05
+authors:
+- Charlotte Chevrie
+- Anisa Hawes
+reviewers:
+- Forename Surname
+- Forename Surname
+editors:
+- Forename Surname
+review-ticket: https://github.com/programminghistorian/ph-submissions/issues/123
+difficulty: 3
+activity: analyzing
+topics: [python, data-manipulation]
+abstract: Short abstract of this lesson
+avatar_alt: Visual description of lesson image
+doi: 10.46430/phen0120
+---
+
+{% include toc.html %}
+
+
+This is a test file to investigate the best ways to upload colab notebooks and link to them from within lessons.
+
+We are testing the [TEST-colab-notebook.ipynb](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/TEST-colab-notebook/TEST-colab-notebook.ipynb).


### PR DESCRIPTION
This is a test PR to investigate the best ways to upload colab notebooks and link to them from within lessons.

- In this PR, I'm creating TEST-colab-notebook.md (including nbviewer link)
- In #3309, I uploaded the `.ipynb` notebook asset

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- ~~[ ] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~~
- [ ] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [ ] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
