### PR TITLE
Revise link to TopicsExplorer from working-with-batches-of-pdf-files

### DIFF
--- a/en/lessons/working-with-batches-of-pdf-files.md
+++ b/en/lessons/working-with-batches-of-pdf-files.md
@@ -328,7 +328,7 @@ In order to create a Topic Model with the DARIAH Topics Explorer, you don’t ne
 Now open the [DARIAH Topics Explorer](https://dariah-de.github.io/TopicsExplorer/) and follow the steps given in the software. Then:
 
 1.  Select all 340 text files for the analysis.
-2.  Remove the 150 most common words. Alternatively, you can also load the file with the English stop words contained in the [example Corpus](https://github.com/DARIAH-DE/TopicsExplorer/tree/master/data) of the DARIAH Topics Explorer.
+2.  Remove the 150 most common words. Alternatively, you can also load the file with the English stop words contained in the [example Corpus](https://github.com/DARIAH-DE/TopicsExplorer/tree/master) of the DARIAH Topics Explorer.
 3.  Choose 30 for the number of topics and 200 for the number of iterations. You should play with the number of topics and choose a value between 10 and 100. With the number of iterations you increase the accuracy to the price of the calculation duration.
 4.  Click on 'Train Model'. Depending on the speed of your computer, this process may take several minutes.
 


### PR DESCRIPTION
I'm revising a link to a sample corpus referenced in the EN lesson working-with-batches-of-pdf-files which is currently unavailable.

This sample corpus serves as an alternative learning option in the lesson, rather than the central case study.

Ref: #3659

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [ ] ~~If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
