### PR TITLE
Issue-3481-close-CfP

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -20,7 +20,7 @@ These guidelines have been developed to help you understand the process of creat
 ## Step 1: Proposing a New Lesson
 
 <div class="alert alert-success">
-Our English journal is currently seeking proposals for new original lessons or translations to be considered for publication in 2025. Learn more in our <a href="/posts/en-call-for-proposals">call for proposals</a>, open until 31 January 2025 (extended deadline). Submissions to our <a href="/es/guia-para-autores#paso-1-proponer-una-nueva-lección">Spanish</a>, <a href="/posts/appel-a-propositions">French</a> and <a href="/pt/directrizes-autor#etapa-1-propor-uma-nova-lição">Portuguese</a> journals are open year-round.
+Our English journal will open its next annual submission window in October 2025. In the meantime, you may find it useful to <a href="/posts/en-call-for-proposals">consult our past call for proposals</a> (closed in January 2025). Submissions to our <a href="/es/guia-para-autores#paso-1-proponer-una-nueva-lección">Spanish</a>, <a href="/fr/consignes-auteurs#étape-1-proposer-une-nouvelle-leçon">French</a> and <a href="/pt/directrizes-autor#etapa-1-propor-uma-nova-lição">Portuguese</a> journals are open year-round.
 </div>
 
 You can get a sense of what we publish by looking through our [published lessons]({{site.baseurl}}/en/lessons), reading our [reviewer guidelines]({{site.baseurl}}/en/reviewer-guidelines) or browsing [lessons in development](https://github.com/programminghistorian/ph-submissions/tree/gh-pages/en/drafts). Please also take a moment to check our [Lesson Concordance document](https://docs.google.com/spreadsheets/d/1vrvZTygZLfQRoQildD667Xcgzhf_reQC8Nq4OD-BRIA/edit#gid=0) to see which methods we have already covered in our published or forthcoming lessons. 

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -11,7 +11,7 @@ The _Programming Historian_ runs on the far-from-endless energy of volunteers, a
 ## Write a new lesson
 
 <div class="alert alert-success">
-Our English journal is currently seeking proposals for new original lessons or translations to be considered for publication in 2025. Learn more in our <a href="/posts/en-call-for-proposals">call for proposals</a>, open until 31 January 2025 (extended deadline). Submissions to our <a href="/es/guia-para-autores#paso-1-proponer-una-nueva-lección">Spanish</a>, <a href="/posts/appel-a-propositions">French</a> and <a href="/pt/directrizes-autor#etapa-1-propor-uma-nova-lição">Portuguese</a> journals are open year-round.
+Our English journal will open its next annual submission window in October 2025. In the meantime, you may find it useful to <a href="/posts/en-call-for-proposals">consult our past call for proposals</a> (closed in January 2025). Submissions to our <a href="/es/guia-para-autores#paso-1-proponer-una-nueva-lección">Spanish</a>, <a href="/fr/consignes-auteurs#étape-1-proposer-une-nouvelle-leçon">French</a> and <a href="/pt/directrizes-autor#etapa-1-propor-uma-nova-lição">Portuguese</a> journals are open year-round.
 </div>
 
 <img src="{{site.baseurl}}/images/website/woman-at-writing-desk.png" class="garnish rounded float-right" alt="{{ site.data.snippets.write-a-lesson-image-alt[page.lang] }}"/>


### PR DESCRIPTION
I have updated the text on the website after closing our most recent EN CfP. I've added the template text boxes to [the wiki](https://github.com/programminghistorian/jekyll/wiki/Call-for-Proposals#text-boxes-on-website) for future reference.

Closes #3481 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
