### PR TITLE
Move Purdue University to Alumni Partners

### DIFF
--- a/en/supporters.md
+++ b/en/supporters.md
@@ -31,7 +31,6 @@ Contributors to our [Institutional Partner Programme](support-us#institutional-p
 - [Center for Digital Research in the Humanities, University of Nebraska-Lincoln](http://cdrh.unl.edu/), United States
 - [The National Archives](https://www.nationalarchives.gov.uk/), United Kingdom
 - [College of the Liberal Arts, Penn State University](https://la.psu.edu/), United States
-- [Purdue University](https://www.purdue.edu/), United States
 - [University of Bristol Library](https://www.bristol.ac.uk/library/), United Kingdom
 - [University of Sheffield Library](https://www.sheffield.ac.uk/library), United Kingdom
 - [School of Advanced Study, University of London](https://www.sas.ac.uk/), United Kingdom
@@ -69,6 +68,7 @@ Former contributors to our [Institutional Partner Programme](support-us#institut
 - [Roskilde University Library](https://ruc.dk/en/roskilde-university-library), Denmark [2021-2024]
 - [Sussex Humanities Lab](https://www.sussex.ac.uk/research/centres/sussex-humanities-lab/), United Kingdom [2022-2024]
 - [University of Lancaster Library](https://www.lancaster.ac.uk/), United Kingdom [2022-2024]
+- [Purdue University](https://www.purdue.edu/), United States [2021-2025]   
 
 ## Additional Supporters
 Organizations that have or continue to give support ranging from in kind services, to project-specific funding:

--- a/es/colaboradores.md
+++ b/es/colaboradores.md
@@ -32,7 +32,6 @@ Contribuidores de nuestro [Programa de Instituciones Asociadas](pia):
 - [Center for Digital Research in the Humanities, University of Nebraska-Lincoln](http://cdrh.unl.edu/), Estados Unidos
 - [The National Archives](https://www.nationalarchives.gov.uk/), Reino Unido
 - [College of the Liberal Arts, Penn State University](https://la.psu.edu/), Estados Unidos
-- [Purdue University](https://www.purdue.edu/), Estados Unidos
 - [University of Bristol Library](https://www.bristol.ac.uk/library/), Reino Unido
 - [University of Sheffield Library](https://www.sheffield.ac.uk/library), Reino Unido
 - [School of Advanced Study, University of London](https://www.sas.ac.uk/), Reino Unido
@@ -70,6 +69,7 @@ Antiguos contribuidores de nuestro [Programa de Instituciones Asociadas](pia):
 - [Roskilde University Library](https://ruc.dk/en/roskilde-university-library), Dinamarca [2021-2024]
 - [Sussex Humanities Lab](https://www.sussex.ac.uk/research/centres/sussex-humanities-lab/), Reino Unido [2022-2024]
 - [University of Lancaster Library](https://www.lancaster.ac.uk/), Reino Unido [2022-2024]
+- [Purdue University](https://www.purdue.edu/), Estados Unidos [2021-2025]
 
 ## Colaboradores adicionales
 Organizaciones que han o continúan brindando apoyo en forma de contribuciones en especie o de financiamiento específico para proyectos:

--- a/fr/nos-soutiens.md
+++ b/fr/nos-soutiens.md
@@ -32,7 +32,6 @@ Les institutions suivantes font partie de notre programme de [Partenariat instit
 - [Center for Digital Research in the Humanities, University of Nebraska-Lincoln](http://cdrh.unl.edu/), États-Unis
 - [The National Archives](https://www.nationalarchives.gov.uk/), Royaume-Uni
 - [College of the Liberal Arts, Penn State University](https://la.psu.edu/), États-Unis
-- [Purdue University](https://www.purdue.edu/), États-Unis
 - [University of Bristol Library](https://www.bristol.ac.uk/library/), Royaume-Uni
 - [University of Sheffield Library](https://www.sheffield.ac.uk/library), Royaume-Uni
 - [School of Advanced Study, University of London](https://www.sas.ac.uk/), Royaume-Uni
@@ -71,6 +70,7 @@ Les institutions suivantes ont participé à de notre programme de [Partenariat 
 - [Roskilde University Library](https://ruc.dk/en/roskilde-university-library), Danemark [2021-2024]
 - [Sussex Humanities Lab](https://www.sussex.ac.uk/research/centres/sussex-humanities-lab/), Royaume-Uni [2022-2024]
 - [University of Lancaster Library](https://www.lancaster.ac.uk/), Royaume-Uni [2022-2024]
+- [Purdue University](https://www.purdue.edu/), États-Unis [2021-2025]
 
 ## Soutien additionnel
 Les organisations suivantes ont apporté ou continuent d'apporter un soutien allant de services en nature au financement de projets spécifiques&nbsp;:

--- a/pt/apoiadores.md
+++ b/pt/apoiadores.md
@@ -34,7 +34,6 @@ Contribuintes para o nosso [Programa de Parceria Institucional](/pt/ppi):
 - [Center for Digital Research in the Humanities, University of Nebraska-Lincoln](http://cdrh.unl.edu/), Estados Unidos
 - [The National Archives](https://www.nationalarchives.gov.uk/), Reino Unido
 - [College of the Liberal Arts, Penn State University](https://la.psu.edu/), Estados Unidos
-- [Purdue University](https://www.purdue.edu/), Estados Unidos
 - [University of Bristol Library](https://www.bristol.ac.uk/library/), Reino Unido
 - [University of Sheffield Library](https://www.sheffield.ac.uk/library), Reino Unido
 - [School of Advanced Study, University of London](https://www.sas.ac.uk/), Reino Unido
@@ -72,6 +71,7 @@ Antigos contribuintes para o nosso [Programa de Parceria Institucional](/pt/ppi)
 - [Roskilde University Library](https://ruc.dk/en/roskilde-university-library), Dinamarca [2021-2024]
 - [Sussex Humanities Lab](https://www.sussex.ac.uk/research/centres/sussex-humanities-lab/), Reino Unido [2022-2024]
 - [University of Lancaster Library](https://www.lancaster.ac.uk/), Reino Unido [2022-2024]
+- [Purdue University](https://www.purdue.edu/), Estados Unidos [2021-2025]
 
 ## Parceiros adicionais
 Organizações que contribuíram ou continuam a dar apoio em forma de serviços, em espécie e até financiamento para projetos específicos:


### PR DESCRIPTION
I have moved Purdue University to the Alumni Partners section of our en/supporters, es/colaboradores, fr/nos-soutiens, pt/apoiadores pages

Closes #3714

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [ ] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
