### PR TITLE
Issue-3473-reinsert-sample

### DIFF
--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -331,7 +331,7 @@ small image) to your folder, and add the following somewhere in the body
 of the text: `![image caption](your_image.jpg)`.
 
 At this point, your `main.md` should look something like the following.
-You can [download this sample Markdown file](https://github.com/programminghistorian/jekyll/blob/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
+You can [download this sample Markdown file](/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
 
     ---
     title: Plain Text Workflow

--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -331,7 +331,7 @@ small image) to your folder, and add the following somewhere in the body
 of the text: `![image caption](your_image.jpg)`.
 
 At this point, your `main.md` should look something like the following.
-You can [download this sample Markdown file](/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
+You can [download this sample Markdown file](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
 
     ---
     title: Plain Text Workflow

--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -331,7 +331,7 @@ small image) to your folder, and add the following somewhere in the body
 of the text: `![image caption](your_image.jpg)`.
 
 At this point, your `main.md` should look something like the following.
-You can [download this sample Markdown file](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
+You can [download this sample Markdown file](https://github.com/programminghistorian/jekyll/blob/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
 
     ---
     title: Plain Text Workflow

--- a/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
+++ b/en/lessons/sustainable-authorship-in-plain-text-using-pandoc-and-markdown.md
@@ -331,7 +331,7 @@ small image) to your folder, and add the following somewhere in the body
 of the text: `![image caption](your_image.jpg)`.
 
 At this point, your `main.md` should look something like the following.
-You can download this sample Markdown file from the _Programming Historian_ repository.
+You can [download this sample Markdown file](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) from the _Programming Historian_ repository.
 
     ---
     title: Plain Text Workflow

--- a/fr/lecons/redaction-durable-avec-pandoc-et-markdown.md
+++ b/fr/lecons/redaction-durable-avec-pandoc-et-markdown.md
@@ -147,7 +147,7 @@ Enregistrons maintenant notre document avant d'aller plus loin. Créez un nouvea
 
 Une fois le fichier enregistré, ajoutons-y une illustration. Copiez n'importe quelle image de petite taille dans votre dossier, et ajoutez ceci au corps du texte: `![Légende de l'image](votre_image.jpg)`.
 
-À ce stade, le fichier 'projet.md' devrait ressembler au texte ci-dessous. Vous pouvez télécharger cet exemple de fichier Markdown depuis le dépot de _Programming Historian_.
+À ce stade, le fichier 'projet.md' devrait ressembler au texte ci-dessous. Vous pouvez [télécharger cet exemple de fichier Markdown](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) depuis le dépot de _Programming Historian_.
 
 ```
 ---


### PR DESCRIPTION
I've reinserted the links to the [sample.md](https://github.com/programminghistorian/jekyll/blob/gh-pages/assets/sustainable-authorship-in-plain-text-using-pandoc-and-markdown/sample.md) asset in `en/sustainable-authorship-in-plain-text-using-pandoc-and-markdown` and `fr/redaction-durable-avec-pandoc-et-markdown`.

Closes #3473 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
