### PR TITLE
Issue-3616-warning-message

### DIFF
--- a/en/lessons/creating-apis-with-python-and-flask.md
+++ b/en/lessons/creating-apis-with-python-and-flask.md
@@ -30,7 +30,7 @@ Access to Twitter’s API has recently changed. The Free Tier no longer allows u
 </div>
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website has recently been updated. Unfortunately, many (if not all) elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
+The Chronicling America website has recently been updated so many (if not all) elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for adapting this lesson. [August 2025]
 </div>
 
 # Lesson Goals

--- a/en/lessons/creating-apis-with-python-and-flask.md
+++ b/en/lessons/creating-apis-with-python-and-flask.md
@@ -29,6 +29,10 @@ doi: 10.46430/phen0072
 Access to Twitter’s API has recently changed. The Free Tier no longer allows users to search and download Twitter data. Unfortunately, this means that elements of this lesson will only work for those who are paying for an upgraded plan. At the moment, there are no special access plans for researchers or academics. [2023]
 </div>
 
+<div class="alert alert-warning" role="alert">
+The Chronicling America website has recently been updated. Unfortunately, many (if not all) elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
+</div>
+
 # Lesson Goals
 
 Web APIs are tools for making information and application functionality accessible over the internet. In this lesson, you will:

--- a/en/lessons/creating-apis-with-python-and-flask.md
+++ b/en/lessons/creating-apis-with-python-and-flask.md
@@ -30,7 +30,7 @@ Access to Twitter’s API has recently changed. The Free Tier no longer allows u
 </div>
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website has recently been updated so many (if not all) elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for adapting this lesson. [August 2025]
+The Chronicling America website has recently been updated, so many (if not all) elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for updating this lesson. [August 2025]
 </div>
 
 # Lesson Goals

--- a/en/lessons/fetch-and-parse-data-with-openrefine.md
+++ b/en/lessons/fetch-and-parse-data-with-openrefine.md
@@ -22,7 +22,7 @@ doi: 10.46430/phen0065
 {% include toc.html %}
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website has recently been updated. Unfortunately, many (if not all) elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
+The Chronicling America website has recently been updated. Unfortunately, many elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
 </div>
 
 # Lesson Goals

--- a/en/lessons/fetch-and-parse-data-with-openrefine.md
+++ b/en/lessons/fetch-and-parse-data-with-openrefine.md
@@ -21,6 +21,10 @@ doi: 10.46430/phen0065
 
 {% include toc.html %}
 
+<div class="alert alert-warning" role="alert">
+The Chronicling America website has recently been updated. Unfortunately, many (if not all) elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
+</div>
+
 # Lesson Goals
 
 OpenRefine is a powerful tool for exploring, cleaning, and transforming data.

--- a/en/lessons/fetch-and-parse-data-with-openrefine.md
+++ b/en/lessons/fetch-and-parse-data-with-openrefine.md
@@ -22,7 +22,7 @@ doi: 10.46430/phen0065
 {% include toc.html %}
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website has recently been updated. Unfortunately, many elements of the example website used in this lesson will not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are working on adapting the lesson to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated. [August 2025]
+The Chronicling America website has recently been updated so many elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for adapting this lesson. [August 2025]
 </div>
 
 # Lesson Goals

--- a/en/lessons/fetch-and-parse-data-with-openrefine.md
+++ b/en/lessons/fetch-and-parse-data-with-openrefine.md
@@ -22,7 +22,7 @@ doi: 10.46430/phen0065
 {% include toc.html %}
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website has recently been updated so many elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for adapting this lesson. [August 2025]
+The Chronicling America website has recently been updated, so many elements of the example website used in this lesson may not work as described. The methodologies taught by this lesson remain relevant, however, and may be adapted by readers to a different example site. We are currently investigating options for updating this lesson. [August 2025]
 </div>
 
 # Lesson Goals

--- a/en/lessons/interactive-data-visualization-dashboard.md
+++ b/en/lessons/interactive-data-visualization-dashboard.md
@@ -22,6 +22,10 @@ doi: 10.46430/phen0124
 
 {% include toc.html %}
 
+<div class="alert alert-warning" role="alert">
+The Chronicling America website used in the second example has recently been updated. Unfortunately, many (if not all) elements of this example will not work as described. The methodologies taught remain relevant, however, and may be adapted by readers to a different site. We are working on adapting the example to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated.<br><br>The first example remains unaffected and works as described. [August 2025]
+</div>
+
 ## Introduction
 
 To advance open scholarship in the humanities it is important to make research outputs more accessible, both to other scholars and the general public. Creating a web-based interactive dashboard to visualize data results has become a popular method to achieve this goal. There are a wide range of examples, such as [the StanceXplore project led by a team at Lund University](https://perma.cc/Y886-8MB5) that tracks social media data, [Stephanie Boddie and Amy Hillier's study](https://perma.cc/VE92-T796) that recreates W. E. B. Du Bois' study of black residents in Philadelphia, and [Johannes Burgers' project](https://perma.cc/Y3C5-XS79) that visualizes the narrative structure in William Faulkner's work. 

--- a/en/lessons/interactive-data-visualization-dashboard.md
+++ b/en/lessons/interactive-data-visualization-dashboard.md
@@ -23,7 +23,7 @@ doi: 10.46430/phen0124
 {% include toc.html %}
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website used in the second example has recently been updated. Unfortunately, many (if not all) elements of this example will not work as described. The methodologies taught remain relevant, however, and may be adapted by readers to a different site. We are working on adapting the example to the new Chronicling America website, but we have no clear timeline on when the lesson will be updated.<br><br>The first example remains unaffected and works as described. [August 2025]
+The Chronicling America website used in the second example has recently been updated, so many (if not all) elements of this example will not work as described. The methodologies taught remain relevant, however, and may be adapted by readers to a different site. We are investigating options for adapting this example.<br><br>The first example remains unaffected and works as described. [August 2025]
 </div>
 
 ## Introduction

--- a/en/lessons/interactive-data-visualization-dashboard.md
+++ b/en/lessons/interactive-data-visualization-dashboard.md
@@ -23,7 +23,7 @@ doi: 10.46430/phen0124
 {% include toc.html %}
 
 <div class="alert alert-warning" role="alert">
-The Chronicling America website used in the second example has recently been updated, so many (if not all) elements of this example will not work as described. The methodologies taught remain relevant, however, and may be adapted by readers to a different site. We are investigating options for adapting this example.<br><br>The first example remains unaffected and works as described. [August 2025]
+The Chronicling America website used in the second example has recently been updated, so many (if not all) elements of this example will not work as described. The methodologies taught remain relevant, however, and may be adapted by readers to a different site. We are investigating options for updating this example.<br><br>The first example remains unaffected and works as described. [August 2025]
 </div>
 
 ## Introduction


### PR DESCRIPTION
I have added a warning message at the top of the three lessons affected by the changes to the Chronicling America website.

This does not close the linked issue as we still want to work on updating the lessons to make them workable.

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- ~[ ] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~
