### PR TITLE
Remove broken link in /es/lecciones/introduccion-a-tei-1

### DIFF
--- a/es/lecciones/introduccion-a-tei-1.md
+++ b/es/lecciones/introduccion-a-tei-1.md
@@ -399,7 +399,7 @@ En [la segunda parte](/es/lecciones/introduccion-a-tei-2) verás en detalle dos 
 
 - Una buena introducción a TEI es el libro *¿Qué es la iniciativa de codificación de textos? Cómo añadir marcado inteligente a los recursos digitales* de Lou Burnard (Marsella: OpenEdition Press, 2012/2022) [disponible gratuitamente en línea](https://books.openedition.org/oep/15662).
 
-- Un buen tutorial para XML está disponible en: [https://www.w3schools.com/xml/](https://www.w3schools.com/xml/) y en: [https://www.tutorialspoint.com/xml/index.htm](https://www.tutorialspoint.com/xml/index.htm).
+- Un buen tutorial para XML está disponible en: [https://www.w3schools.com/xml/](https://www.w3schools.com/xml/).
 
 - El consorcio TEI también ofrece [una buena introducción a XML](https://www.tei-c.org/release/doc/tei-p5-doc/en/html/SG.html).
 


### PR DESCRIPTION
I'm removing a broken link in ES lesson [Introducción a la codificación de textos en TEI (parte 1)](https://programminghistorian.org/es/lecciones/introduccion-a-tei-1), line 402.

**The Publishing Team will return to check this link next week, and replace it if available.**

Closes #3388 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
