### PR TITLE
Issue-3489-texas-link

### DIFF
--- a/es/lecciones/exhibicion-con-collection-builder.md
+++ b/es/lecciones/exhibicion-con-collection-builder.md
@@ -559,6 +559,6 @@ Si necesitas realizar cambios en la página web, puedes hacerlos en tu repositor
 CollectionBuilder cuenta con funcionalidades extra que puedes ir añadiendo cuando te sientas más cómodo/a con el manejo de los archivos en el respositorio. Además, están ampliando la herramienta poco a poco. Visita su página web[https://collectionbuilder.github.io](https://collectionbuilder.github.io) de vez en cuando para ver nuevas actualizaciones.  
 
 ## Agradecimiento
-Esta lección fue escrita a partir de los materiales creados para un taller virtual de capacitación digital para las organizaciones latinoamericanas que colaboran con el repositorio de [Iniciativas Digitales de América Latina](https://ladi.lib.utexas.edu/es) de la Universidad de Texas en Austin y financiada por una beca de la Andrew W. Mellon Foundation.
+Esta lección fue escrita a partir de los materiales creados para un taller virtual de capacitación digital para las organizaciones latinoamericanas que colaboran con el repositorio de [Iniciativas Digitales de América Latina](https://ladi.lib.utexas.edu/) de la Universidad de Texas en Austin y financiada por una beca de la Andrew W. Mellon Foundation.
 
 ## Notas


### PR DESCRIPTION
I've replaced the old link https://ladi.lib.utexas.edu/es/ with its new version https://ladi.lib.utexas.edu/.

This link only appears once in our lessons, in `es/lecciones/exhibicion-con-collection-builder`.

Closes #3489 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
