### PR TITLE
Issue 3501

### DIFF
--- a/en/lessons/geocoding-qgis.md
+++ b/en/lessons/geocoding-qgis.md
@@ -13,6 +13,9 @@ difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/27
 activity: transforming
 topics: [mapping]
+previous: georeferencing-qgis
+series_total: 5 lessons
+sequence: 5
 abstract: |
   Learn how to use QGIS to convert lists of place names in to geographic coordinates, allowing you to map them.
 redirect_from: /lessons/geocoding-qgis

--- a/en/lessons/georeferencing-qgis.md
+++ b/en/lessons/georeferencing-qgis.md
@@ -20,7 +20,7 @@ exclude_from_check:
 abstract: "In this lesson, you will learn how to georeference historical maps so
 that they may be added to a GIS as a raster layer."
 previous: vector-layers-qgis
-series_total: 4 lessons
+series_total: 5 lessons
 sequence: 4
 redirect_from: /lessons/georeferencing-qgis
 avatar_alt: Map of a moutnaintop city

--- a/en/lessons/georeferencing-qgis.md
+++ b/en/lessons/georeferencing-qgis.md
@@ -20,6 +20,7 @@ exclude_from_check:
 abstract: "In this lesson, you will learn how to georeference historical maps so
 that they may be added to a GIS as a raster layer."
 previous: vector-layers-qgis
+next: geocoding-qgis
 series_total: 5 lessons
 sequence: 4
 redirect_from: /lessons/georeferencing-qgis

--- a/en/lessons/googlemaps-googleearth.md
+++ b/en/lessons/googlemaps-googleearth.md
@@ -20,7 +20,7 @@ abstract: "Google My Maps and Google Earth provide an easy way to start creating
 digital maps. With a Google Account you can create and edit personal
 maps by clicking on My Places."
 next: qgis-layers
-series_total: 4 lessons
+series_total: 5 lessons
 sequence: 1 
 redirect_from: /lessons/googlemaps-googleearth
 avatar_alt: An old man consulting a large globe with a compass

--- a/en/lessons/qgis-layers.md
+++ b/en/lessons/qgis-layers.md
@@ -21,7 +21,7 @@ like shapefiles and GeoTIFFs, and create a map out of a number of vector
 and raster layers."
 next: vector-layers-qgis
 previous: googlemaps-googleearth
-series_total: 4 lessons
+series_total: 5 lessons
 sequence: 2 
 redirect_from: /lessons/qgis-layers
 avatar_alt: Elevation view view of a mountain range

--- a/en/lessons/vector-layers-qgis.md
+++ b/en/lessons/vector-layers-qgis.md
@@ -21,7 +21,7 @@ abstract: "In this lesson you will learn how to create vector layers based on
 scanned historical maps."
 next: georeferencing-qgis
 previous: qgis-layers
-series_total: 4 lessons
+series_total: 5 lessons
 sequence: 3
 redirect_from: /lessons/vector-layers-qgis
 avatar_alt: Map of city streets

--- a/es/lecciones/analisis-redes-sociales-teatro-1.md
+++ b/es/lecciones/analisis-redes-sociales-teatro-1.md
@@ -12,6 +12,9 @@ reviewers:
 editors:
 - Jennifer Isasi
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/517
+next: analisis-redes-sociales-teatro-2
+series_total: 2 lessons
+sequence: 1
 difficulty: 1
 activity: analyzing
 topics: [network-analysis, get-ready, distant-reading]

--- a/es/lecciones/analisis-redes-sociales-teatro-2.md
+++ b/es/lecciones/analisis-redes-sociales-teatro-2.md
@@ -12,6 +12,9 @@ reviewers:
 editors:
 - Jennifer Isasi
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/547
+previous: analisis-redes-sociales-teatro-1
+series_total: 2 lessons
+sequence: 2
 difficulty: 2
 activity: analyzing
 topics: [network-analysis, distant-reading, data-visualization]

--- a/es/lecciones/introduccion-a-tei-1.md
+++ b/es/lecciones/introduccion-a-tei-1.md
@@ -12,6 +12,9 @@ reviewers:
   - Rocío Méndez
   - Iñaki Cano
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/366
+next: introduccion-a-tei-2
+series_total: 2 lessons
+sequence: 1
 difficulty: 2
 activity: transforming
 topics:

--- a/es/lecciones/introduccion-a-tei-2.md
+++ b/es/lecciones/introduccion-a-tei-2.md
@@ -12,6 +12,9 @@ editors:
 reviewers:
   - David Merino Recalde
   - Rosa María Muñoz Mendo
+previous: introduccion-a-tei-1
+series_total: 2 lessons
+sequence: 2
 difficulty: 2
 activity: transforming
 topics:

--- a/fr/lecons/du-html-a-une-liste-de-mots-1.md
+++ b/fr/lecons/du-html-a-une-liste-de-mots-1.md
@@ -23,6 +23,9 @@ translation-reviewer:
 - Marie Flesch
 difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/560
+next: du-html-a-une-liste-de-mots-2
+series_total: 2 lessons
+sequence: 1
 activity: transforming
 topics: [python]
 abstract: Dans cette leçon en deux parties, nous allons utiliser les compétences acquises dans la leçon &laquo;&nbsp;Télécharger des pages web avec Python&nbsp;&raquo;, et voir comment supprimer les *balises HTML* de la page de la transcription du procès-verbal de Benjamin Bowsey en 1780 dans le but de créer un texte propre et réutilisable. Nous réaliserons cette tâche en utilisant les *opérateurs et méthodes de chaines de caractères* propres à Python, ainsi que nos compétences relatives à la *lecture attentive*. Nous introduirons ensuite les concepts de *boucles* et *d’instructions conditionnelles* afin de répéter notre processus de traitement et de tester certaines conditions nous permettant de séparer le contenu des balises HTML. Pour finir, nous convertirons les données obtenues et enregistrées sous la forme d’un texte sans balises HTML en une *liste de mots* qui pourra par la suite être triée, indexée et investie lors d’analyses statistiques.

--- a/fr/lecons/du-html-a-une-liste-de-mots-2.md
+++ b/fr/lecons/du-html-a-une-liste-de-mots-2.md
@@ -23,6 +23,9 @@ translation-reviewer:
 - Florian Barras
 difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/584
+previous: du-html-a-une-liste-de-mots-1
+series_total: 2 lessons
+sequence: 2
 activity: transforming
 topics: [python]
 abstract: Dans cette leçon, nous allons implémenter l'algorithme découvert dans la leçon &laquo;&nbsp;Du HTML à une liste de mots, partie 1&nbsp;&raquo;, afin d'apprendre à découper une chaine de caractères en une liste de mots.

--- a/pt/licoes/HTML-lista-palavras-1.md
+++ b/pt/licoes/HTML-lista-palavras-1.md
@@ -22,6 +22,9 @@ translation-reviewer:
 - Diana Rebelo Rodriguez
 difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/442
+next: HTML-lista-palavras-1
+series_total: 2 lessons
+sequence: 1
 activity: transforming
 topics: [python]
 abstract: "Nesta lição de duas partes, aprofundaremos o que aprendeu sobre o Download de Páginas Web com Python, aprendendo como remover a marcação HTML de uma página web da transcrição do julgamento criminal de Benjamin Bowsey em 1780. Faremos isso usando uma variedade de operadores de string, métodos de string e habilidades de leitura atenta. Introduziremos looping e branching de modo que os programas possam repetir tarefas e testar certas condições, tornando possível a separação do conteúdo das tags HTML. Finalmente, faremos a conversão do conteúdo de uma string longa para uma lista de palavras, que podem ser ordenadas, indexadas e contabilizadas posteriormente."

--- a/pt/licoes/HTML-lista-palavras-2.md
+++ b/pt/licoes/HTML-lista-palavras-2.md
@@ -22,6 +22,9 @@ translation-reviewer:
 - Diana Rebelo Rodriguez
 difficulty: 2
 review-ticket: https://github.com/programminghistorian/ph-submissions/issues/443
+previous: HTML-lista-palavras-1
+series_total: 2 lessons
+sequence: 2
 activity: transforming
 topics: [python]
 abstract: "Nesta lição aprenderá os comandos de Python necessários para implementar a segunda parte do algoritmo iniciado na lição 'De HTML para Lista de Palavras (parte 1)'."


### PR DESCRIPTION
I've added next/previous buttons to multi-part lessons which were missing them.

Closes #3501 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
