### PR TITLE
Issue-3546-reviewer-tinyurls

### DIFF
--- a/_posts/2024-09-27-bulletin-issue-04.md
+++ b/_posts/2024-09-27-bulletin-issue-04.md
@@ -37,7 +37,7 @@ We’re proudly committed to an **Open Review policy**, in which peer reviewers 
 
 Please register your interest to participate in your preferred language(s):
 
-[Form in English](https://tinyurl.com/en-ph-peer-review) // [Formulario en español](https://tinyurl.com/es-ph-revision-por-pares) // [Formulaire en français](https://tinyurl.com/fr-ph-evaluation)
+[Form in English](https://tinyurl.com/en-ph-peer-review) // [Formulario en español](https://tinyurl.com/es-ph-revision-por-pares) // [Formulaire en français](https://tinyurl.com/fr-ph-evaluation) // [Enviar um email ao Editor-Chefe em português](mailto:portugues@programminghistorian.org)
 
 ## New Lessons
 

--- a/_posts/2024-09-27-bulletin-issue-04.md
+++ b/_posts/2024-09-27-bulletin-issue-04.md
@@ -37,7 +37,7 @@ We’re proudly committed to an **Open Review policy**, in which peer reviewers 
 
 Please register your interest to participate in your preferred language(s):
 
-[Form in English](https://forms.gle/9nPjy9t8Bzf2FUdy9) // [Formulario en español](https://forms.gle/u3BS29FqH84bMxP37) // [Formulaire en français](https://forms.gle/tKZQJvhqjfps6Sua6)
+[Form in English](https://tinyurl.com/en-ph-peer-review) // [Formulario en español](https://tinyurl.com/es-ph-revision-por-pares) // [Formulaire en français](https://tinyurl.com/fr-ph-evaluation)
 
 ## New Lessons
 

--- a/_posts/2024-12-13-bulletin-issue-05.md
+++ b/_posts/2024-12-13-bulletin-issue-05.md
@@ -61,7 +61,7 @@ Reviewing for _Programming Historian_ is a great opportunity to **learn new tech
 
 Please register your interest to participate in your preferred language(s):
 
-[Form in English](https://forms.gle/9nPjy9t8Bzf2FUdy9) // [Formulario en español](https://forms.gle/u3BS29FqH84bMxP37) // [Formulaire en français](https://forms.gle/u3BS29FqH84bMxP37) // [Enviar um email ao Editor-Chefe](mailto:portugues@programminghistorian.org)
+[Form in English](https://tinyurl.com/en-ph-peer-review) // [Formulario en español](https://tinyurl.com/es-ph-revision-por-pares) // [Formulaire en français](https://tinyurl.com/fr-ph-evaluation) // [Enviar um email ao Editor-Chefe](mailto:portugues@programminghistorian.org)
 
 ## Call for Proposals
 

--- a/_posts/2025-03-28-bulletin-issue-06.md
+++ b/_posts/2025-03-28-bulletin-issue-06.md
@@ -80,7 +80,7 @@ Reviewing for _Programming Historian_ is a great opportunity to **learn new tech
 
 Please register your interest to participate in your preferred language(s):
 
-[Form in English](https://forms.gle/9nPjy9t8Bzf2FUdy9) // [Formulario en español](https://forms.gle/u3BS29FqH84bMxP37) // [Formulaire en français](https://forms.gle/u3BS29FqH84bMxP37) // [Enviar um email ao Editor-Chefe em português](mailto:portugues@programminghistorian.org)
+[Form in English](https://tinyurl.com/en-ph-peer-review) // [Formulario en español](https://tinyurl.com/es-ph-revision-por-pares) // [Formulaire en français](https://tinyurl.com/fr-ph-evaluation) // [Enviar um email ao Editor-Chefe em português](mailto:portugues@programminghistorian.org)
 
 ------    
 Next issue: June 2025. Follow us on social media to stay updated on our new publications, research and events!

--- a/assets/forms/en-ph-peer-review-form.txt
+++ b/assets/forms/en-ph-peer-review-form.txt
@@ -27,8 +27,8 @@ ORCID ID:
 2. Which languages would you be comfortable reviewing in? If you would like to review in any other language, please take the time to fill in the expression of interest form in those languages too.
 
 - [ ] English 
-- [ ] Español – Expression of Interest form: https://forms.gle/L1vXpoave9P7M7U76
-- [ ] Français – Expression of Interest form: https://forms.gle/B4g3r3qiUx6tn3RB8
+- [ ] Español – Expression of Interest form: https://tinyurl.com/es-ph-revision-por-pares
+- [ ] Français – Expression of Interest form: https://tinyurl.com/fr-ph-evaluation
 - [ ] Português – Please email: portugues@programminghistorian.org
 
 3. Are you available to review within the next 12 months? (If a lesson relevant to your specialism/technical expertise is submitted.)

--- a/assets/forms/es-ph-revisión-por-pares-formulario.txt
+++ b/assets/forms/es-ph-revisión-por-pares-formulario.txt
@@ -26,9 +26,9 @@ ORCID ID:
 
 2. ¿En qué lenguajes te sentirías cómodo revisando?
 
-- [ ] English - formulario: https://forms.gle/Fdm8JXstKEKZX2xt6
+- [ ] English - formulario: https://tinyurl.com/en-ph-peer-review
 - [ ] Español
-- [ ] Français - formulario: https://forms.gle/B4g3r3qiUx6tn3RB8
+- [ ] Français - formulario: https://tinyurl.com/fr-ph-evaluation
 - [ ] Português - envía un email: portugues@programminghistorian.org
 
 3. ¿Estás disponible para revisar dentro de los próximos doce meses? (Si recibimos una lección relevante a tu especialidad/experiencia técnica.)

--- a/assets/forms/fr-ph-evaluation-par-les-pairs-formulaire.txt
+++ b/assets/forms/fr-ph-evaluation-par-les-pairs-formulaire.txt
@@ -26,8 +26,8 @@ Numéro d'identifiant ORCID :
 
 2. Dans quelle(s) langue(s) pourriez-vous également évaluer ? Si vous souhaitez participer dans une autre langue, nous vous prions de remplir le formulaire correspondant également.
 
-- [ ] English – Formulaire : https://forms.gle/Fdm8JXstKEKZX2xt6
-- [ ] Español – Formulaire : https://forms.gle/L1vXpoave9P7M7U76
+- [ ] English – Formulaire : https://tinyurl.com/en-ph-peer-review
+- [ ] Español – Formulaire : https://tinyurl.com/es-ph-revision-por-pares
 - [ ] Français
 - [ ] Português – Merci d'envoyer un courriel: portugues@programminghistorian.org
 

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -24,7 +24,7 @@ We don't simply accept or reject articles like traditional journals. Our editors
 
 We are proud to use an Open Peer Review system. We think this provides a valuable opportunity for collaboration between authors, translators and peers in the global community. The peer review process also supports productive knowledge exchange, and helps us to shape lessons that are practical, accessible, and sustainable. 
 
-If you would like to contribute as a peer reviewer, please take a few minutes to [register your interest via our Google Form](https://tinyurl.com/en-ph-peer-review) which you can submit directly online. There's also [a plain-text version](/assets/forms/en-ph-peer-review-form.txt) which you can [send to us by email](mailto:publishing.assistant@programminghistorian.org), if you prefer. Our English edition is currently seeking volunteers who are available to review a lesson within the next 6 months. 
+If you would like to contribute as a peer reviewer, please take a few minutes to [register your interest via our Google Form](https://tinyurl.com/en-ph-peer-review) which you can submit directly online. There's also [a plain-text version](/assets/forms/en-ph-peer-review-form.txt) which you can [send to us by email](mailto:publishing.assistant@programminghistorian.org), if you prefer. We seek volunteers who are available to review a lesson within 12 months of registering their interest.
 
 ## Edit lessons
 

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -24,7 +24,7 @@ We don't simply accept or reject articles like traditional journals. Our editors
 
 We are proud to use an Open Peer Review system. We think this provides a valuable opportunity for collaboration between authors, translators and peers in the global community. The peer review process also supports productive knowledge exchange, and helps us to shape lessons that are practical, accessible, and sustainable. 
 
-If you would like to contribute as a peer reviewer, please take a few minutes to [register your interest via our Google Form](https://forms.gle/Fdm8JXstKEKZX2xt6) which you can submit directly online. There's also [a plain-text version](/assets/forms/en-ph-peer-review-form.txt) which you can [send to us by email](mailto:publishing.assistant@programminghistorian.org), if you prefer. Our English edition is currently seeking volunteers who are available to review a lesson within the next 6 months. 
+If you would like to contribute as a peer reviewer, please take a few minutes to [register your interest via our Google Form](https://tinyurl.com/en-ph-peer-review) which you can submit directly online. There's also [a plain-text version](/assets/forms/en-ph-peer-review-form.txt) which you can [send to us by email](mailto:publishing.assistant@programminghistorian.org), if you prefer. Our English edition is currently seeking volunteers who are available to review a lesson within the next 6 months. 
 
 ## Edit lessons
 

--- a/en/reviewer-guidelines.md
+++ b/en/reviewer-guidelines.md
@@ -13,6 +13,8 @@ Reviewing for the _Programming Historian_ is a great way to learn new technical 
 
 These guidelines are to help reviewers understand their role in the editorial process and to answer common questions about how to be most efficient and effective with your reviews.
 
+If you would like to contribute as a peer reviewer, please take a few minutes to [register your interest via our Google Form](https://tinyurl.com/en-ph-peer-review) which you can submit directly online. There's also [a plain-text version](/assets/forms/en-ph-peer-review-form.txt) which you can [send to us by email](mailto:publishing.assistant@programminghistorian.org), if you prefer. We seek volunteers who are available to review a lesson within 12 months of registering their interest.
+
 {% include toc.html %}
 
 

--- a/es/contribuciones.md
+++ b/es/contribuciones.md
@@ -25,7 +25,7 @@ En <i>Programming Historian en español</i> buscamos revisores voluntarios para 
 
 Estamos orgullosos de utilizar un sistema de revisión por pares en abierto. Creemos que esto brinda una valiosa oportunidad para que autores, traductores y revisores de la comunidad global colaboren, intercambiando conocimientos de manera productiva y así ayudarnos a crear lecciones que sean prácticas, accesibles y sostenibles. 
 
-Si desea contribuir como revisor por pares, tómese unos minutos para [registrar su interés a través de nuestro formulario de Google](https://tinyurl.com/es-ph-revision-por-pares), que puede enviar directamente en línea. También hay [una versión de texto sin formato](/assets/forms/es-ph-revisión-por-pares-formulario.txt) que puede [enviarnos por correo electrónico](mailto:publishing.assistant@programminghistorian.org) si lo prefiere. Nuestra edición de en español actualmente está buscando voluntarios que estén disponibles para revisar una lección dentro de los próximos 12 meses.
+Si desea contribuir como revisor por pares, tómese unos minutos para [registrar su interés a través de nuestro formulario de Google](https://tinyurl.com/es-ph-revision-por-pares), que puede enviar directamente en línea. También hay [una versión de texto sin formato](/assets/forms/es-ph-revisión-por-pares-formulario.txt) que puede [enviarnos por correo electrónico](mailto:publishing.assistant@programminghistorian.org) si lo prefiere. Nuestra edición en español actualmente está buscando voluntarios que estén disponibles para revisar una lección dentro de los próximos 12 meses.
 
 ## Escribe una lección
 

--- a/es/contribuciones.md
+++ b/es/contribuciones.md
@@ -25,7 +25,7 @@ En <i>Programming Historian en español</i> buscamos revisores voluntarios para 
 
 Estamos orgullosos de utilizar un sistema de revisión por pares en abierto. Creemos que esto brinda una valiosa oportunidad para que autores, traductores y revisores de la comunidad global colaboren, intercambiando conocimientos de manera productiva y así ayudarnos a crear lecciones que sean prácticas, accesibles y sostenibles. 
 
-Si desea contribuir como revisor por pares, tómese unos minutos para [registrar su interés a través de nuestro formulario de Google](https://forms.gle/L1vXpoave9P7M7U76), que puede enviar directamente en línea. También hay [una versión de texto sin formato](/assets/forms/es-ph-revisión-por-pares-formulario.txt) que puede [enviarnos por correo electrónico](mailto:publishing.assistant@programminghistorian.org) si lo prefiere. Nuestra edición de en español actualmente está buscando voluntarios que estén disponibles para revisar una lección dentro de los próximos 12 meses.
+Si desea contribuir como revisor por pares, tómese unos minutos para [registrar su interés a través de nuestro formulario de Google](https://tinyurl.com/es-ph-revision-por-pares), que puede enviar directamente en línea. También hay [una versión de texto sin formato](/assets/forms/es-ph-revisión-por-pares-formulario.txt) que puede [enviarnos por correo electrónico](mailto:publishing.assistant@programminghistorian.org) si lo prefiere. Nuestra edición de en español actualmente está buscando voluntarios que estén disponibles para revisar una lección dentro de los próximos 12 meses.
 
 ## Escribe una lección
 

--- a/es/guia-para-revisores.md
+++ b/es/guia-para-revisores.md
@@ -11,11 +11,10 @@ original: reviewer-guidelines
 
 Esta guía pretende responder preguntas frecuentes y ayudar a los revisores a comprender mejor su rol durante el proceso editorial.
 
+Si desea contribuir como revisor por pares, tómese unos minutos para [registrar su interés a través de nuestro formulario de Google](https://tinyurl.com/es-ph-revision-por-pares), que puede enviar directamente en línea. También hay [una versión de texto sin formato](/assets/forms/es-ph-revisión-por-pares-formulario.txt) que puede [enviarnos por correo electrónico](mailto:publishing.assistant@programminghistorian.org) si lo prefiere. Nuestra edición en español actualmente está buscando voluntarios que estén disponibles para revisar una lección dentro de los próximos 12 meses.
+
 {% include toc.html %}
 
-<div class="alert alert-success">
-En <i>Programming Historian en español</i> buscamos revisores voluntarios para contribuir al desarrollo de lecciones que se publicarán a lo largo de 2025. Si quieres saber más sobre cómo participar, <a href="/posts/es-buscamos-revisores">lee nuestro blogpost</a>.
-</div>
 
 ## Nuestra filosofía
 Para el equipo de _The Programming Historian en español_ revisar una traducción o una lección nueva constituye una oportunidad para aprender una nueva habilidad (a cualquier nivel) y para contribuir en la comunidad de humanidades digitales al mismo tiempo. Por eso nos esforzarmos en que nuestros revisores reciban crédito y reconocimiento por su trabajo.

--- a/fr/consignes-evaluateurs.md
+++ b/fr/consignes-evaluateurs.md
@@ -13,6 +13,8 @@ Devenir évaluateur(trice) pour le _Programming Historian en français_ est une 
 
 Ces consignes sont destinées à aider les évaluateurs et les évaluatrices à comprendre quel est leur rôle dans le processus éditorial, et à répondre aux questions les plus fréquentes concernant la manière la plus efficace de produire des évaluations.
 
+Si vous souhaitez contribuer en tant qu’évaluatrice ou évaluateur, veuillez prendre quelques minutes pour [faire part de votre intérêt via notre formulaire Google](https://tinyurl.com/fr-ph-evaluation) que vous pouvez soumettre directement en ligne. Il existe également [une version texte](/assets/forms/fr-ph-evaluation-par-les-pairs-formulaire.txt) que vous pouvez [nous envoyer par mail](mailto:publishing.assistant@programminghistorian.org), si vous préférez. Notre édition française cherche actuellement des volontaires disponibles pour évaluer une leçon dans les 12 prochains mois.
+
 {% include toc.html %}
 
 

--- a/fr/contribuer.md
+++ b/fr/contribuer.md
@@ -22,7 +22,7 @@ Si vous souhaitez proposer une leçon, que vous en soyez l'auteur(e) ou pas, mer
 
 Nous sommes fiers de notre politique ouverte d'évaluation par les pairs. Nous pensons que ce système offre une occasion précieuse de collaboration entre les auteurs/res, les traducteur/rices et leurs pairs de la communauté internationale d’humanités numériques. L’évaluation ouverte favorise un échange de connaissances productif et nous aide à élaborer des leçons utiles, accessibles et durables. 
 
-Si vous souhaitez contribuer en tant qu’évaluatrice ou évaluateur, veuillez prendre quelques minutes pour [faire part de votre intérêt via notre formulaire Google](https://forms.gle/B4g3r3qiUx6tn3RB8) que vous pouvez soumettre directement en ligne. Il existe également [une version texte](/assets/forms/fr-ph-evaluation-par-les-pairs-formulaire.txt) que vous pouvez [nous envoyer par mail](mailto:publishing.assistant@programminghistorian.org), si vous préférez. Notre édition française cherche actuellement des volontaires disponibles pour évaluer une leçon dans les 12 prochains mois.
+Si vous souhaitez contribuer en tant qu’évaluatrice ou évaluateur, veuillez prendre quelques minutes pour [faire part de votre intérêt via notre formulaire Google](https://tinyurl.com/fr-ph-evaluation) que vous pouvez soumettre directement en ligne. Il existe également [une version texte](/assets/forms/fr-ph-evaluation-par-les-pairs-formulaire.txt) que vous pouvez [nous envoyer par mail](mailto:publishing.assistant@programminghistorian.org), si vous préférez. Notre édition française cherche actuellement des volontaires disponibles pour évaluer une leçon dans les 12 prochains mois.
 
 ## Assurer le suivi éditorial d'une leçon
 


### PR DESCRIPTION
I've updated the links to our reviewer sign-up form to use TinyURLs instead of the google form links.

Closes #3546 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
