### PR TITLE
Issue-3362-retire-OCR-lesson

### DIFF
--- a/en/lessons/retired/OCR-and-Machine-Translation.md
+++ b/en/lessons/retired/OCR-and-Machine-Translation.md
@@ -17,6 +17,13 @@ topics: [data-manipulation]
 abstract: This lesson covers how to convert images of text into text files and translate those text files. The lesson will also cover how to organize and edit images to make the conversion and translation of whole folders of text files easier and more accurate. The lesson concludes with a discussion of the shortcomings of automated translation and how to overcome them.
 avatar_alt: An image of a tree with the Latin phrase Labor Omnia Vincit Improbus
 doi: 10.46430/phen0091
+redirect_from:
+  - /lessons/OCR-and-Machine-Translation
+  - /en/lessons/OCR-and-Machine-Translation
+retired: true
+retirement-reason: |
+  Users cannot successfully follow this lesson without substantially adaptating the instructions. Notably, the translation software Yandex is now deprecated. Overall, the lesson requires significant prior knowledge and applied experience, both to work through the steps as they are explained, and to adapt them to non-Mac operating systems and alternative software. 
+
 ---
 
 

--- a/en/lessons/retired/OCR-and-Machine-Translation.md
+++ b/en/lessons/retired/OCR-and-Machine-Translation.md
@@ -22,7 +22,7 @@ redirect_from:
   - /en/lessons/OCR-and-Machine-Translation
 retired: true
 retirement-reason: |
-  Users cannot successfully follow this lesson without substantially adaptating the instructions. Notably, the translation software Yandex is now deprecated. Overall, the lesson requires significant prior knowledge and applied experience, both to work through the steps as they are explained, and to adapt them to non-Mac operating systems and alternative software. 
+  Yandex, the translation software used in this lesson, has been deprecated. To successfully follow this lesson, many steps require significant adaptations, especially if users are working on a non-Mac operating system. 
 
 ---
 


### PR DESCRIPTION
I've prepared the retirement of `en/OCR-and-machine-translation`. There are no published translations, so this is the only lesson that needs to be retired.

Closes #3362 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
