### PR TITLE
3707-b : links 

### DIFF
--- a/en/author-guidelines.md
+++ b/en/author-guidelines.md
@@ -208,7 +208,7 @@ All lessons must be written in [Markdown](https://en.wikipedia.org/wiki/Markdown
 
 * [Download the English Language Lesson template (.md)]({{site.baseurl}}/en/lesson-template.md).
 
-Markdown is a mark-up language that is best created with a text editor. MS Word and Open Office are NOT text editors and should be avoided. We recommend [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/) or [Notepad++](https://notepad-plus-plus.org/download).
+Markdown is a mark-up language that is best created with a text editor. MS Word and Open Office are NOT text editors and should be avoided. We recommend [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/) or [Notepad++](https://notepad-plus-plus.org/downloads).
 For a gentle introduction to Markdown formatting see [Getting Started with Markdown]({{site.baseurl}}/en/lessons/getting-started-with-markdown), or the concise reference [GitHub Guide to Markdown](https://guides.github.com/features/mastering-markdown/).
 
 Your lesson should be saved in .md format. Your lesson filename becomes part of the lesson URL. Therefore, it should be named according to the following rules:

--- a/es/guia-para-autores.md
+++ b/es/guia-para-autores.md
@@ -209,7 +209,7 @@ Todas las lecciones deben ser escritas en [Markdown](https://es.wikipedia.org/wi
 
 * [Descarga la plantilla para lecciones en español (.md)]({{site.baseurl}}/es/plantilla-leccion.md).
 
-Markdown es un lenguaje de marcado que se crea mejor con un editor de texto. MS Word y Open Office NO son editores de texto y deben ser evitados. Recomendamos [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/),  [Notepad++](https://notepad-plus-plus.org/download) o [Sublime Text](https://www.sublimetext.com/).
+Markdown es un lenguaje de marcado que se crea mejor con un editor de texto. MS Word y Open Office NO son editores de texto y deben ser evitados. Recomendamos [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/),  [Notepad++](https://notepad-plus-plus.org/downloads) o [Sublime Text](https://www.sublimetext.com/).
 Para una introducción sencilla a Markdown puedes ver la lección [Introducción a Markdown]({{site.baseurl}}/es/lecciones/introduccion-a-markdown) o la referencia concisa [GitHub Guide to Markdown](https://help.github.com/es/github/writing-on-github/basic-writing-and-formatting-syntax).
 
 Tu lección debe ser guardada en formato .md. El nombre del archivo de tu lección se convierte en parte de la URL de la lección, por lo tanto, debe ser nombrado de acuerdo a las siguientes reglas:

--- a/es/guia-para-traductores.md
+++ b/es/guia-para-traductores.md
@@ -169,7 +169,7 @@ Esta última sección abarca cuestiones de formato para el envío de tu traducci
 ### Escribe en Markdown
 Todas las lecciones deben ser escritas en [Markdown](https://es.wikipedia.org/wiki/Markdown). Tu editor/a te indicará dónde puedes encontrar el archivo de la lección original para que trabajes sobre él.
 
-Markdown es un lenguaje de marcado que se crea mejor con un editor de texto. MS Word y Open Office NO son editores de texto y deben ser evitados. Recomendamos [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/),  [Notepad++](https://notepad-plus-plus.org/download) o [Sublime Text](https://www.sublimetext.com/).
+Markdown es un lenguaje de marcado que se crea mejor con un editor de texto. MS Word y Open Office NO son editores de texto y deben ser evitados. Recomendamos [Atom](https://atom.io/), [TextWrangler](https://www.barebones.com/products/textwrangler/), [TextEdit](https://en.wikipedia.org/wiki/TextEdit), [MacDown](https://macdown.uranusjr.com/),  [Notepad++](https://notepad-plus-plus.org/downloads) o [Sublime Text](https://www.sublimetext.com/).
 Para una introducción sencilla a Markdown puedes ver la lección [Introducción a Markdown]({{site.baseurl}}/es/lecciones/introduccion-a-markdown) o la referencia concisa [GitHub Guide to Markdown](https://help.github.com/es/github/writing-on-github/basic-writing-and-formatting-syntax).
 
 Tu lección debe ser guardada en formato .md. El nombre del archivo de tu lección se convierte en parte de la URL de la lección, por lo tanto, debe ser nombrado de acuerdo a las siguientes reglas:


### PR DESCRIPTION
Replacing 2x more instances of broken link across the /en/author-guidelines and /es/guia-para-autores (it is up-to-date in FR)

- The problem link is:
   - https://notepad-plus-plus.org/download
- It needs to be updated to:
   - https://notepad-plus-plus.org/downloads/


### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [ ] ~~If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above~~
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - [ ] ~~if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
