### PR TITLE
Update ph_authors.yml

### DIFF
--- a/_data/ph_authors.yml
+++ b/_data/ph_authors.yml
@@ -2556,8 +2556,9 @@
   status: volunteer
 
 - name: Giulia Taurino
-  team: true
+  team: false
   team_start: 2022
+  team_end: 2026
   institution: Northeastern University
   github: giuliataurino
   email: g.taurino@northeastern.edu
@@ -2873,8 +2874,9 @@
   twitter: davvalent
   mastodon: mas.to/@davvalent
   orcid: 0000-0003-3410-7677
-  team: true
+  team: false
   team_start: 2023
+  team_end: 2026
   institution: Université de Montréal
   sortname: Valentine
   affiliation:
@@ -3132,8 +3134,9 @@
   orcid: 0000-0003-3179-6980
   github: semanticnoodles
   email: giulia.osti@ucdconnect.ie
-  team: true
+  team: false
   team_start: 2024
+  team_end: 2026
   institution: School of Information and Communication Studies, University College Dublin
   sortname: Osti
   affiliation:
@@ -3385,3 +3388,8 @@
   bio:
     es: |
       Douglas McRae se doctoró en historia de América Latina en Georgetown University. Fue coordinador de educación para Tropy a través del Roy Rosenzweig Center for History and New Media en George Mason University.
+
+
+- name: Patricia A. Loto
+  orcid: 0000-0003-1849-6916
+  team: false


### PR DESCRIPTION
- Update `team:` status to `false` + add `team_end:` for David Valentine, Giulia Taurino and Giulia Osti
- Add entry + ORCID for reviewer (+ soon to be author of ES OR lesson) Patricia A. Loto by request


Closes #3776 
Closes #3777 
Closes #3778 

### Checklist

- [x] Assign yourself in the "Assignees" menu
- [x] Add the appropriate "Label"
- [x] If this PR closes an Issue, add the phrase `Closes #ISSUENUMBER` to your summary above
- [x] Ensure the status checks pass: if you have difficulty fixing build errors, please contact our Publishing Manager @anisa-hawes 
- [x] Check the Netlify Preview: navigate to netlify/ph-preview/deploy-preview and click 'details' (at right)
- [x] Assign at least one individual or team to "Reviewers"
  - ~~[ ] if the text needs to be translated, please follow the [translation request guidelines](https://github.com/programminghistorian/jekyll/wiki/Requesting-Translation-Guidelines), then assign the relevant language team(s) as "Reviewers" and tag both the team as well as the managing editor in your PR.~~
