### PR TITLE
Issue 3670

### DIFF
--- a/en/lessons/intro-to-linked-data.md
+++ b/en/lessons/intro-to-linked-data.md
@@ -321,7 +321,7 @@ As I mentioned at the beginning, *Programming Historian* has [a complete lesson]
 
 We're going to run our SPARQL queries on [DBpedia](https://en.wikipedia.org/wiki/DBpedia), which is a huge LOD set derived from Wikipedia. As well as being full of information that is very difficult to find through the usual Wikipedia interface, it has several SPARQL "end points" - interfaces where you can type in SPARQL queries and get results from DBpedia's triples.
 
-The SPARQL query end point I use is called [snorql](http://dbpedia.org/snorql/). These end points occasionally seem to go offline, so if that should be the case, try searching for *dbpedia sparql* and you should find a similar replacement.
+The SPARQL query end point I use is called snorql `http://dbpedia.org/snorql/`. These end points occasionally seem to go offline, so if that should be the case, try searching for *dbpedia sparql* and you should find a similar replacement.
 
 If you go to the snorql URL above you will see at first that a number of prefixes have already been declared for us, which is handy. You'll recognise some of the prefixes now too.
 
@@ -375,7 +375,7 @@ Run the query. Does it work for you? I get a big list of historians.
 
 {% include figure.html filename="en-or-intro-to-linked-data-05.png" caption="Figure 5. Historians, according to DBpedia." %}
 
-So this works for creating lists, which is useful, but it would much more powerful to combine lists, to get intersections of sests. I found a couple more things that might be interesting to query in Lyndal Roper's DBpedia attributes: <http://dbpedia.org/class/yago/WikicatBritishHistorians> and <http://dbpedia.org/class/yago/WikicatWomenHistorians>. It's very easy to combine these by asking for a variable to be returned (in our case this is `?name`) and then using that in multiple lines of a query. Note as well the space and full point at the end of the first line beginning with `?name`:
+So this works for creating lists, which is useful, but it would much more powerful to combine lists, to get intersections of sests. I found a couple more things that might be interesting to query in Lyndal Roper's DBpedia attributes: `http://dbpedia.org/class/yago/WikicatBritishHistorians` and `http://dbpedia.org/class/yago/WikicatWomenHistorians`. It's very easy to combine these by asking for a variable to be returned (in our case this is `?name`) and then using that in multiple lines of a query. Note as well the space and full point at the end of the first line beginning with `?name`:
 
 	SELECT ?name
 	WHERE {

--- a/es/lecciones/introduccion-datos-abiertos-enlazados.md
+++ b/es/lecciones/introduccion-datos-abiertos-enlazados.md
@@ -312,7 +312,7 @@ Como mencioné al principio, *The Programming Historian en español* tiene [una 
 
 Vamos a ejecutar nuestras consultas SPARQL en [DBpedia](https://es.wikipedia.org/wiki/DBpedia), que es un gran conjunto de LOD derivado de Wikipedia. Además de estar lleno de información que es muy difícil de encontrar a través de la interfaz habitual de Wikipedia, tiene varios "puntos finales" SPARQL: interfaces donde puedes escribir consultas SPARQL y obtener resultados de las tripletas de DBpedia.
 
-El punto de entrada (*endpoint*) de consulta SPARQL que yo uso se llama [snorql](http://dbpedia.org/snorql/). Estos puntos de entrada a veces parecen desconectarse, por lo que, si ese fuera el caso, busca *dbpedia sparql* en internet para encontrar un reemplazo similar.
+El punto de entrada (*endpoint*) de consulta SPARQL que yo uso se llama snorql: `http://dbpedia.org/snorql/`. Estos puntos de entrada a veces parecen desconectarse, por lo que, si ese fuera el caso, busca *dbpedia sparql* en internet para encontrar un reemplazo similar.
 
 Si vas a la URL snorql indicada antes, verás que al principio ya están declarados varios prefijos, lo cual te será útil. También reconocerás ya algunos de los prefijos.
 {% include figure.html filename="en-or-intro-to-linked-data-03.png" caption="Figura 3. Cuadro de consulta predeterminado de snorql, con algunos prefijos declarados para ti." %}
@@ -365,7 +365,7 @@ Ejecuta la consulta. ¿Te funciona? Yo obtuve una gran lista de historiadores.
 
 {% include figure.html filename="en-or-intro-to-linked-data-05.png" caption="Figura 5. Historiadores, según DBpedia." %}
 
-Así que esto funciona para crear listas, lo cual es útil, pero sería mucho más potente combinar listas, para obtener intersecciones de conjuntos. Encontré un par de cosas más que podrían ser interesantes para consultar en los atributos de DBpedia de Lyndal Roper: <http://dbpedia.org/class/yago/WikicatBritishHistorians> y <http://dbpedia.org/class/yago/WikicatWomenHistorians>. Es muy fácil combinarlos pidiendo una variable que retornará (en nuestro caso, esta es `?name`) y luego usar eso en múltiples líneas de una consulta. Ten en cuenta también el espacio y el punto al final de la primera línea que comienza con `?name`:
+Así que esto funciona para crear listas, lo cual es útil, pero sería mucho más potente combinar listas, para obtener intersecciones de conjuntos. Encontré un par de cosas más que podrían ser interesantes para consultar en los atributos de DBpedia de Lyndal Roper: `http://dbpedia.org/class/yago/WikicatBritishHistorians` y `http://dbpedia.org/class/yago/WikicatWomenHistorians`. Es muy fácil combinarlos pidiendo una variable que retornará (en nuestro caso, esta es `?name`) y luego usar eso en múltiples líneas de una consulta. Ten en cuenta también el espacio y el punto al final de la primera línea que comienza con `?name`:
 
 
 	SELECT ?name

--- a/pt/licoes/introducao-dados-abertos-conectados.md
+++ b/pt/licoes/introducao-dados-abertos-conectados.md
@@ -327,7 +327,7 @@ Como mencionado no início, o *Programming Historian* tem [uma lição completa]
 
 Vamos realizar as nossas consultas SPARQL na [DBpedia](https://www.dbpedia.org/), que é um enorme conjunto de LOD derivado da Wikipedia. Além de estar cheio de informação que é muito difícil de encontrar através da habitual interface da Wikipédia, tem vários "pontos de extremidade" (end points) SPARQL - interfaces onde se podem digitar as consultas SPARQL e obter resultados a partir das triplas semânticas da DBpedia.
 
-O end point de consulta SPARQL que é utilizado chama-se [snorql](http://dbpedia.org/snorql/) (em inglês). Estes end points ocasionalmente ficam offline. Se for o seu caso, tente procurar por *dbpedia sparql* e deverá encontrar um substituto semelhante.
+O end point de consulta SPARQL que é utilizado chama-se snorql: `http://dbpedia.org/snorql/` (em inglês). Estes end points ocasionalmente ficam offline. Se for o seu caso, tente procurar por *dbpedia sparql* e deverá encontrar um substituto semelhante.
 
 Se for ao URL snorql acima verá, no início, um número de prefixos que já nos foram declarados, o que é útil. Agora também irá reconhecer alguns dos prefixos.
 
@@ -382,7 +382,7 @@ Execute a *querie*. Deverá encontrar uma grande lista de historiadores.
 
 {% include figure.html filename="en-or-intro-to-linked-data-05.png" alt="Duas capturas de tela com a interface de consultas snorql e respectivos resultados" caption="Figura 5. Historiadores de acordo com a DBpedia." %}
 
-Assim, esta ferramenta funciona para criar listas, o que é útil, mas seria muito mais poderoso combinar listas para obter intersecções de conjuntos. Encontrei mais algumas coisas que podem ser interessantes consultar nos atributos DBpedia de Lyndal Roper: <http://dbpedia.org/class/yago/WikicatBritishHistorians> e <http://dbpedia.org/class/yago/WikicatWomenHistorians>. É muito fácil combiná-los pedindo uma variável a ser devolvida (no nosso caso isto é `?name` (nome)) e depois utilizando-a em múltiplas linhas de uma *querie*. Note também o espaço e o ponto completo no final da primeira linha que começa com `?name`:
+Assim, esta ferramenta funciona para criar listas, o que é útil, mas seria muito mais poderoso combinar listas para obter intersecções de conjuntos. Encontrei mais algumas coisas que podem ser interessantes consultar nos atributos DBpedia de Lyndal Roper: `http://dbpedia.org/class/yago/WikicatBritishHistorians` e `http://dbpedia.org/class/yago/WikicatWomenHistorians`. É muito fácil combiná-los pedindo uma variável a ser devolvida (no nosso caso isto é `?name` (nome)) e depois utilizando-a em múltiplas linhas de uma *querie*. Note também o espaço e o ponto completo no final da primeira linha que começa com `?name`:
 
 	SELECT ?name
 	WHERE {
@@ -418,3 +418,4 @@ No entanto, apesar das suas inconsistências, a *DBpedia* é um ótimo local par
 ## Agradecimentos
 
 Gostaria de agradecer aos meus dois colegas revisores, Matthew Lincoln e Terhi Nurmikko-Fuller e ao meu editor, Adam Crymble, por me ajudarem generosamente a melhorar esta lição com numerosas sugestões, esclarecimentos e correções. Este tutorial baseia-se num outro escrito como parte do '*Thesaurus of British and Irish History as SKOS*' [*(Tobias) project*](https://gtr.ukri.org/projects?ref=AH%2FN003446%2F1#/tabOverview) (em inglês), financiado pelo [AHRC](http://www.ahrc.ac.uk/) (em inglês). A lição foi revista para o projeto *Programming Historian*.
+


### PR DESCRIPTION
Our build is currently failing due to a set of of SPARQL endpoints on the dbpedia platform which are offline. The author writes in the lesson that These end points occasionally seem to go offline [...] so it is very possible these will be back soon.

In the meantime, I am replacing 3x live links within inline code in the following lessons:

EN intro-to-linked-data
PT introducao-dados-abertos-conectados
ES introduccion-datos-abiertos-enlazados.

Closes #3670 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - [ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.
