### PR TITLE
Update geocodificando-qgis.md

### DIFF
--- a/pt/licoes/geocodificando-qgis.md
+++ b/pt/licoes/geocodificando-qgis.md
@@ -19,8 +19,8 @@ translator:
 translation-editor:
 - Joana Vieira Paulino
 translation-reviewer:
-- Ângela Pité
 - Diogo Paiva
+- Luis Ferla
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/565
 difficulty: 2
 activity: transforming


### PR DESCRIPTION
Correct name of second `translation-reviewer:` in geocodificando-qgis

Closes #3466 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.
