### PR TITLE
Issue-3618-link-format

### DIFF
--- a/en/lessons/correspondence-analysis-in-R.md
+++ b/en/lessons/correspondence-analysis-in-R.md
@@ -61,7 +61,7 @@ With more data, CA can uncover more subtle distinctions among groups within a pa
 
 ## Canadian Parliamentary Committees
 
-In the Canadian Parliamentary system, citizens elect representatives called Members of Parliament, or MPs, to the House of Commons. MPs are responsible for voting on and proposing changes to legislation in Canada. [Parliamentary Committees (CPCs)](http://www.ourcommons.ca/Committees/en/Home) consist of MPs who inform the House about important details of policy in a topic area. Examples of such committees include the CPCs on Finance, Justice and Health.
+In the Canadian Parliamentary system, citizens elect representatives called Members of Parliament, or MPs, to the House of Commons. MPs are responsible for voting on and proposing changes to legislation in Canada. [Parliamentary Committees (CPCs)](https://www.ourcommons.ca/Committees/en/Home) consist of MPs who inform the House about important details of policy in a topic area. Examples of such committees include the CPCs on Finance, Justice and Health.
 
 We will use abbreviations for the parliamentary committees because the names can get long, making them hard to read on a plot. You can use this table as a reference guide for the abbreviations and their respective committee names:
 

--- a/es/lecciones/introduccion-a-tei-1.md
+++ b/es/lecciones/introduccion-a-tei-1.md
@@ -94,7 +94,7 @@ Ahora bien, para realizar el segundo tipo de validación, es preciso que en el d
   schematypens="http://purl.oclc.org/dsdl/schematron"?>
 ```
 
-Puedes bajar una plantilla básica de un documento TEI-XML [aquí](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/introduccion-a-tei-1/plantilla-TEI.xml), con estas líneas ya incluidas.
+Puedes bajar una plantilla básica de un documento TEI-XML [aquí](/assets/introduccion-a-tei-1/plantilla-TEI.xml), con estas líneas ya incluidas.
 
 **Tercero**, la extensión ofrece también una herramientas para autocompletar el código de XML a partir del esquema de validación RELAX NG. Por ejemplo, si hemos introducido en el documento un elemento `<q>` (para marcar un texto entrecomillado, por ejemplo una cita), podemos presionar la barra espaciador luego del `q` de la etiqueta de apertura y VS Code nos mostrará una lista de atributos posibles para seleccionar en el menú:
 

--- a/es/lecciones/introduccion-a-tei-1.md
+++ b/es/lecciones/introduccion-a-tei-1.md
@@ -94,7 +94,7 @@ Ahora bien, para realizar el segundo tipo de validación, es preciso que en el d
   schematypens="http://purl.oclc.org/dsdl/schematron"?>
 ```
 
-Puedes bajar una plantilla básica de un documento TEI-XML [aquí](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/introduccion-a-tei-1/plantilla-TEI.xml**, con estas líneas ya incluidas.
+Puedes bajar una plantilla básica de un documento TEI-XML [aquí](https://raw.githubusercontent.com/programminghistorian/jekyll/gh-pages/assets/introduccion-a-tei-1/plantilla-TEI.xml), con estas líneas ya incluidas.
 
 **Tercero**, la extensión ofrece también una herramientas para autocompletar el código de XML a partir del esquema de validación RELAX NG. Por ejemplo, si hemos introducido en el documento un elemento `<q>` (para marcar un texto entrecomillado, por ejemplo una cita), podemos presionar la barra espaciador luego del `q` de la etiqueta de apertura y VS Code nos mostrará una lista de atributos posibles para seleccionar en el menú:
 


### PR DESCRIPTION
I have made a minor formatting fix to correctly display a link in the lesson.

Closes #3618 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
