### PR TITLE
Update simulating-historical-communication-networks-python.md

### DIFF
--- a/en/lessons/simulating-historical-communication-networks-python.md
+++ b/en/lessons/simulating-historical-communication-networks-python.md
@@ -573,7 +573,7 @@ Since one of the main goals of Agent-Based Modeling is generating data for analy
 
 When the data collector’s `collect` method is called with a model object as its argument, it applies each model-level collection function to the model, and stores the results in a dictionary, linking the value to the current step of the model. If the input model is an agent, the method also links the resulting value to the agent’s `unique_id`.
 
-Let's add a data collector to the model with [`mesa.DataCollector`](https://github.com/projectmesa/mesa/blob/2.4.x-maintenance/mesa/datacollection.py), and collect two variables at the agent level: the number of letters every agent has sent at every step, and the number of letters it has received.
+Let's add a data collector to the model with [`mesa.DataCollector`](https://github.com/mesa/mesa/blob/main/mesa/datacollection.py), and collect two variables at the agent level: the number of letters every agent has sent at every step, and the number of letters it has received.
 
 ```python
 self.datacollector = mesa.DataCollector(


### PR DESCRIPTION
I'm updating broken link in the EN lesson simulating-historical-communication-networks-python

- The problem link is:
   - https://github.com/projectmesa/mesa/blob/2.4.x-maintenance/mesa/datacollection.py
- This repository has been reorganised and the file is now available at:
   - https://github.com/mesa/mesa/blob/main/mesa/datacollection.py

Closes #3727 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
