### PR TITLE
Issue 3316-b

### DIFF
--- a/en/lessons/computer-vision-deep-learning-pt1.md
+++ b/en/lessons/computer-vision-deep-learning-pt1.md
@@ -72,7 +72,7 @@ This two-part lesson does not aim to:
 We suggest approaching this two-part lesson in two stages:
 
 - First, read through the materials on this page, to gain familiarity with the key conceptual issues and the overall workflow for training a computer vision model
-- Second, we recommend that you run the code for this lesson through the [accompanying Jupyter Notebook](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1/computer-vision-deep-learning-pt1-2.ipynb) on Google Colab, which works well for the exploratory approch we will be following.
+- Second, we recommend that you run the code for this lesson through the [accompanying Jupyter Notebook](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1-2/computer-vision-deep-learning-pt1-2.ipynb) on Google Colab, which works well for the exploratory approch we will be following.
 
 In this two-part lesson we will be using a deep learning based approach to computer vision. The process of setting up an environment for doing deep learning has become easier but can still be complex. We have tried to keep this setup process as simple as possible, and recommend a fairly quick route to start running the lesson's code.
 
@@ -91,7 +91,7 @@ You can run the lesson code in a variety of different ways, but we strongly enco
 To run the lesson code on Google Colab you will need to:
 
 - Create a free account on [Google](https://accounts.google.com/signup) if you don't already have one, or log in to your existing account. A Google account is required to save and run notebooks on Colab.
-- [Open the notebook](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1/computer-vision-deep-learning-pt1-2.ipynb) and click the _Open in Colab_ button.
+- [Open the notebook](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1-2/computer-vision-deep-learning-pt1-2.ipynb) and click the _Open in Colab_ button.
 - Once the notebook is opened, you may want to save a copy to your own Google Drive. You can do this by selecting **File** > _Save a copy in Drive_.
 - To use a GPU, go to **Runtime** > **Change runtime type**, then under the `Hardware accelerator` dropdown, select a GPU option (e.g. T4 GPU) and click _Save_. This will enable GPU acceleration for your notebook. Colab occasionally changes which type of GPUs they make available. 
 

--- a/en/lessons/computer-vision-deep-learning-pt1.md
+++ b/en/lessons/computer-vision-deep-learning-pt1.md
@@ -20,7 +20,7 @@ review-ticket: https://github.com/programminghistorian/ph-submissions/issues/342
 difficulty: 3
 activity: analyzing
 topics: [python, machine-learning]
-abstract: This is the first of a two-part lesson introducing deep learning based computer vision methods for humanities research. Using a dataset of historical newspaper advertisements and the fastai Python library, the lesson walks through the pipeline of training a computer vision model to perform image classification. 
+abstract: This is the first of a two-part lesson introducing deep learning based computer vision methods for humanities research. Using a dataset of historical newspaper advertisements and the fastai Python library, the lesson walks through the pipeline of training a computer vision model to perform image classification.     
 mathjax: true
 avatar_alt: An illustration of a camera on top of a wooden stand with a dark cloth.
 next: computer-vision-deep-learning-pt2

--- a/en/lessons/computer-vision-deep-learning-pt2.md
+++ b/en/lessons/computer-vision-deep-learning-pt2.md
@@ -51,7 +51,7 @@ A particular focus of this lesson will be on how the fuzziness of concepts can t
 
 ## Lesson Set-Up
 
-We assume you have already completed [Part 1](/en/lessons/computer-vision-deep-learning-pt1), which includes setup instructions. You can find the notebook accompanying this lesson [here](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1/computer-vision-deep-learning-pt1-2.ipynb). Please see Part 1 of the lesson for more information on setting up if you need.
+We assume you have already completed [Part 1](/en/lessons/computer-vision-deep-learning-pt1), which includes setup instructions. You can find the notebook accompanying this lesson [here](https://nbviewer.org/github/programminghistorian/jekyll/blob/gh-pages/assets/computer-vision-deep-learning-pt1-2/computer-vision-deep-learning-pt1-2.ipynb). Please see Part 1 of the lesson for more information on setting up if you need.
 
 ## The Deep Learning Pipeline
 


### PR DESCRIPTION
I have updated the nbviewer links in `computer-vision-deep-learning-pt1` and `computer-vision-deep-learning-pt2` to reflect the change made to the asset folder name (now `computer-vision-deep-learning-pt1-2`).

Closes #3316 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
